### PR TITLE
fixed a significant bug in the calculation of the total volume of the me...

### DIFF
--- a/src/meshfem3D/compute_area.f90
+++ b/src/meshfem3D/compute_area.f90
@@ -84,7 +84,8 @@
         case(IREGION_OUTER_CORE)
           write(IMAIN,*) '            exact area: ',dble(NCHUNKS)*(4.0d0/6.0d0)*PI*(RICB/R_EARTH)**2
         case(IREGION_INNER_CORE)
-          write(IMAIN,*) '            similar area (central cube): ',dble(NCHUNKS)*(2.*(R_CENTRAL_CUBE / R_EARTH)/sqrt(3.))**2
+          write(IMAIN,*) '            more or less similar area (central cube): ', &
+                                           dble(NCHUNKS)*(2.*(R_CENTRAL_CUBE / R_EARTH)/sqrt(3.))**2
         case default
           call exit_MPI(myrank,'incorrect region code')
       end select
@@ -94,31 +95,4 @@
   endif
 
   end subroutine compute_area
-
-!=====================================================================
-
-  ! computes total Earth mass
-
-  subroutine compute_total_Earth_mass(myrank,Earth_mass_local,Earth_mass_total)
-
-  use meshfem3D_models_par
-
-  implicit none
-
-  integer :: myrank
-
-  double precision :: Earth_mass_local
-  double precision :: Earth_mass_total
-
-  ! local parameters
-  double precision :: Earth_mass_total_region
-
-  ! use an MPI reduction to compute the total Earth mass
-  Earth_mass_total_region = ZERO
-  call sum_all_dp(Earth_mass_local,Earth_mass_total_region)
-
-  !   sum volume over all the regions
-  if(myrank == 0) Earth_mass_total = Earth_mass_total + Earth_mass_total_region
-
-  end subroutine compute_total_Earth_mass
 

--- a/src/meshfem3D/create_regions_mesh.F90
+++ b/src/meshfem3D/create_regions_mesh.F90
@@ -392,7 +392,8 @@
     call crm_free_MPI_arrays(iregion_code)
 
     ! boundary mesh for MOHO, 400 and 670 discontinuities
-    if (SAVE_BOUNDARY_MESH .and. iregion_code == IREGION_CRUST_MANTLE) then
+!! DK DK for Roland_Sylvain
+    if (SAVE_BOUNDARY_MESH .and. iregion_code == IREGION_CRUST_MANTLE .and. .not. ROLAND_SYLVAIN) then
       ! user output
       call synchronize_all()
       if( myrank == 0) then
@@ -413,27 +414,35 @@
     call compute_volumes(volume_local,area_local_bottom,area_local_top, &
         nspec,wxgll,wygll,wzgll,xixstore,xiystore,xizstore, &
         etaxstore,etaystore,etazstore,gammaxstore,gammaystore,gammazstore, &
-        NSPEC2D_BOTTOM,jacobian2D_bottom,NSPEC2D_TOP,jacobian2D_top)
+        NSPEC2D_BOTTOM,jacobian2D_bottom,NSPEC2D_TOP,jacobian2D_top,idoubling)
 
     ! computes total area and volume
     call compute_area(myrank,NCHUNKS,iregion_code, area_local_bottom, &
         area_local_top,volume_local,volume_total,RCMB,RICB,R_CENTRAL_CUBE)
 
-    ! compute Earth mass of that part of the slice
-    call compute_Earth_mass(Earth_mass_local, &
+    ! compute Earth mass of that part of the slice and then total Earth mass
+    call compute_Earth_mass(myrank,Earth_mass_local,Earth_mass_total, &
         nspec,wxgll,wygll,wzgll,xixstore,xiystore,xizstore, &
-        etaxstore,etaystore,etazstore,gammaxstore,gammaystore,gammazstore,rhostore)
+        etaxstore,etaystore,etazstore,gammaxstore,gammaystore,gammazstore,rhostore,idoubling)
 
-    ! computes total Earth mass
-    call compute_total_Earth_mass(myrank,Earth_mass_local,Earth_mass_total)
+!! DK DK for Roland_Sylvain
+    if(ROLAND_SYLVAIN) then
+      call synchronize_all()
+      if( myrank == 0) then
+        write(IMAIN,*)
+        write(IMAIN,*) '  ...computing Roland_Sylvain integrals'
+        call flush_IMAIN()
+      endif
+    endif
 
     ! create AVS or DX mesh data for the slices
-    if(SAVE_MESH_FILES) then
+!! DK DK for Roland_Sylvain
+    if(SAVE_MESH_FILES .and. .not. ROLAND_SYLVAIN) then
       ! user output
       call synchronize_all()
       if( myrank == 0) then
         write(IMAIN,*)
-        write(IMAIN,*) '  ...saving AVS mesh files'
+        write(IMAIN,*) '  ...saving AVS or DX mesh files'
         call flush_IMAIN()
       endif
       call crm_save_mesh_files(nspec,npointot,iregion_code)

--- a/src/meshfem3D/finalize_mesher.f90
+++ b/src/meshfem3D/finalize_mesher.f90
@@ -43,17 +43,8 @@
     ! check volume of chunk
     write(IMAIN,*)
     write(IMAIN,*) 'calculated volume: ',volume_total
-    if(.not. TOPOGRAPHY) then
-      ! take the central cube into account
-      ! it is counted 6 times because of the fictitious elements
-      if(INCLUDE_CENTRAL_CUBE) then
-        write(IMAIN,*) '     exact volume: ', &
-          dble(NCHUNKS)*((4.0d0/3.0d0)*PI*(R_UNIT_SPHERE**3)+5.*(2.*(R_CENTRAL_CUBE/R_EARTH)/sqrt(3.))**3)/6.d0
-      else
-        write(IMAIN,*) '     exact volume: ', &
-          dble(NCHUNKS)*((4.0d0/3.0d0)*PI*(R_UNIT_SPHERE**3)-(2.*(R_CENTRAL_CUBE/R_EARTH)/sqrt(3.))**3)/6.d0
-      endif
-    endif
+    if(NCHUNKS == 6 .and. .not. ELLIPTICITY .and. .not. TOPOGRAPHY) &
+        write(IMAIN,*) '     exact volume: ',(4.0d0/3.0d0)*PI*(R_UNIT_SPHERE**3)
 
     ! check total Earth mass
     if(NCHUNKS == 6) then


### PR DESCRIPTION
...sh: some central cube elements were counted several times because IFLAG_IN_FICTITIOUS_CUBE elements were not excluded. This volume is computed in the mesher for information purposes only and thus seismograms were not affected.
