### PR TITLE
tried to use the same notations in model_crust_1_0.f90 and model_crust_2...

### DIFF
--- a/src/gpu/assemble_MPI_scalar_gpu.c
+++ b/src/gpu/assemble_MPI_scalar_gpu.c
@@ -47,7 +47,7 @@ void FC_FUNC_ (transfer_boun_pot_from_device,
 
   TRACE ("transfer_boun_pot_from_device");
   int size_mpi_buffer;
-  
+
   Mesh *mp = (Mesh *) *Mesh_pointer_f;   //get mesh pointer out of Fortran integer container
 
   // MPI buffer size
@@ -69,7 +69,7 @@ void FC_FUNC_ (transfer_boun_pot_from_device,
     size_t local_work_size[2];
     cl_uint idx = 0;
     cl_event kernel_evt;
-    
+
     if (*FORWARD_OR_ADJOINT == 1) {
       clCheck (clSetKernelArg (mocl.kernels.prepare_boundary_potential_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_accel_outer_core.ocl));
       clCheck (clSetKernelArg (mocl.kernels.prepare_boundary_potential_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_send_accel_buffer_outer_core.ocl));
@@ -82,7 +82,7 @@ void FC_FUNC_ (transfer_boun_pot_from_device,
       local_work_size[1] = 1;
       global_work_size[0] = num_blocks_x * blocksize;
       global_work_size[1] = num_blocks_y;
-      
+
       clCheck (clEnqueueNDRangeKernel (mocl.command_queue, mocl.kernels.prepare_boundary_potential_on_device, 2, NULL, global_work_size, local_work_size, 0, NULL, &kernel_evt));
 
       // copies buffer to CPU
@@ -148,7 +148,7 @@ void FC_FUNC_ (transfer_boun_pot_from_device,
                                                                                     mp->max_nibool_interfaces_oc,
                                                                                     mp->d_nibool_interfaces_outer_core.cuda,
                                                                                     mp->d_ibool_interfaces_outer_core.cuda);
-      
+
       // copies buffer to CPU
       if (GPU_ASYNC_COPY) {
         // waits until kernel is finished before starting async memcpy
@@ -177,11 +177,11 @@ void FC_FUNC_ (transfer_boun_pot_from_device,
       if( GPU_ASYNC_COPY ){
         // waits until kernel is finished before starting async memcpy
         cudaStreamSynchronize(mp->compute_stream);
-        
+
         // copies buffer to CPU
         cudaMemcpyAsync(mp->h_b_send_accel_buffer_oc,mp->d_b_send_accel_buffer_outer_core.cuda,size_mpi_buffer*sizeof(realw),
                         cudaMemcpyDeviceToHost,mp->copy_stream);
-       
+
       }else{
         // synchronous copy
         print_CUDA_error_if_any(cudaMemcpy(send_buffer,mp->d_b_send_accel_buffer_outer_core.cuda,
@@ -232,20 +232,20 @@ void FC_FUNC_ (transfer_asmbl_pot_to_device,
     cl_uint idx = 0;
     cl_event *copy_evt = NULL;
     cl_uint num_evt = 0;
-    
+
     if (GPU_ASYNC_COPY && mp->has_last_copy_evt) {
       copy_evt = &mp->last_copy_evt;
       num_evt = 1;
     }
-    
-    if (*FORWARD_OR_ADJOINT == 1) {      
+
+    if (*FORWARD_OR_ADJOINT == 1) {
       if (!GPU_ASYNC_COPY) {
         // copies scalar buffer onto GPU
         clCheck (clEnqueueWriteBuffer (mocl.command_queue, mp->d_send_accel_buffer_outer_core.ocl, CL_FALSE, 0,
                                        mp->max_nibool_interfaces_oc * mp->num_interfaces_outer_core * sizeof (realw),
                                        buffer_recv_scalar, 0, NULL, NULL));
       }
-      
+
       //assemble forward field
       clCheck (clSetKernelArg (mocl.kernels.assemble_boundary_potential_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_accel_outer_core));
       clCheck (clSetKernelArg (mocl.kernels.assemble_boundary_potential_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_send_accel_buffer_outer_core));

--- a/src/gpu/assemble_MPI_vector_gpu.c
+++ b/src/gpu/assemble_MPI_vector_gpu.c
@@ -53,7 +53,7 @@ void FC_FUNC_(transfer_boun_from_device,
   size_t global_work_size[2];
   size_t local_work_size[2];
   cl_uint idx = 0;
-    
+
 #endif
 #ifdef USE_CUDA
   dim3 grid,threads;
@@ -77,14 +77,14 @@ void FC_FUNC_(transfer_boun_from_device,
 #ifdef USE_OPENCL
       if (run_opencl) {
         cl_event kernel_evt;
-        
+
         local_work_size[0] = blocksize;
         local_work_size[1] = 1;
         global_work_size[0] = num_blocks_x * blocksize;
         global_work_size[1] = num_blocks_y;
 
         if (*FORWARD_OR_ADJOINT == 1) {
-            
+
           clCheck (clSetKernelArg (mocl.kernels.prepare_boundary_accel_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_accel_crust_mantle.ocl));
           clCheck (clSetKernelArg (mocl.kernels.prepare_boundary_accel_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_send_accel_buffer_crust_mantle.ocl));
           clCheck (clSetKernelArg (mocl.kernels.prepare_boundary_accel_on_device, idx++, sizeof (int), (void *) &mp->num_interfaces_crust_mantle));
@@ -126,7 +126,7 @@ void FC_FUNC_(transfer_boun_from_device,
             if (mp->has_last_copy_evt) {
               clCheck (clReleaseEvent (mp->last_copy_evt));
             }
-            
+
             clCheck (clEnqueueReadBuffer (mocl.copy_queue, mp->d_b_send_accel_buffer_crust_mantle.ocl, CL_TRUE, 0,
                                           size_mpi_buffer * sizeof (realw),
                                           mp->h_b_send_accel_buffer_cm, 1, &kernel_evt, &mp->last_copy_evt));
@@ -186,7 +186,7 @@ void FC_FUNC_(transfer_boun_from_device,
             // synchronous copy
             print_CUDA_error_if_any(cudaMemcpy(send_accel_buffer,mp->d_b_send_accel_buffer_crust_mantle.cuda,size_mpi_buffer*sizeof(realw),
                                                cudaMemcpyDeviceToHost),41001);
-            
+
           }
         }
       }
@@ -208,9 +208,9 @@ void FC_FUNC_(transfer_boun_from_device,
 #ifdef USE_OPENCL
       if (run_opencl) {
         cl_event kernel_evt;
-        
+
         idx = 0;
-        
+
         if (*FORWARD_OR_ADJOINT == 1) {
           clCheck (clSetKernelArg (mocl.kernels.prepare_boundary_accel_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_accel_inner_core.ocl));
           clCheck (clSetKernelArg (mocl.kernels.prepare_boundary_accel_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_send_accel_buffer_inner_core.ocl));
@@ -231,7 +231,7 @@ void FC_FUNC_(transfer_boun_from_device,
             if (mp->has_last_copy_evt) {
               clCheck (clReleaseEvent (mp->last_copy_evt));
             }
-            
+
             clCheck (clEnqueueReadBuffer (mocl.copy_queue, mp->d_send_accel_buffer_inner_core.ocl, CL_TRUE, 0,
                                           size_mpi_buffer * sizeof (realw),
                                           mp->h_send_accel_buffer_ic, 1, &kernel_evt, &mp->last_copy_evt));
@@ -265,12 +265,12 @@ void FC_FUNC_(transfer_boun_from_device,
             if (mp->has_last_copy_evt) {
               clCheck (clReleaseEvent (mp->last_copy_evt));
             }
-            
+
             clCheck (clEnqueueReadBuffer (mocl.copy_queue, mp->d_b_send_accel_buffer_inner_core.ocl, CL_FALSE, 0,
                                           size_mpi_buffer * sizeof (realw),
                                           mp->h_b_send_accel_buffer_ic, 1, &kernel_evt, &mp->last_copy_evt));
             mp->has_last_copy_evt = 1;
-          } else {            
+          } else {
             clCheck (clEnqueueReadBuffer (mocl.command_queue, mp->d_b_send_accel_buffer_inner_core.ocl, CL_TRUE, 0,
                                           size_mpi_buffer * sizeof (realw),
                                           send_accel_buffer, 0, NULL, NULL));
@@ -303,12 +303,12 @@ void FC_FUNC_(transfer_boun_from_device,
             // synchronous copy
             print_CUDA_error_if_any(cudaMemcpy(send_accel_buffer,mp->d_send_accel_buffer_inner_core.cuda,size_mpi_buffer*sizeof(realw),
                                                cudaMemcpyDeviceToHost),41000);
-            
+
           }
         } else if (*FORWARD_OR_ADJOINT == 3) {
           // debug
           DEBUG_BACKWARD_ASSEMBLY();
-          
+
           prepare_boundary_accel_on_device<<<grid,threads,0,mp->compute_stream>>>(mp->d_b_accel_inner_core.cuda,
                                                                                   mp->d_b_send_accel_buffer_inner_core.cuda,
                                                                                   mp->num_interfaces_inner_core,
@@ -349,7 +349,7 @@ void FC_FUNC_ (transfer_asmbl_accel_to_device,
   int blocksize, size_padded;
   int num_blocks_x, num_blocks_y;
   int size_mpi_buffer;
-  
+
 #ifdef USE_OPENCL
   size_t global_work_size[2];
   size_t local_work_size[2];
@@ -375,12 +375,12 @@ void FC_FUNC_ (transfer_asmbl_accel_to_device,
       get_blocks_xy (size_padded / blocksize, &num_blocks_x, &num_blocks_y);
 
 #ifdef USE_OPENCL
-      if (run_opencl) {        
+      if (run_opencl) {
         if (GPU_ASYNC_COPY && mp->has_last_copy_evt) {
           copy_evt = &mp->last_copy_evt;
           num_evt = 1;
         }
-        
+
         if (*FORWARD_OR_ADJOINT == 1) {
           // copies vector buffer values to GPU
           if (!GPU_ASYNC_COPY) {
@@ -405,14 +405,14 @@ void FC_FUNC_ (transfer_asmbl_accel_to_device,
         } else if (*FORWARD_OR_ADJOINT == 3) {
           // debug
           DEBUG_BACKWARD_ASSEMBLY ();
-          
+
           if (!GPU_ASYNC_COPY) {
             // copies vector buffer values to GPU
             clCheck (clEnqueueWriteBuffer (mocl.command_queue, mp->d_b_send_accel_buffer_crust_mantle.ocl, CL_FALSE, 0,
                                            NDIM * (mp->max_nibool_interfaces_cm) * (mp->num_interfaces_crust_mantle) * sizeof (realw),
                                            buffer_recv_vector, 0, NULL, NULL));
           }
-          
+
           //assemble adjoint accel
           clCheck (clSetKernelArg (mocl.kernels.assemble_boundary_accel_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_b_accel_crust_mantle.ocl));
           clCheck (clSetKernelArg (mocl.kernels.assemble_boundary_accel_on_device, idx++, sizeof (cl_mem), (void *) &mp->d_b_send_accel_buffer_crust_mantle.ocl));
@@ -507,7 +507,7 @@ void FC_FUNC_ (transfer_asmbl_accel_to_device,
           copy_evt = &mp->last_copy_evt;
           num_evt = 1;
         }
-        
+
         if (*FORWARD_OR_ADJOINT == 1) {
           // copies buffer values to GPU
           if (!GPU_ASYNC_COPY) {
@@ -532,7 +532,7 @@ void FC_FUNC_ (transfer_asmbl_accel_to_device,
         } else if (*FORWARD_OR_ADJOINT == 3) {
           // debug
           DEBUG_BACKWARD_ASSEMBLY ();
-          
+
           if (!GPU_ASYNC_COPY) {
             // copies buffer values to GPU
             clCheck (clEnqueueWriteBuffer (mocl.command_queue, mp->d_b_send_accel_buffer_inner_core.ocl, CL_FALSE, 0,
@@ -680,7 +680,7 @@ void FC_FUNC_(transfer_buffer_to_device_async,
                                          size_mpi_buffer * sizeof (realw),
                                          mp->h_b_recv_accel_buffer_cm, 0, NULL, NULL));
         }
-#endif    
+#endif
 #ifdef USE_CUDA
         if (run_cuda) {
           cudaMemcpyAsync(mp->d_b_send_accel_buffer_crust_mantle.cuda,mp->h_b_recv_accel_buffer_cm,size_mpi_buffer*sizeof(realw),
@@ -814,7 +814,7 @@ void FC_FUNC_(sync_copy_from_device,
   if (*iphase != 2) {
     exit_on_error("sync_copy_from_device must be called for iphase == 2");
   }
-  
+
   // regions
   if (*IREGION == IREGION_CRUST_MANTLE) {
     // crust/mantle
@@ -828,7 +828,7 @@ void FC_FUNC_(sync_copy_from_device,
           clCheck (clReleaseEvent (mp->last_copy_evt));
           mp->has_last_copy_evt = 0;
         }
-        
+
         clCheck (clFinish (mocl.copy_queue));
       }
 #endif
@@ -859,7 +859,7 @@ void FC_FUNC_(sync_copy_from_device,
           clCheck (clReleaseEvent (mp->last_copy_evt));
           mp->has_last_copy_evt = 0;
         }
-        
+
         clCheck (clFinish (mocl.copy_queue));
       }
 #endif
@@ -891,7 +891,7 @@ void FC_FUNC_(sync_copy_from_device,
           clCheck (clReleaseEvent (mp->last_copy_evt));
           mp->has_last_copy_evt = 0;
         }
-        
+
         clCheck (clFinish (mocl.copy_queue));
       }
 #endif

--- a/src/gpu/check_fields_gpu.c
+++ b/src/gpu/check_fields_gpu.c
@@ -250,7 +250,7 @@ void exit_on_error (char *info) {
     fprintf (fp, "ERROR: %s\n", info);
     fclose (fp);
   }
-  
+
   // stops program
 #ifdef WITH_MPI
   MPI_Abort (MPI_COMM_WORLD, 1);
@@ -537,7 +537,7 @@ void FC_FUNC_ (check_norm_acoustic_from_device,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     d_max.ocl = clCreateBuffer (mocl.context, CL_MEM_READ_WRITE, num_blocks_x * num_blocks_y * sizeof (realw), NULL, &errcode);
 
     if (*FORWARD_OR_ADJOINT == 1) {
@@ -642,7 +642,7 @@ void FC_FUNC_ (check_norm_elastic_from_device,
   size_t global_work_size[2];
   size_t local_work_size[2];
   cl_uint idx = 0;
-    
+
   if (run_opencl) {
     d_max.ocl = clCreateBuffer (mocl.context, CL_MEM_READ_WRITE, num_blocks_x*num_blocks_y*sizeof (realw), NULL, &errcode);
 
@@ -669,7 +669,7 @@ void FC_FUNC_ (check_norm_elastic_from_device,
 #endif
 #ifdef USE_CUDA
   dim3 grid,threads;
-  
+
   if (run_cuda) {
     grid = dim3(num_blocks_x,num_blocks_y);
     threads = dim3(blocksize,1,1);
@@ -843,7 +843,7 @@ void FC_FUNC_ (check_norm_strain_from_device,
     local_work_size[1] = 1;
     global_work_size[0] = num_blocks_x * blocksize;
     global_work_size[1] = num_blocks_y;
-    
+
     idx = 0;
     d_max.ocl = clCreateBuffer (mocl.context, CL_MEM_READ_WRITE, num_blocks_x * num_blocks_y * sizeof (realw), NULL, clck_(&errcode));
 

--- a/src/gpu/compute_add_sources_elastic_gpu.c
+++ b/src/gpu/compute_add_sources_elastic_gpu.c
@@ -54,7 +54,7 @@ void FC_FUNC_ (compute_add_sources_gpu,
     size_t global_work_size[3];
     size_t local_work_size[3];
     cl_uint idx = 0;
-    
+
     // copies source time function buffer values to GPU
     clCheck (clEnqueueWriteBuffer (mocl.command_queue, mp->d_stf_pre_compute.ocl, CL_FALSE, 0,
                                    NSOURCES * sizeof (double),
@@ -85,7 +85,7 @@ void FC_FUNC_ (compute_add_sources_gpu,
   if (run_cuda) {
     dim3 grid(num_blocks_x,num_blocks_y);
     dim3 threads(NGLLX,NGLLX,NGLLX);
-    
+
     // copies source time function buffer values to GPU
     print_CUDA_error_if_any(cudaMemcpy(mp->d_stf_pre_compute.cuda,h_stf_pre_compute,
                                        NSOURCES*sizeof(double),cudaMemcpyHostToDevice),71018);
@@ -136,7 +136,7 @@ void FC_FUNC_ (compute_add_sources_backward_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // copies source time function buffer values to GPU
     clCheck (clEnqueueWriteBuffer (mocl.command_queue, mp->d_stf_pre_compute.ocl, CL_FALSE, 0,
                                    NSOURCES * sizeof (double),
@@ -220,7 +220,7 @@ void FC_FUNC_ (compute_add_sources_adjoint_gpu,
     cl_uint idx = 0;
     cl_event *copy_evt = NULL;
     cl_uint num_evt = 0;
-    
+
     if (GPU_ASYNC_COPY && mp->has_last_copy_evt) {
       copy_evt = &mp->last_copy_evt;
       num_evt = 1;
@@ -404,7 +404,7 @@ please check mesh_constants_cuda.h");
       clCheck (clReleaseEvent (mp->last_copy_evt));
       mp->has_last_copy_evt = 0;
     }
-    
+
     clCheck (clFinish (mocl.copy_queue));
   }
 #endif
@@ -446,11 +446,11 @@ please check mesh_constants_cuda.h");
   if (run_opencl) {
     cl_event *copy_evt = NULL;
     cl_uint num_evt = 0;
-    
+
     if (mp->has_last_copy_evt) {
       clCheck (clReleaseEvent (mp->last_copy_evt));
     }
-    
+
     clCheck (clEnqueueWriteBuffer (mocl.copy_queue, mp->d_adj_sourcearrays.ocl, CL_FALSE, 0,
                                    mp->nadj_rec_local * NDIM * NGLL3 * sizeof (realw),
                                    mp->h_adj_sourcearrays_slice, num_evt, copy_evt, &mp->last_copy_evt));

--- a/src/gpu/compute_coupling_gpu.c
+++ b/src/gpu/compute_coupling_gpu.c
@@ -52,7 +52,7 @@ void FC_FUNC_ (compute_coupling_fluid_cmb_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // launches GPU kernel
     if (*FORWARD_OR_ADJOINT == 1) {
 
@@ -86,7 +86,7 @@ void FC_FUNC_ (compute_coupling_fluid_cmb_gpu,
     clCheck (clEnqueueNDRangeKernel (mocl.command_queue, mocl.kernels.compute_coupling_fluid_CMB_kernel, 2, NULL, global_work_size, local_work_size, 0, NULL, NULL));
   }
 skip_exec:;
-  
+
 #endif
 #ifdef USE_CUDA
   if (run_cuda) {
@@ -146,7 +146,7 @@ void FC_FUNC_ (compute_coupling_fluid_icb_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // launches GPU kernel
     if (*FORWARD_OR_ADJOINT == 1) {
       clCheck (clSetKernelArg (mocl.kernels.compute_coupling_fluid_ICB_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_displ_inner_core.ocl));
@@ -239,7 +239,7 @@ void FC_FUNC_ (compute_coupling_cmb_fluid_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // launches GPU kernel
     if (*FORWARD_OR_ADJOINT == 1) {
       clCheck (clSetKernelArg (mocl.kernels.compute_coupling_CMB_fluid_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_displ_crust_mantle.ocl));
@@ -343,7 +343,7 @@ void FC_FUNC_ (compute_coupling_icb_fluid_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // launches GPU kernel
     if (*FORWARD_OR_ADJOINT == 1) {
 
@@ -455,7 +455,7 @@ void FC_FUNC_ (compute_coupling_ocean_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // uses corrected mass matrices
     if (*FORWARD_OR_ADJOINT == 1) {
       clCheck (clSetKernelArg (mocl.kernels.compute_coupling_ocean_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_accel_crust_mantle.ocl));

--- a/src/gpu/compute_forces_crust_mantle_gpu.c
+++ b/src/gpu/compute_forces_crust_mantle_gpu.c
@@ -132,7 +132,7 @@ void crust_mantle (int nb_blocks_to_compute, Mesh *mp,
     size_t local_work_size[2];
     cl_kernel *crust_mantle_kernel_p;
     cl_uint idx = 0;
-    
+
     if (FORWARD_OR_ADJOINT != 1 && FORWARD_OR_ADJOINT != 3) {
       goto skipexec;
     } else if (FORWARD_OR_ADJOINT == 3) {
@@ -144,7 +144,7 @@ void crust_mantle (int nb_blocks_to_compute, Mesh *mp,
     } else {
       crust_mantle_kernel_p = &mocl.kernels.crust_mantle_impl_kernel_adjoint;
     }
-    
+
     clCheck (clSetKernelArg (*crust_mantle_kernel_p, idx++, sizeof (int), (void *) &nb_blocks_to_compute));
     clCheck (clSetKernelArg (*crust_mantle_kernel_p, idx++, sizeof (cl_mem), (void *) &d_ibool.ocl));
     clCheck (clSetKernelArg (*crust_mantle_kernel_p, idx++, sizeof (cl_mem), (void *) &d_ispec_is_tiso.ocl));

--- a/src/gpu/compute_forces_inner_core_gpu.c
+++ b/src/gpu/compute_forces_inner_core_gpu.c
@@ -106,7 +106,7 @@ void inner_core (int nb_blocks_to_compute, Mesh *mp,
     size_t local_work_size[2];
     cl_kernel *inner_core_kernel_p;
     cl_uint idx = 0;
-    
+
     if (FORWARD_OR_ADJOINT != 1 && FORWARD_OR_ADJOINT != 3) {
       goto skipexec;
     } else if (FORWARD_OR_ADJOINT == 3) {
@@ -118,7 +118,7 @@ void inner_core (int nb_blocks_to_compute, Mesh *mp,
     } else {
       inner_core_kernel_p = &mocl.kernels.inner_core_impl_kernel_adjoint;
     }
-    
+
     clCheck (clSetKernelArg (*inner_core_kernel_p, idx++, sizeof (int), (void *) &nb_blocks_to_compute));
     clCheck (clSetKernelArg (*inner_core_kernel_p, idx++, sizeof (cl_mem), (void *) &d_ibool.ocl));
     clCheck (clSetKernelArg (*inner_core_kernel_p, idx++, sizeof (cl_mem), (void *) &d_idoubling.ocl));

--- a/src/gpu/compute_forces_outer_core_gpu.c
+++ b/src/gpu/compute_forces_outer_core_gpu.c
@@ -77,7 +77,7 @@ void outer_core (int nb_blocks_to_compute, Mesh *mp,
     size_t local_work_size[2];
     cl_kernel *outer_core_kernel_p;
     cl_uint idx = 0;
-    
+
     if (FORWARD_OR_ADJOINT != 1 && FORWARD_OR_ADJOINT != 3) {
       goto skipexec;
     } else if (FORWARD_OR_ADJOINT == 3) {
@@ -90,7 +90,7 @@ void outer_core (int nb_blocks_to_compute, Mesh *mp,
     } else {
       outer_core_kernel_p = &mocl.kernels.outer_core_impl_kernel_adjoint;
     }
-    
+
     clCheck (clSetKernelArg (*outer_core_kernel_p, idx++, sizeof (int), (void *) &nb_blocks_to_compute));
     clCheck (clSetKernelArg (*outer_core_kernel_p, idx++, sizeof (cl_mem), (void *) &d_ibool.ocl));
     clCheck (clSetKernelArg (*outer_core_kernel_p, idx++, sizeof (cl_mem), (void *) &mp->d_phase_ispec_inner_outer_core));

--- a/src/gpu/compute_kernels_gpu.c
+++ b/src/gpu/compute_kernels_gpu.c
@@ -50,7 +50,7 @@ void FC_FUNC_ (compute_kernels_cm_gpu,
   size_t global_work_size[2];
   size_t local_work_size[2];
   cl_uint idx = 0;
-    
+
   if (run_opencl) {
     // density kernel
     clCheck (clSetKernelArg (mocl.kernels.compute_rho_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_ibool_crust_mantle.ocl));
@@ -332,7 +332,7 @@ void FC_FUNC_ (compute_kernels_ic_gpu,
   size_t global_work_size[2];
   size_t local_work_size[2];
   cl_uint idx = 0;
-    
+
   if (run_opencl) {
     clCheck (clSetKernelArg (mocl.kernels.compute_rho_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_ibool_inner_core.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_rho_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_accel_inner_core.ocl));
@@ -446,7 +446,7 @@ void FC_FUNC_ (compute_kernels_oc_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     clCheck (clSetKernelArg (mocl.kernels.compute_acoustic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_ibool_outer_core.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_acoustic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_rhostore_outer_core.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_acoustic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_kappavstore_outer_core.ocl));
@@ -528,7 +528,7 @@ void FC_FUNC_ (compute_kernels_strgth_noise_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // copies surface buffer to GPU
     clCheck (clEnqueueWriteBuffer (mocl.command_queue, mp->d_noise_surface_movie.ocl, CL_FALSE, 0,
                                    NDIM * NGLL2 * mp->nspec2D_top_crust_mantle * sizeof (realw),

--- a/src/gpu/compute_stacey_acoustic_gpu.c
+++ b/src/gpu/compute_stacey_acoustic_gpu.c
@@ -118,7 +118,7 @@ void FC_FUNC_ (compute_stacey_acoustic_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_veloc_outer_core.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_accel_outer_core.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_kernel, idx++, sizeof (int), (void *) &interface_type));
@@ -295,7 +295,7 @@ void FC_FUNC_ (compute_stacey_acoustic_backward_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_backward_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_b_accel_outer_core.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_backward_kernel, idx++, sizeof (cl_mem), (void *) &d_b_absorb_potential->ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_backward_kernel, idx++, sizeof (int), (void *) &interface_type));
@@ -431,7 +431,7 @@ void FC_FUNC_ (compute_stacey_acoustic_undoatt_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_b_veloc_outer_core.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_b_accel_outer_core.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_acoustic_kernel, idx++, sizeof (int), (void *) &interface_type));

--- a/src/gpu/compute_stacey_elastic_gpu.c
+++ b/src/gpu/compute_stacey_elastic_gpu.c
@@ -114,7 +114,7 @@ void FC_FUNC_ (compute_stacey_elastic_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // absorbing boundary contributions
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_elastic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_veloc_crust_mantle.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_elastic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_accel_crust_mantle.ocl));
@@ -269,7 +269,7 @@ void FC_FUNC_ (compute_stacey_elastic_backward_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // adjoint simulations: needs absorbing boundary buffer
     // copies array to GPU
 
@@ -415,7 +415,7 @@ void FC_FUNC_ (compute_stacey_elastic_undoatt_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     // absorbing boundary contributions
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_elastic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_b_veloc_crust_mantle.ocl));
     clCheck (clSetKernelArg (mocl.kernels.compute_stacey_elastic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_b_accel_crust_mantle.ocl));

--- a/src/gpu/initialize_gpu.c
+++ b/src/gpu/initialize_gpu.c
@@ -50,22 +50,22 @@ static struct {
   PASS(IFLAG_IN_FICTITIOUS_CUBE),
   PASS(COLORING_MIN_NSPEC_OUTER_CORE), PASS(COLORING_MIN_NSPEC_INNER_CORE),
   PASS(R_EARTH_KM),
-  
+
   /* macro functions: not working yet, spaces not allowed in OCL compiler*/
-  
+
 /* PASS(INDEX2(xsize, x, y)),
    PASS(INDEX3(xsize, ysize, x, y, z)),
    PASS(INDEX4(xsize, ysize, zsize, x, y, z, i)),
    PASS(INDEX4_PADDED(xsize, ysize, zsize, x, y, z, i)),
    PASS(INDEX5(xsize, ysize, zsize, isize, x, y, z, i, j)),
    PASS(INDEX6(xsize, ysize, zsize, isize, jsize, x, y, z, i, j, k)), */
-  
+
   /* macro flags, passed only ifdefed */
   PASS(MANUALLY_UNROLLED_LOOPS), PASS(USE_TEXTURES_CONSTANTS), PASS(USE_TEXTURES_FIELDS),
 
   PASS(USE_LAUNCH_BOUNDS),
   PASS(LAUNCH_MIN_BLOCKS),
-  
+
   {NULL, NULL}
 };
 #endif
@@ -103,7 +103,7 @@ exiting...\n");
   if (device_count == 0) {
     exit_on_error("CUDA runtime error: there is no device supporting CUDA\n");
   }
-  
+
   *nb_devices = device_count;
 
   // releases previous contexts
@@ -117,7 +117,7 @@ exiting...\n");
   int nbMatchingDevices = 0;
   struct cudaDeviceProp deviceProp;
   int i;
-  
+
   for (i = 0; i < device_count; i++) {
     // get device properties
     cudaGetDeviceProperties(&deviceProp, i);
@@ -131,13 +131,13 @@ exiting...\n");
     printf("ERROR: no matching devices for criteria %s/%s\n", platform_filter, device_filter);
     exit(1);
   }
-  
+
   int myDevice = matchingDevices[myrank % nbMatchingDevices];
   free(matchingDevices);
-  
+
   cudaSetDevice(myDevice);
   cudaGetDeviceProperties(&deviceProp, myDevice);
-  
+
   // exit if the machine has no CUDA-enabled device
   if (deviceProp.major == 9999 && deviceProp.minor == 9999){
     fprintf(stderr,"No CUDA-enabled device found, exiting...\n\n");
@@ -263,7 +263,7 @@ void build_kernels (void);
 
 static void initialize_ocl_device(const char *platform_filter, const char *device_filter, int myrank, int *nb_devices) {
   ocl_select_device(platform_filter, device_filter, myrank, nb_devices);
-  
+
   // outputs device info to file
   char filename[BUFSIZ];
   FILE *fp;
@@ -284,7 +284,7 @@ static void initialize_ocl_device(const char *platform_filter, const char *devic
     clGetDeviceInfo(mocl.device, CL_DEVICE_NAME, sizeof(name), name, NULL);
     clGetDeviceInfo(mocl.device, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof(size_t), &image2d_max_size[0], NULL);
     clGetDeviceInfo(mocl.device, CL_DEVICE_IMAGE2D_MAX_HEIGHT, sizeof(size_t), &image2d_max_size[1], NULL);
-    
+
     fprintf (fp, "Device Name = %s\n", name);
     fprintf (fp, "Type: %d\n", (int) device_type);
     fprintf (fp, "local_mem_size: %zu\n", local_mem_size);
@@ -325,9 +325,9 @@ void build_kernels (void) {
     pos += written;
     len -= written;
   }
-  
+
   #include "kernel_inc_cl.c"
-  
+
 #undef BOAST_KERNEL
 #define BOAST_KERNEL(__kern_name__)                                     \
   mocl.programs.__kern_name__##_program = clCreateProgramWithSource(    \
@@ -349,7 +349,7 @@ void build_kernels (void) {
   mocl.kernels.__kern_name__ = clCreateKernel (                         \
                                mocl.programs.__kern_name__ ## _program, \
                                #__kern_name__ , clck_(&errcode));
-  
+
   #include "kernel_list.h"
 }
 
@@ -389,12 +389,12 @@ static void get_platform_version(cl_platform_id platform_id, struct _opencl_vers
 
     char *cl_platform_version;
     cl_platform_version = (char *) malloc(cl_platform_version_size);
-    
+
     if (cl_platform_version == NULL) {
       fprintf(stderr,"Error: Failed to create string (out of memory)!\n");
       exit(1);
     }
-    
+
     clCheck(clGetPlatformInfo(platform_id, CL_PLATFORM_VERSION, cl_platform_version_size, cl_platform_version, NULL));
     //OpenCL<space><major_version.minor_version><space><platform-specific information>
     char minor[2], major[2];
@@ -412,23 +412,23 @@ void ocl_select_device(const char *platform_filter, const char *device_filter, i
     cl_int errcode = CL_SUCCESS;
     cl_platform_id *platform_ids;
     cl_uint num_platforms;
-    
+
     clGetPlatformIDs(0, NULL, &num_platforms);
-    
+
     if (num_platforms == 0) {
       fprintf(stderr,"No OpenCL platform available!\n");
       exit(1);
     }
-    
+
     platform_ids = (cl_platform_id *) malloc(num_platforms * sizeof(cl_platform_id));
-    
+
     clGetPlatformIDs(num_platforms, platform_ids, NULL);
-    
+
     cl_context_properties properties[] = {CL_CONTEXT_PLATFORM, 0, 0 };
     if (strlen(platform_filter)) {
       cl_uint found = 0;
       cl_uint i;
-      
+
       for (i = 0; i < num_platforms && !found; i++) {
         size_t info_length;
         char *info;
@@ -438,20 +438,20 @@ void ocl_select_device(const char *platform_filter, const char *device_filter, i
 
         for (j = 0; j < 2 && !found; j++) {
           clGetPlatformInfo(platform_ids[i], props_to_check[j], 0, NULL, &info_length);
-        
+
           info = (char *) malloc(info_length * sizeof(char));
-        
+
           clGetPlatformInfo(platform_ids[i], props_to_check[j], info_length, info, NULL);
 
           if (strcasestr(info, platform_filter)) {
             properties[1] = (cl_context_properties) platform_ids[i];
             found = 1;
           }
-        
+
           free(info);
         }
       }
-      
+
       if (!found) {
         fprintf(stderr, "No matching OpenCL platform available : %s!\n", platform_filter);
         exit(1);
@@ -459,54 +459,54 @@ void ocl_select_device(const char *platform_filter, const char *device_filter, i
     } else {
       properties[1] = (cl_context_properties) platform_ids[0];
     }
-    
+
     if (strlen(device_filter)) {
       cl_uint found = 0;
       cl_uint i;
       cl_uint num_devices;
       cl_device_id *device_ids;
       cl_device_id *matching_device_ids;
-      
+
       clGetDeviceIDs((cl_platform_id) properties[1], OCL_DEV_TYPE, 0, NULL, &num_devices);
       if (num_devices == 0) {
         fprintf(stderr,"No device of type %d!\n", (int) OCL_DEV_TYPE);
         exit(1);
       }
-      
+
       device_ids = (cl_device_id *) malloc(num_devices * sizeof(cl_device_id));
-      
+
       matching_device_ids = (cl_device_id *) malloc(num_devices * sizeof(cl_device_id));
-      
+
       clGetDeviceIDs((cl_platform_id) properties[1], OCL_DEV_TYPE, num_devices, device_ids, NULL);
       for (i = 0; i < num_devices; i++) {
         size_t info_length;
         char *info;
-        
+
         clGetDeviceInfo(device_ids[i], CL_DEVICE_NAME, 0, NULL, &info_length);
-        
+
         info = (char *) malloc(info_length * sizeof(char));
-        
+
         clGetDeviceInfo(device_ids[i], CL_DEVICE_NAME, info_length, info, NULL);
         if (strcasestr(info, device_filter)) {
           matching_device_ids[found] = device_ids[i];
           found++;
         }
-        
+
         free(info);
       }
-      
+
       if (!found) {
         fprintf(stderr, "No matching OpenCL device available : %s!\n", device_filter);
         exit(1);
       }
-      
+
       mocl.context = clCreateContext(properties, found, matching_device_ids, NULL, NULL, clck_(&errcode));
       free (matching_device_ids);
       free (device_ids);
     } else {
       mocl.context = clCreateContextFromType(properties, OCL_DEV_TYPE, NULL, NULL, clck_(&errcode));
     }
-    
+
     //get the number of devices available in the context (devices which are of DEVICE_TYPE_GPU of platform platform_ids[0])
     struct _opencl_version  platform_version;
     get_platform_version((cl_platform_id) properties[1], &platform_version);
@@ -522,16 +522,16 @@ void ocl_select_device(const char *platform_filter, const char *device_filter, i
     }
    mocl.nb_devices = *nb_devices;
    free(platform_ids);
- 
+
    size_t szParmDataBytes;
    cl_device_id* cdDevices;
-  
+
    // get the list of GPU devices associated with context
    clGetContextInfo(mocl.context, CL_CONTEXT_DEVICES, 0, NULL, &szParmDataBytes);
    cdDevices = (cl_device_id *) malloc(szParmDataBytes);
-   
+
    clGetContextInfo(mocl.context, CL_CONTEXT_DEVICES, szParmDataBytes, cdDevices, NULL);
-  
+
    mocl.device = cdDevices[myrank % mocl.nb_devices];
    free(cdDevices);
 
@@ -550,7 +550,7 @@ static char *trim_and_default(char *s)
   if (*s == '\0') {
     return s;
   }
-  
+
   // trim after
   char *back = s + strlen(s);
   while (isspace(*--back));
@@ -560,7 +560,7 @@ static char *trim_and_default(char *s)
   if (strlen(s) == 1 && *s == '*') {
     *s = '\0';
   }
-  
+
   return s;
 }
 
@@ -574,7 +574,7 @@ void FC_FUNC_ (initialize_gpu_device,
 
   platform_filter = trim_and_default(platform_filter);
   device_filter = trim_and_default(device_filter);
-  
+
 #if defined(USE_OPENCL) && defined(USE_CUDA)
   run_cuda = runtime_type == CUDA;
   run_opencl = runtime_type == OPENCL;

--- a/src/gpu/mesh_constants_gpu.h
+++ b/src/gpu/mesh_constants_gpu.h
@@ -883,13 +883,13 @@ typedef struct mesh_ {
   float* h_recv_accel_buffer_cm;
   float* h_b_send_accel_buffer_cm;
   float* h_b_recv_accel_buffer_cm;
-  
+
   // inner core
   float* h_send_accel_buffer_ic;
   float* h_recv_accel_buffer_ic;
   float* h_b_send_accel_buffer_ic;
   float* h_b_recv_accel_buffer_ic;
-  
+
   // outer core
   float* h_send_accel_buffer_oc;
   float* h_recv_accel_buffer_oc;
@@ -905,13 +905,13 @@ typedef struct mesh_ {
   cl_mem h_pinned_recv_accel_buffer_cm;
   cl_mem h_pinned_b_send_accel_buffer_cm;
   cl_mem h_pinned_b_recv_accel_buffer_cm;
-  
+
   // inner core
   cl_mem h_pinned_send_accel_buffer_ic;
   cl_mem h_pinned_recv_accel_buffer_ic;
   cl_mem h_pinned_b_send_accel_buffer_ic;
   cl_mem h_pinned_b_recv_accel_buffer_ic;
-  
+
   // outer core
   cl_mem h_pinned_send_accel_buffer_oc;
   cl_mem h_pinned_recv_accel_buffer_oc;
@@ -928,7 +928,7 @@ typedef struct mesh_ {
   cl_event last_copy_evt;
   int has_last_copy_evt;
 #endif
-  
+
 } Mesh;
 
 

--- a/src/gpu/mesh_constants_ocl.h
+++ b/src/gpu/mesh_constants_ocl.h
@@ -81,7 +81,7 @@ const char* clewErrorString (cl_int error);
                                   mp->h_##_buffer_,                     \
                                   0, NULL, NULL));                      \
   clCheck(clReleaseMemObject (mp->h_pinned_##_buffer_))
-                                                                
+
 extern int mocl_errcode;
 static inline cl_int _clCheck(cl_int errcode, const char *file, int line, const char *func) {
   mocl_errcode = errcode;
@@ -110,11 +110,11 @@ struct mesh_programs_s {
 
   #include "kernel_list.h"
 };
-  
+
 struct mesh_kernels_s {
 #undef BOAST_KERNEL
 #define BOAST_KERNEL(__kern_name__) cl_kernel __kern_name__
-  
+
   #include "kernel_list.h"
 };
 

--- a/src/gpu/noise_tomography_gpu.c
+++ b/src/gpu/noise_tomography_gpu.c
@@ -50,7 +50,7 @@ void FC_FUNC_ (noise_transfer_surface_to_host,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     clCheck (clSetKernelArg (mocl.kernels.noise_transfer_surface_to_host_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_ibelm_top_crust_mantle.ocl));
     clCheck (clSetKernelArg (mocl.kernels.noise_transfer_surface_to_host_kernel, idx++, sizeof (int), (void *) &mp->nspec2D_top_crust_mantle));
     clCheck (clSetKernelArg (mocl.kernels.noise_transfer_surface_to_host_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_ibool_crust_mantle.ocl));
@@ -121,7 +121,7 @@ void FC_FUNC_ (noise_add_source_master_rec_gpu,
       size_t global_work_size[2];
       size_t local_work_size[2];
       cl_uint idx = 0;
-      
+
       clCheck (clSetKernelArg (mocl.kernels.noise_add_source_master_rec_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_ibool_crust_mantle.ocl));
       clCheck (clSetKernelArg (mocl.kernels.noise_add_source_master_rec_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_ispec_selected_rec.ocl));
       clCheck (clSetKernelArg (mocl.kernels.noise_add_source_master_rec_kernel, idx++, sizeof (int), (void *) &irec_master_noise));
@@ -175,7 +175,7 @@ void FC_FUNC_ (noise_add_surface_movie_gpu,
   size_t global_work_size[2];
   size_t local_work_size[2];
   cl_uint idx = 0;
-    
+
   if (run_opencl) {
     clCheck (clEnqueueWriteBuffer (mocl.command_queue, mp->d_noise_surface_movie.ocl, CL_FALSE, 0,
                                    NDIM*NGLL2 *(mp->nspec2D_top_crust_mantle)*sizeof (realw),

--- a/src/gpu/prepare_mesh_constants_gpu.c
+++ b/src/gpu/prepare_mesh_constants_gpu.c
@@ -91,7 +91,7 @@ void moclEnqueueFillBuffer (Mesh *mp, cl_mem *buffer, int val, size_t size) {
   size_t global_work_size[2];
   size_t local_work_size[2];
   cl_uint idx = 0;
-    
+
   clCheck (clSetKernelArg (*memset_kern, idx++, sizeof (cl_mem), (void *) buffer));
   clCheck (clSetKernelArg (*memset_kern, idx++, sizeof (cl_int), (void *) &val));
 
@@ -205,7 +205,7 @@ void copy_todevice_realw (Mesh *mp, gpu_realw_mem *d_array_addr_ptr, realw *h_ar
 void initialize_dummy_buffers(Mesh *mp) {
 #ifdef USE_OPENCL
   #define INIT_DUMMY_BUFFER(_field_) mp->_field_.ocl = NULL;
-  
+
   #define GPU_REALW_BUFFER INIT_DUMMY_BUFFER
   #define GPU_INT_BUFFER INIT_DUMMY_BUFFER
   #define GPU_DOUBLE_BUFFER INIT_DUMMY_BUFFER
@@ -214,7 +214,7 @@ void initialize_dummy_buffers(Mesh *mp) {
 #endif
 #ifdef USE_CUDA
   #define INIT_DUMMY_BUFFER(_field_) mp->_field_.cuda = NULL
-  
+
   #define GPU_REALW_BUFFER INIT_DUMMY_BUFFER
   #define GPU_INT_BUFFER INIT_DUMMY_BUFFER
   #define GPU_DOUBLE_BUFFER INIT_DUMMY_BUFFER
@@ -226,7 +226,7 @@ void initialize_dummy_buffers(Mesh *mp) {
 // setup functions
 void setConst (gpu_realw_mem *buffer, size_t size, realw *array) {
   size *= sizeof(realw);
-  
+
 #ifdef USE_OPENCL
   if (run_opencl) {
     cl_int errcode;
@@ -292,7 +292,7 @@ void FC_FUNC_ (prepare_constants_device,
 #ifdef USE_OPENCL
   cl_int errcode;
 #endif
-  
+
   initialize_dummy_buffers(mp);
   // checks if NGLLX == 5
   if (*h_NGLLX != NGLLX) {
@@ -305,7 +305,7 @@ void FC_FUNC_ (prepare_constants_device,
   // sets constant arrays
   setConst (&mp->d_hprime_xx, NGLL2, h_hprime_xx);
   setConst (&mp->d_hprimewgll_xx, NGLL2, h_hprimewgll_xx);
-  
+
   setConst (&mp->d_wgllwgll_xy, NGLL2, h_wgllwgll_xy);
   setConst (&mp->d_wgllwgll_xz, NGLL2, h_wgllwgll_xz);
   setConst (&mp->d_wgllwgll_yz, NGLL2, h_wgllwgll_yz);
@@ -322,7 +322,7 @@ void FC_FUNC_ (prepare_constants_device,
     mp->d_hprimewgll_xx_cm_tex = moclGetDummyImage2D(mp);
 #endif //USE_TEXTURES_CONSTANTS
   }
-#endif 
+#endif
 #ifdef USE_CUDA
   if (run_cuda) {
     // Using texture memory for the hprime-style constants is slower on
@@ -346,7 +346,7 @@ void FC_FUNC_ (prepare_constants_device,
                                             &channelDesc, sizeof(realw)*(NGLL2)), 1102);
     // d_hprime_xx was cudaMalloced, so offset is 0
     //print_CUDA_error_if_any(cudaMemcpyToSymbol(d_hprime_xx_tex_offset,&offset,sizeof(offset)),11202);
-    
+
     // weighted
     const textureReference* d_hprimewgll_xx_tex_ptr;
     print_CUDA_error_if_any(cudaGetTextureReference(&d_hprimewgll_xx_tex_ptr, "d_hprimewgll_xx_tex"), 1107);
@@ -361,7 +361,7 @@ void FC_FUNC_ (prepare_constants_device,
     //print_CUDA_error_if_any(cudaMemcpyToSymbol(d_hprime_xx_tex_offset,&offset,sizeof(offset)),11202);
     // debug
     //if( mp->myrank == 0 ) printf("texture constants hprime_xx: offset = %lu \n",offset);
-    
+
     // weighted
     print_CUDA_error_if_any(cudaBindTexture(&offset, &d_hprimewgll_xx_tex, mp->d_hprimewgll_xx.cuda,
                                             &channelDesc, sizeof(realw)*(NGLL2)), 11204);
@@ -470,19 +470,19 @@ void FC_FUNC_ (prepare_constants_device,
         ALLOC_PINNED_BUFFER_OCL (station_seismo_field, NDIM * NGLL3 * mp->nrec_local * sizeof(realw));
       } else {
         mp->h_station_seismo_field = (realw *) malloc (NDIM * NGLL3 * mp->nrec_local * sizeof(realw));
-        
+
         if (mp->h_station_seismo_field == NULL) {
           exit_on_error("h_station_seismo_field not allocated \n");
         }
       }
-    
+
       // for adjoint strain
       if (mp->simulation_type == 2) {
         mp->d_station_strain_field.ocl = clCreateBuffer (mocl.context, CL_MEM_READ_WRITE,
                                                          NGLL3 * mp->nrec_local * sizeof (realw),
                                                          NULL, clck_(&errcode));
         mp->h_station_strain_field = (realw *) malloc (NGLL3 * mp->nrec_local * sizeof(realw));
-        
+
         if (mp->h_station_strain_field == NULL) {
           exit_on_error("h_station_strain_field not allocated \n");
         }
@@ -503,7 +503,7 @@ void FC_FUNC_ (prepare_constants_device,
         mp->h_station_seismo_field = (realw*) malloc( NDIM*NGLL3*(mp->nrec_local)*sizeof(realw) );
         if (mp->h_station_seismo_field == NULL) exit_on_error("h_station_seismo_field not allocated \n");
       }
-    
+
       // for adjoint strain
       if (mp->simulation_type == 2) {
         print_CUDA_error_if_any(cudaMalloc((void**)&(mp->d_station_strain_field),
@@ -1358,14 +1358,14 @@ void FC_FUNC_ (prepare_mpi_buffers_device,
       }
 #endif
     }
-  
+
 #ifdef USE_OPENCL
     if (run_opencl) {
       // asynchronous MPI buffer
       if (GPU_ASYNC_COPY) {
         ALLOC_PINNED_BUFFER_OCL(send_accel_buffer_cm, sizeof(realw)* size_mpi_buffer);
         ALLOC_PINNED_BUFFER_OCL(recv_accel_buffer_cm, sizeof(realw)* size_mpi_buffer);
-      
+
         if (mp->simulation_type == 3) {
           ALLOC_PINNED_BUFFER_OCL(b_send_accel_buffer_cm, sizeof(realw)* size_mpi_buffer);
           ALLOC_PINNED_BUFFER_OCL(b_recv_accel_buffer_cm, sizeof(realw)* size_mpi_buffer);
@@ -1379,7 +1379,7 @@ void FC_FUNC_ (prepare_mpi_buffers_device,
       if (GPU_ASYNC_COPY) {
         ALLOC_PINNED_BUFFER_OCL(send_accel_buffer_cm, sizeof(realw)* size_mpi_buffer);
         ALLOC_PINNED_BUFFER_OCL(recv_accel_buffer_cm, sizeof(realw)* size_mpi_buffer);
-      
+
         if (mp->simulation_type == 3) {
           ALLOC_PINNED_BUFFER_OCL(b_send_accel_buffer_cm, sizeof(realw)* size_mpi_buffer);
           ALLOC_PINNED_BUFFER_OCL(b_recv_accel_buffer_cm, sizeof(realw)* size_mpi_buffer);
@@ -1406,7 +1406,7 @@ void FC_FUNC_ (prepare_mpi_buffers_device,
     }
 #endif
   }
-  
+
   // inner core mesh
   mp->num_interfaces_inner_core = *num_interfaces_inner_core;
   mp->max_nibool_interfaces_ic = *max_nibool_interfaces_ic;
@@ -1450,14 +1450,14 @@ void FC_FUNC_ (prepare_mpi_buffers_device,
       }
 #endif
     }
-    
+
 #ifdef USE_OPENCL
     if (run_opencl) {
       // asynchronous MPI buffer
       if (GPU_ASYNC_COPY) {
         ALLOC_PINNED_BUFFER_OCL(send_accel_buffer_ic, sizeof(realw)* size_mpi_buffer);
         ALLOC_PINNED_BUFFER_OCL(recv_accel_buffer_ic, sizeof(realw)* size_mpi_buffer);
-      
+
         if (mp->simulation_type == 3) {
           ALLOC_PINNED_BUFFER_OCL(b_send_accel_buffer_ic, sizeof(realw)* size_mpi_buffer);
           ALLOC_PINNED_BUFFER_OCL(b_recv_accel_buffer_ic, sizeof(realw)* size_mpi_buffer);
@@ -1516,7 +1516,7 @@ void FC_FUNC_ (prepare_mpi_buffers_device,
 #endif
 
     /***************************/
-    
+
     if (mp->simulation_type == 3) {
 #ifdef USE_OPENCL
       if (run_opencl) {
@@ -1533,14 +1533,14 @@ void FC_FUNC_ (prepare_mpi_buffers_device,
     }
 
     /**************************/
-    
+
 #ifdef USE_OPENCL
   if (run_opencl) {
     // asynchronous MPI buffer
     if (GPU_ASYNC_COPY) {
       ALLOC_PINNED_BUFFER_OCL(send_accel_buffer_oc, sizeof(realw)* size_mpi_buffer);
       ALLOC_PINNED_BUFFER_OCL(recv_accel_buffer_oc, sizeof(realw)* size_mpi_buffer);
-      
+
       if (mp->simulation_type == 3) {
         ALLOC_PINNED_BUFFER_OCL(b_send_accel_buffer_oc, sizeof(realw)* size_mpi_buffer);
         ALLOC_PINNED_BUFFER_OCL(b_recv_accel_buffer_oc, sizeof(realw)* size_mpi_buffer);
@@ -2271,10 +2271,10 @@ void FC_FUNC_ (prepare_crust_mantle_device,
   if (run_opencl) {
 #ifdef USE_TEXTURES_FIELDS
     cl_image_format format = {CL_R, CL_UNSIGNED_INT32};
-    
+
     mp->d_displ_cm_tex = clCreateImage2D (mocl.context, CL_MEM_READ_ONLY, &format, size, 1, 0, mp->d_displ_crust_mantle.ocl, clck_(&errcode));
     mp->d_accel_cm_tex = clCreateImage2D (mocl.context, CL_MEM_READ_ONLY, &format, size, 1, 0, mp->d_accel_crust_mantle.ocl, clck_(&errcode));
-    
+
     if (mp->simulation_type == 3) {
       mp->d_b_displ_cm_tex = clCreateImage2D (mocl.context, CL_MEM_READ_ONLY, &format, size, 1, 0, mp->d_b_displ_crust_mantle.ocl, clck_(&errcode));
       mp->d_b_accel_cm_tex = clCreateImage2D (mocl.context, CL_MEM_READ_ONLY, &format, size, 1, 0, mp->d_b_accel_crust_mantle.ocl, clck_(&errcode));
@@ -2282,7 +2282,7 @@ void FC_FUNC_ (prepare_crust_mantle_device,
 #else
     mp->d_displ_cm_tex = moclGetDummyImage2D(mp);
     mp->d_accel_cm_tex = moclGetDummyImage2D(mp);
-    
+
     mp->d_b_displ_cm_tex = moclGetDummyImage2D(mp);
     mp->d_b_accel_cm_tex = moclGetDummyImage2D(mp);
 #endif
@@ -2742,7 +2742,7 @@ void FC_FUNC_ (prepare_outer_core_device,
 #else
     mp->d_displ_oc_tex = moclGetDummyImage2D(mp);
     mp->d_accel_oc_tex = moclGetDummyImage2D(mp);
-    
+
     mp->d_b_displ_oc_tex = moclGetDummyImage2D(mp);
     mp->d_b_accel_oc_tex = moclGetDummyImage2D(mp);
 #endif
@@ -2757,7 +2757,7 @@ void FC_FUNC_ (prepare_outer_core_device,
     print_CUDA_error_if_any(cudaGetTextureReference(&d_displ_oc_tex_ref_ptr, "d_displ_oc_tex"), 5021);
     print_CUDA_error_if_any(cudaBindTexture(0, d_displ_oc_tex_ref_ptr, mp->d_displ_outer_core,
                                             &channelDesc, sizeof(realw)*size_glob), 5021);
-    
+
     const textureReference* d_accel_oc_tex_ref_ptr;
     print_CUDA_error_if_any(cudaGetTextureReference(&d_accel_oc_tex_ref_ptr, "d_accel_oc_tex"), 5023);
     print_CUDA_error_if_any(cudaBindTexture(0, d_accel_oc_tex_ref_ptr, mp->d_accel_outer_core,
@@ -2768,7 +2768,7 @@ void FC_FUNC_ (prepare_outer_core_device,
       print_CUDA_error_if_any(cudaGetTextureReference(&d_b_displ_oc_tex_ref_ptr, "d_b_displ_oc_tex"), 5021);
       print_CUDA_error_if_any(cudaBindTexture(0, d_b_displ_oc_tex_ref_ptr, mp->d_b_displ_outer_core,
                                               &channelDesc, sizeof(realw)*size_glob), 5021);
-      
+
       const textureReference* d_b_accel_oc_tex_ref_ptr;
       print_CUDA_error_if_any(cudaGetTextureReference(&d_b_accel_oc_tex_ref_ptr, "d_b_accel_oc_tex"), 5023);
         print_CUDA_error_if_any(cudaBindTexture(0, d_b_accel_oc_tex_ref_ptr, mp->d_b_accel_outer_core,
@@ -3220,7 +3220,7 @@ void FC_FUNC_ (prepare_inner_core_device,
     cl_image_format format = {CL_R, CL_UNSIGNED_INT32};
     mp->d_displ_ic_tex = clCreateImage2D (mocl.context, CL_MEM_READ_ONLY, &format, size, 1, 0, mp->d_displ_inner_core.ocl, clck_(&errcode));
     mp->d_accel_ic_tex = clCreateImage2D (mocl.context, CL_MEM_READ_ONLY, &format, size, 1, 0, mp->d_accel_inner_core.ocl, clck_(&errcode));
-    
+
     if( mp->simulation_type == 3 ){
       mp->d_b_displ_ic_tex = clCreateImage2D (mocl.context, CL_MEM_READ_ONLY, &format, size, 1, 0, mp->d_b_displ_inner_core.ocl, clck_(&errcode));
       mp->d_b_accel_ic_tex = clCreateImage2D (mocl.context, CL_MEM_READ_ONLY, &format, size, 1, 0, mp->d_b_accel_inner_core.ocl, clck_(&errcode));
@@ -3228,7 +3228,7 @@ void FC_FUNC_ (prepare_inner_core_device,
 #else
     mp->d_displ_ic_tex = moclGetDummyImage2D(mp);
     mp->d_accel_ic_tex = moclGetDummyImage2D(mp);
-    
+
     mp->d_b_displ_ic_tex = moclGetDummyImage2D(mp);
     mp->d_b_accel_ic_tex = moclGetDummyImage2D(mp);
 #endif
@@ -3445,7 +3445,7 @@ void FC_FUNC_ (prepare_cleanup_device,
       if (GPU_ASYNC_COPY) {
         RELEASE_PINNED_BUFFER_OCL (send_accel_buffer_cm);
         RELEASE_PINNED_BUFFER_OCL (recv_accel_buffer_cm);
-      
+
         if (mp->simulation_type == 3) {
           RELEASE_PINNED_BUFFER_OCL (b_send_accel_buffer_cm);
           RELEASE_PINNED_BUFFER_OCL (b_recv_accel_buffer_cm);
@@ -3456,7 +3456,7 @@ void FC_FUNC_ (prepare_cleanup_device,
       if (GPU_ASYNC_COPY) {
         RELEASE_PINNED_BUFFER_OCL (send_accel_buffer_ic);
         RELEASE_PINNED_BUFFER_OCL (recv_accel_buffer_ic);
-      
+
         if (mp->simulation_type == 3) {
           RELEASE_PINNED_BUFFER_OCL (b_send_accel_buffer_ic);
           RELEASE_PINNED_BUFFER_OCL (b_recv_accel_buffer_ic);
@@ -3467,7 +3467,7 @@ void FC_FUNC_ (prepare_cleanup_device,
       if (GPU_ASYNC_COPY) {
         RELEASE_PINNED_BUFFER_OCL (send_accel_buffer_oc);
         RELEASE_PINNED_BUFFER_OCL (recv_accel_buffer_oc);
-      
+
         if (mp->simulation_type == 3) {
           RELEASE_PINNED_BUFFER_OCL (b_send_accel_buffer_oc);
           RELEASE_PINNED_BUFFER_OCL (b_recv_accel_buffer_oc);
@@ -3547,7 +3547,7 @@ void FC_FUNC_ (prepare_cleanup_device,
     if (mp->rotation) {
       clReleaseMemObject (mp->d_A_array_rotation.ocl);
       clReleaseMemObject (mp->d_B_array_rotation.ocl);
-      
+
       if (mp->simulation_type == 3) {
         clReleaseMemObject (mp->d_b_A_array_rotation.ocl);
         clReleaseMemObject (mp->d_b_B_array_rotation.ocl);
@@ -3559,7 +3559,7 @@ void FC_FUNC_ (prepare_cleanup_device,
     //------------------------------------------
     if (!mp->gravity) {
       clReleaseMemObject (mp->d_d_ln_density_dr_table.ocl);
-      
+
     } else {
       clReleaseMemObject (mp->d_minus_rho_g_over_kappa_fluid.ocl);
       clReleaseMemObject (mp->d_minus_gravity_table.ocl);
@@ -3573,7 +3573,7 @@ void FC_FUNC_ (prepare_cleanup_device,
     if (mp->attenuation) {
       clReleaseMemObject (mp->d_one_minus_sum_beta_crust_mantle.ocl);
       clReleaseMemObject (mp->d_one_minus_sum_beta_inner_core.ocl);
-      
+
       if (! mp->partial_phys_dispersion_only) {
         clReleaseMemObject (mp->d_factor_common_crust_mantle.ocl);
         clReleaseMemObject (mp->d_R_xx_crust_mantle.ocl);
@@ -3588,11 +3588,11 @@ void FC_FUNC_ (prepare_cleanup_device,
         clReleaseMemObject (mp->d_R_xz_inner_core.ocl);
         clReleaseMemObject (mp->d_R_yz_inner_core.ocl);
       }
-      
+
       clReleaseMemObject (mp->d_alphaval.ocl);
       clReleaseMemObject (mp->d_betaval.ocl);
       clReleaseMemObject (mp->d_gammaval.ocl);
-      
+
       if (mp->simulation_type == 3) {
         clReleaseMemObject (mp->d_b_alphaval.ocl);
         clReleaseMemObject (mp->d_b_betaval.ocl);
@@ -3618,7 +3618,7 @@ void FC_FUNC_ (prepare_cleanup_device,
 
       clReleaseMemObject (mp->d_eps_trace_over_3_crust_mantle.ocl);
       clReleaseMemObject (mp->d_eps_trace_over_3_inner_core.ocl);
-      
+
       if (mp->simulation_type == 3 && ! mp->undo_attenuation){
         clReleaseMemObject (mp->d_b_epsilondev_xx_crust_mantle.ocl);
         clReleaseMemObject (mp->d_b_epsilondev_yy_crust_mantle.ocl);
@@ -3649,17 +3649,17 @@ void FC_FUNC_ (prepare_cleanup_device,
       clReleaseMemObject (mp->d_njmax_crust_mantle.ocl);
       clReleaseMemObject (mp->d_nimin_crust_mantle.ocl);
       clReleaseMemObject (mp->d_nimax_crust_mantle.ocl);
-      
+
       if (mp->nspec2D_xmin_crust_mantle > 0) {
         clReleaseMemObject (mp->d_ibelm_xmin_crust_mantle.ocl);
         clReleaseMemObject (mp->d_normal_xmin_crust_mantle.ocl);
         clReleaseMemObject (mp->d_jacobian2D_xmin_crust_mantle.ocl);
-        
+
         if ((mp->simulation_type == 1 && mp->save_forward) || (mp->simulation_type == 3)) {
           clReleaseMemObject (mp->d_absorb_xmin_crust_mantle.ocl);
         }
       }
-      
+
       if (mp->nspec2D_xmax_crust_mantle > 0) {
         clReleaseMemObject (mp->d_ibelm_xmax_crust_mantle.ocl);
         clReleaseMemObject (mp->d_normal_xmax_crust_mantle.ocl);
@@ -3668,22 +3668,22 @@ void FC_FUNC_ (prepare_cleanup_device,
           clReleaseMemObject (mp->d_absorb_xmax_crust_mantle.ocl);
         }
       }
-      
+
       if (mp->nspec2D_ymin_crust_mantle > 0) {
         clReleaseMemObject (mp->d_ibelm_ymin_crust_mantle.ocl);
         clReleaseMemObject (mp->d_normal_ymin_crust_mantle.ocl);
         clReleaseMemObject (mp->d_jacobian2D_ymin_crust_mantle.ocl);
-        
+
         if ((mp->simulation_type == 1 && mp->save_forward) || (mp->simulation_type == 3)) {
           clReleaseMemObject (mp->d_absorb_ymin_crust_mantle.ocl);
         }
       }
-      
+
       if (mp->nspec2D_ymax_crust_mantle > 0) {
         clReleaseMemObject (mp->d_ibelm_ymax_crust_mantle.ocl);
         clReleaseMemObject (mp->d_normal_ymax_crust_mantle.ocl);
         clReleaseMemObject (mp->d_jacobian2D_ymax_crust_mantle.ocl);
-        
+
         if ((mp->simulation_type == 1 && mp->save_forward) || (mp->simulation_type == 3)) {
           clReleaseMemObject (mp->d_absorb_ymax_crust_mantle.ocl);
         }
@@ -3696,11 +3696,11 @@ void FC_FUNC_ (prepare_cleanup_device,
       clReleaseMemObject (mp->d_njmax_outer_core.ocl);
       clReleaseMemObject (mp->d_nimin_outer_core.ocl);
       clReleaseMemObject (mp->d_nimax_outer_core.ocl);
-      
+
       if (mp->nspec2D_xmin_outer_core > 0) {
         clReleaseMemObject (mp->d_ibelm_xmin_outer_core.ocl);
         clReleaseMemObject (mp->d_jacobian2D_xmin_outer_core.ocl);
-        
+
         if ((mp->simulation_type == 1 && mp->save_forward) || (mp->simulation_type == 3)) {
           clReleaseMemObject (mp->d_absorb_xmin_outer_core.ocl);
         }
@@ -3708,7 +3708,7 @@ void FC_FUNC_ (prepare_cleanup_device,
       if (mp->nspec2D_xmax_outer_core > 0) {
         clReleaseMemObject (mp->d_ibelm_xmax_outer_core.ocl);
         clReleaseMemObject (mp->d_jacobian2D_xmax_outer_core.ocl);
-        
+
         if ((mp->simulation_type == 1 && mp->save_forward) || (mp->simulation_type == 3)) {
           clReleaseMemObject (mp->d_absorb_xmax_outer_core.ocl);
         }
@@ -3716,7 +3716,7 @@ void FC_FUNC_ (prepare_cleanup_device,
       if (mp->nspec2D_ymin_outer_core > 0) {
         clReleaseMemObject (mp->d_ibelm_ymin_outer_core.ocl);
         clReleaseMemObject (mp->d_jacobian2D_ymin_outer_core.ocl);
-        
+
         if ((mp->simulation_type == 1 && mp->save_forward) || (mp->simulation_type == 3)) {
           clReleaseMemObject (mp->d_absorb_ymin_outer_core.ocl);
         }
@@ -3724,7 +3724,7 @@ void FC_FUNC_ (prepare_cleanup_device,
       if (mp->nspec2D_ymax_outer_core > 0) {
         clReleaseMemObject (mp->d_ibelm_ymax_outer_core.ocl);
         clReleaseMemObject (mp->d_jacobian2D_ymax_outer_core.ocl);
-        
+
         if ((mp->simulation_type == 1 && mp->save_forward) || (mp->simulation_type == 3)) {
           clReleaseMemObject (mp->d_absorb_ymax_outer_core.ocl);
         }
@@ -3744,17 +3744,17 @@ void FC_FUNC_ (prepare_cleanup_device,
       clReleaseMemObject (mp->d_nibool_interfaces_crust_mantle.ocl);
       clReleaseMemObject (mp->d_ibool_interfaces_crust_mantle.ocl);
       clReleaseMemObject (mp->d_send_accel_buffer_crust_mantle.ocl);
-      
+
       if (mp->simulation_type == 3) {
         clReleaseMemObject (mp->d_b_send_accel_buffer_crust_mantle.ocl);
       }
     }
-    
+
     if (mp->num_interfaces_inner_core > 0) {
       clReleaseMemObject (mp->d_nibool_interfaces_inner_core.ocl);
       clReleaseMemObject (mp->d_ibool_interfaces_inner_core.ocl);
       clReleaseMemObject (mp->d_send_accel_buffer_inner_core.ocl);
-      
+
       if (mp->simulation_type == 3) {
         clReleaseMemObject (mp->d_b_send_accel_buffer_inner_core.ocl);
       }
@@ -3763,23 +3763,23 @@ void FC_FUNC_ (prepare_cleanup_device,
       clReleaseMemObject (mp->d_nibool_interfaces_outer_core.ocl);
       clReleaseMemObject (mp->d_ibool_interfaces_outer_core.ocl);
       clReleaseMemObject (mp->d_send_accel_buffer_outer_core.ocl);
-      
+
       if (mp->simulation_type == 3) {
         clReleaseMemObject (mp->d_b_send_accel_buffer_outer_core.ocl);
       }
     }
- 
+
     //------------------------------------------
     // NOISE arrays
     //------------------------------------------
     if (mp->noise_tomography > 0) {
       clReleaseMemObject (mp->d_ibelm_top_crust_mantle.ocl);
       clReleaseMemObject (mp->d_noise_surface_movie.ocl);
-      
+
       if (mp->noise_tomography == 1) {
         clReleaseMemObject (mp->d_noise_sourcearray.ocl);
       }
-      
+
       if (mp->noise_tomography > 1) {
         clReleaseMemObject (mp->d_normal_x_noise.ocl);
         clReleaseMemObject (mp->d_normal_y_noise.ocl);
@@ -3787,7 +3787,7 @@ void FC_FUNC_ (prepare_cleanup_device,
         clReleaseMemObject (mp->d_mask_noise.ocl);
         clReleaseMemObject (mp->d_jacobian2D_top_crust_mantle.ocl);
       }
-      
+
       if (mp->noise_tomography == 3) {
         clReleaseMemObject (mp->d_Sigma_kl.ocl);
       }
@@ -3796,7 +3796,7 @@ void FC_FUNC_ (prepare_cleanup_device,
     //------------------------------------------
     // crust_mantle
     //------------------------------------------
-    
+
     clReleaseMemObject (mp->d_xix_crust_mantle.ocl);
     clReleaseMemObject (mp->d_xiy_crust_mantle.ocl);
     clReleaseMemObject (mp->d_xiz_crust_mantle.ocl);
@@ -3816,7 +3816,7 @@ void FC_FUNC_ (prepare_cleanup_device,
       clReleaseMemObject (mp->d_muvstore_crust_mantle.ocl);
       clReleaseMemObject (mp->d_muhstore_crust_mantle.ocl);
       clReleaseMemObject (mp->d_eta_anisostore_crust_mantle.ocl);
-      
+
     } else {
       clReleaseMemObject (mp->d_c11store_crust_mantle.ocl);
       clReleaseMemObject (mp->d_c12store_crust_mantle.ocl);
@@ -3847,7 +3847,7 @@ void FC_FUNC_ (prepare_cleanup_device,
 
     clReleaseMemObject (mp->d_ystore_crust_mantle.ocl);
     clReleaseMemObject (mp->d_zstore_crust_mantle.ocl);
-    
+
     if (mp->gravity) {
       clReleaseMemObject (mp->d_xstore_crust_mantle.ocl);
     }
@@ -3859,7 +3859,7 @@ void FC_FUNC_ (prepare_cleanup_device,
     clReleaseMemObject (mp->d_displ_crust_mantle.ocl);
     clReleaseMemObject (mp->d_veloc_crust_mantle.ocl);
     clReleaseMemObject (mp->d_accel_crust_mantle.ocl);
-    
+
     if (mp->simulation_type == 3) {
       clReleaseMemObject (mp->d_b_displ_crust_mantle.ocl);
       clReleaseMemObject (mp->d_b_veloc_crust_mantle.ocl);
@@ -3868,7 +3868,7 @@ void FC_FUNC_ (prepare_cleanup_device,
 
     // mass matrix
     clReleaseMemObject (mp->d_rmassz_crust_mantle.ocl);
-    
+
     if (*NCHUNKS_VAL != 6 && mp->absorbing_conditions){
       clReleaseMemObject (mp->d_rmassx_crust_mantle.ocl);
       clReleaseMemObject (mp->d_rmassy_crust_mantle.ocl);
@@ -3882,15 +3882,15 @@ void FC_FUNC_ (prepare_cleanup_device,
       }
       // kernels
       clReleaseMemObject (mp->d_rho_kl_crust_mantle.ocl);
-      
+
       if (!mp->anisotropic_kl){
         clReleaseMemObject (mp->d_alpha_kl_crust_mantle.ocl);
         clReleaseMemObject (mp->d_beta_kl_crust_mantle.ocl);
-        
+
       } else {
         clReleaseMemObject (mp->d_cijkl_kl_crust_mantle.ocl);
       }
-      
+
       if (mp->approximate_hess_kl) {
         clReleaseMemObject (mp->d_hess_kl_crust_mantle.ocl);
       }
@@ -3899,7 +3899,7 @@ void FC_FUNC_ (prepare_cleanup_device,
     //------------------------------------------
     // outer_core
     //------------------------------------------
-    
+
     clReleaseMemObject (mp->d_xix_outer_core.ocl);
     clReleaseMemObject (mp->d_xiy_outer_core.ocl);
     clReleaseMemObject (mp->d_xiz_outer_core.ocl);
@@ -3911,7 +3911,7 @@ void FC_FUNC_ (prepare_cleanup_device,
     clReleaseMemObject (mp->d_gammaz_outer_core.ocl);
 
     clReleaseMemObject (mp->d_kappavstore_outer_core.ocl);
-    
+
     if (mp->simulation_type == 3) {
       clReleaseMemObject (mp->d_rhostore_outer_core.ocl);
     }
@@ -3936,13 +3936,13 @@ void FC_FUNC_ (prepare_cleanup_device,
     clReleaseMemObject (mp->d_displ_outer_core.ocl);
     clReleaseMemObject (mp->d_veloc_outer_core.ocl);
     clReleaseMemObject (mp->d_accel_outer_core.ocl);
-    
+
     if (mp->simulation_type == 3) {
       clReleaseMemObject (mp->d_b_displ_outer_core.ocl);
       clReleaseMemObject (mp->d_b_veloc_outer_core.ocl);
       clReleaseMemObject (mp->d_b_accel_outer_core.ocl);
     }
-    
+
     // mass matrix
     clReleaseMemObject (mp->d_rmass_outer_core.ocl);
 
@@ -3965,10 +3965,10 @@ void FC_FUNC_ (prepare_cleanup_device,
     clReleaseMemObject (mp->d_gammaz_inner_core.ocl);
 
     clReleaseMemObject (mp->d_muvstore_inner_core.ocl);
-    
+
     if (! mp->anisotropic_inner_core) {
       clReleaseMemObject (mp->d_kappavstore_inner_core.ocl);
-      
+
     } else {
       clReleaseMemObject (mp->d_c11store_inner_core.ocl);
       clReleaseMemObject (mp->d_c12store_inner_core.ocl);
@@ -3998,7 +3998,7 @@ void FC_FUNC_ (prepare_cleanup_device,
     clReleaseMemObject (mp->d_displ_inner_core.ocl);
     clReleaseMemObject (mp->d_veloc_inner_core.ocl);
     clReleaseMemObject (mp->d_accel_inner_core.ocl);
-    
+
     if (mp->simulation_type == 3) {
       clReleaseMemObject (mp->d_b_displ_inner_core.ocl);
       clReleaseMemObject (mp->d_b_veloc_inner_core.ocl);
@@ -4007,7 +4007,7 @@ void FC_FUNC_ (prepare_cleanup_device,
 
     // mass matrix
     clReleaseMemObject (mp->d_rmassz_inner_core.ocl);
-    
+
     if (mp->rotation && mp->exact_mass_matrix_for_rotation) {
       clReleaseMemObject (mp->d_rmassx_inner_core.ocl);
       clReleaseMemObject (mp->d_rmassy_inner_core.ocl);
@@ -4031,7 +4031,7 @@ void FC_FUNC_ (prepare_cleanup_device,
       clReleaseMemObject (mp->d_rmass_ocean_load.ocl);
       clReleaseMemObject (mp->d_normal_ocean_load.ocl);
     }
-    
+
 #ifdef USE_TEXTURES_FIELDS
     clReleaseMemObject (mp->d_displ_cm_tex);
     clReleaseMemObject (mp->d_accel_cm_tex);
@@ -4251,7 +4251,7 @@ void FC_FUNC_ (prepare_cleanup_device,
           cudaFree(mp->d_absorb_zmin_outer_core.cuda);
         }
       }
-      
+
     }
 
     //------------------------------------------

--- a/src/gpu/update_displacement_gpu.c
+++ b/src/gpu/update_displacement_gpu.c
@@ -71,7 +71,7 @@ void FC_FUNC_ (update_displacement_ic_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     //launch kernel
     if (*FORWARD_OR_ADJOINT == 1) {
       clCheck (clSetKernelArg (mocl.kernels.update_disp_veloc_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_displ_inner_core.ocl));
@@ -187,7 +187,7 @@ void FC_FUNC_ (update_displacement_cm_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     //launch kernel
     if (*FORWARD_OR_ADJOINT == 1) {
 
@@ -297,7 +297,7 @@ void FC_FUNC_ (update_displacement_oc_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     //launch kernel
     if (*FORWARD_OR_ADJOINT == 1) {
       clCheck (clSetKernelArg (mocl.kernels.update_potential_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_displ_outer_core.ocl));
@@ -393,7 +393,7 @@ void FC_FUNC_ (multiply_accel_elastic_gpu,
   size_t global_work_size[2];
   size_t local_work_size[2];
   cl_uint idx = 0;
-    
+
   if (run_opencl) {
     local_work_size[0] = blocksize;
     local_work_size[1] = 1;
@@ -428,7 +428,7 @@ void FC_FUNC_ (multiply_accel_elastic_gpu,
 #endif
 #ifdef USE_CUDA
   dim3 grid,threads;
-  
+
   if (run_cuda) {
     grid = dim3(num_blocks_x,num_blocks_y);
     threads = dim3(blocksize,1,1);
@@ -467,7 +467,7 @@ void FC_FUNC_ (multiply_accel_elastic_gpu,
     global_work_size[0] = num_blocks_x * blocksize;
     global_work_size[1] = num_blocks_y;
     idx = 0;
-    
+
     if (*FORWARD_OR_ADJOINT == 1) {
       clCheck (clSetKernelArg (mocl.kernels.update_accel_elastic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_accel_inner_core.ocl));
       clCheck (clSetKernelArg (mocl.kernels.update_accel_elastic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_veloc_inner_core.ocl));
@@ -555,7 +555,7 @@ void FC_FUNC_ (update_veloc_elastic_gpu,
   size_t global_work_size[2];
   size_t local_work_size[2];
   cl_uint idx = 0;
-  
+
   if (run_opencl) {
     local_work_size[0] = blocksize;
     local_work_size[1] = 1;
@@ -581,7 +581,7 @@ void FC_FUNC_ (update_veloc_elastic_gpu,
 #endif
 #ifdef USE_CUDA
   dim3 grid,threads;
-  
+
   if (run_cuda) {
     grid = dim3(num_blocks_x,num_blocks_y);
     threads = dim3(blocksize,1,1);
@@ -611,7 +611,7 @@ void FC_FUNC_ (update_veloc_elastic_gpu,
     global_work_size[0] = num_blocks_x * blocksize;
     global_work_size[1] = num_blocks_y;
     idx = 0;
-    
+
     if (*FORWARD_OR_ADJOINT == 1) {
       clCheck (clSetKernelArg (mocl.kernels.update_veloc_elastic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_veloc_inner_core.ocl));
       clCheck (clSetKernelArg (mocl.kernels.update_veloc_elastic_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_accel_inner_core.ocl));
@@ -673,7 +673,7 @@ void FC_FUNC_ (multiply_accel_acoustic_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-  
+
     local_work_size[0] = blocksize;
     local_work_size[1] = 1;
     global_work_size[0] = num_blocks_x * blocksize;
@@ -748,7 +748,7 @@ void FC_FUNC_ (update_veloc_acoustic_gpu,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-  
+
     local_work_size[0] = blocksize;
     local_work_size[1] = 1;
     global_work_size[0] = num_blocks_x * blocksize;

--- a/src/gpu/write_seismograms_gpu.c
+++ b/src/gpu/write_seismograms_gpu.c
@@ -55,19 +55,19 @@ void write_seismograms_transfer_from_device (Mesh *mp,
   //prepare field transfer array on device
 
 #ifdef USE_OPENCL
-  if (run_opencl) {    
+  if (run_opencl) {
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
     cl_event kernel_evt;
     cl_event *copy_evt = NULL;
     cl_uint num_evt = 0;
-    
+
     if (GPU_ASYNC_COPY && mp->has_last_copy_evt) {
       copy_evt = &mp->last_copy_evt;
       num_evt = 1;
     }
-    
+
     clCheck (clSetKernelArg (mocl.kernels.write_seismograms_transfer_from_device_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_number_receiver_global.ocl));
     clCheck (clSetKernelArg (mocl.kernels.write_seismograms_transfer_from_device_kernel, idx++, sizeof (cl_mem), (void *) &d_ispec_selected->ocl));
     clCheck (clSetKernelArg (mocl.kernels.write_seismograms_transfer_from_device_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_ibool_crust_mantle.ocl));
@@ -87,7 +87,7 @@ void write_seismograms_transfer_from_device (Mesh *mp,
       if (mp->has_last_copy_evt) {
         clCheck (clReleaseEvent (mp->last_copy_evt));
       }
-      
+
       clCheck (clEnqueueReadBuffer (mocl.copy_queue, mp->d_station_seismo_field.ocl, CL_FALSE, 0,
                                     3 * NGLL3 * mp->nrec_local * sizeof (realw),
                                     mp->h_station_seismo_field, 1, &kernel_evt, &mp->last_copy_evt));
@@ -97,7 +97,7 @@ void write_seismograms_transfer_from_device (Mesh *mp,
                                     3 * NGLL3 * mp->nrec_local * sizeof (realw),
                                     mp->h_station_seismo_field, 0, NULL, NULL));
     }
-    
+
     clReleaseEvent (kernel_evt);
   }
 #endif
@@ -133,14 +133,14 @@ void write_seismograms_transfer_from_device (Mesh *mp,
     print_CUDA_error_if_any(cudaMemcpy(mp->h_station_seismo_field,mp->d_station_seismo_field.cuda,
                                        3*NGLL3*(mp->nrec_local)*sizeof(realw),cudaMemcpyDeviceToHost),77000);
 
-	}
+  }
   }
 #endif
   if (!GPU_ASYNC_COPY) {
     for (irec_local = 0; irec_local < mp->nrec_local; irec_local++) {
       irec = number_receiver_global[irec_local] - 1;
       ispec = h_ispec_selected[irec] - 1;
-      
+
       for (i = 0; i < NGLL3; i++) {
         iglob = ibool[i+NGLL3*ispec] - 1;
         h_field[0+3*iglob] = mp->h_station_seismo_field[0+3*i+irec_local*NGLL3*3];
@@ -183,7 +183,7 @@ void write_seismograms_transfer_strain_from_device (Mesh *mp,
     size_t global_work_size[2];
     size_t local_work_size[2];
     cl_uint idx = 0;
-    
+
     //prepare field transfer array on device
     clCheck (clSetKernelArg (mocl.kernels.write_seismograms_transfer_strain_from_device_kernel, idx++, sizeof (cl_mem), (void *) &mp->d_number_receiver_global.ocl));
     clCheck (clSetKernelArg (mocl.kernels.write_seismograms_transfer_strain_from_device_kernel, idx++, sizeof (cl_mem), (void *) &d_ispec_selected->ocl));

--- a/src/meshfem3D/compute_coordinates_grid.f90
+++ b/src/meshfem3D/compute_coordinates_grid.f90
@@ -332,7 +332,7 @@
   use constants
 
   use meshfem3D_par, only: myrank,x_observation,y_observation,z_observation,lon_observation,lat_observation, &
-                                     ELLIPTICITY,TOPOGRAPHY,OUTPUT_FILES 
+                                     ELLIPTICITY,TOPOGRAPHY,OUTPUT_FILES
 
   use meshfem3D_models_par, only: nspl,rspl,espl,espl2,ibathy_topo
 

--- a/src/meshfem3D/meshfem3D_models.f90
+++ b/src/meshfem3D/meshfem3D_models.f90
@@ -777,24 +777,14 @@
     case (ICRUST_CRUST2)
       ! default
       ! crust 2.0
-      call model_crust(lat,lon,r,vpc,vsc,rhoc,moho,found_crust,elem_in_crust)
+      call model_crust_2_0(lat,lon,r,vpc,vsc,rhoc,moho,found_crust,elem_in_crust)
 
     case (ICRUST_CRUSTMAPS)
       ! general crustmaps
       call model_crustmaps(lat,lon,r,vpc,vsc,rhoc,moho,found_crust,elem_in_crust)
 
     case (ICRUST_EPCRUST)
-!      call model_crust(lat,lon,r,vpc,vsc,rhoc,moho,found_crust,elem_in_crust)
-      ! within EPCRUST region
-!      if (lat >= EPCRUST_LAT_MIN .and. lat <= EPCRUST_LAT_MAX &
-!          .and. lon >= EPCRUST_LON_MIN .and. lon<=EPCRUST_LON_MAX ) then
-!          vpc=0.0d0
-!          vsc=0.0d0
-!          rhoc=0.0d0
-!          moho=0.0d0
-!          found_crust = .false.
-          call model_epcrust(lat,lon,r,vpc,vsc,rhoc,moho,found_crust,elem_in_crust)
-!      endif
+      call model_epcrust(lat,lon,r,vpc,vsc,rhoc,moho,found_crust,elem_in_crust)
 
     case default
       stop 'crustal model type not defined'

--- a/src/meshfem3D/model_crust_2_0.f90
+++ b/src/meshfem3D/model_crust_2_0.f90
@@ -50,14 +50,18 @@
 
   ! crustal_model_constants
   ! crustal model parameters for crust2.0
-  integer, parameter :: NKEYS_CRUST = 359
-  integer, parameter :: NLAYERS_CRUST = 8
-  integer, parameter :: NCAP_CRUST = 180
+  integer, parameter :: CRUST_NP = 8
+  integer, parameter :: CRUST_NLO = 359
+  integer, parameter :: CRUST_NLA = 180
 
   ! model_crust_variables
-  double precision, dimension(:,:),allocatable :: thlr,velocp,velocs,dens
-  character(len=2) :: abbreviation(NCAP_CRUST/2,NCAP_CRUST)
-  character(len=2) :: code(NKEYS_CRUST)
+  ! Vp, Vs and density
+  double precision, dimension(:,:), allocatable :: crust_vp,crust_vs,crust_rho
+  character(len=2) :: abbreviation(CRUST_NLA/2,CRUST_NLA)
+  character(len=2) :: code(CRUST_NLO)
+
+  ! layer thickness
+  double precision, dimension(:,:), allocatable :: crust_thickness
 
   end module model_crust_2_0_par
 
@@ -78,24 +82,30 @@
   integer :: ier
 
   ! allocate crustal arrays
-  allocate(thlr(NLAYERS_CRUST,NKEYS_CRUST), &
-           velocp(NLAYERS_CRUST,NKEYS_CRUST), &
-           velocs(NLAYERS_CRUST,NKEYS_CRUST), &
-           dens(NLAYERS_CRUST,NKEYS_CRUST), &
+  allocate(crust_thickness(CRUST_NP,CRUST_NLO), &
+           crust_vp(CRUST_NP,CRUST_NLO), &
+           crust_vs(CRUST_NP,CRUST_NLO), &
+           crust_rho(CRUST_NP,CRUST_NLO), &
            stat=ier)
   if( ier /= 0 ) call exit_MPI(myrank,'error allocating crustal arrays')
 
+  ! initializes
+  crust_vp(:,:) = ZERO
+  crust_vs(:,:) = ZERO
+  crust_rho(:,:) = ZERO
+  crust_thickness(:,:) = ZERO
+
   ! the variables read are declared and stored in structure model_crust_2_0_par
-  if(myrank == 0) call read_crust_model()
+  if(myrank == 0) call read_crust_2_0_model()
 
   ! broadcast the information read on the master to the nodes
-  call bcast_all_dp(thlr,NKEYS_CRUST*NLAYERS_CRUST)
-  call bcast_all_dp(velocp,NKEYS_CRUST*NLAYERS_CRUST)
-  call bcast_all_dp(velocs,NKEYS_CRUST*NLAYERS_CRUST)
-  call bcast_all_dp(dens,NKEYS_CRUST*NLAYERS_CRUST)
+  call bcast_all_dp(crust_thickness,CRUST_NLO*CRUST_NP)
+  call bcast_all_dp(crust_vp,CRUST_NLO*CRUST_NP)
+  call bcast_all_dp(crust_vs,CRUST_NLO*CRUST_NP)
+  call bcast_all_dp(crust_rho,CRUST_NLO*CRUST_NP)
 
-  call bcast_all_ch_array2(abbreviation,NCAP_CRUST/2,NCAP_CRUST,2)
-  call bcast_all_ch_array(code,NKEYS_CRUST,2)
+  call bcast_all_ch_array2(abbreviation,CRUST_NLA/2,CRUST_NLA,2)
+  call bcast_all_ch_array(code,CRUST_NLO,2)
 
   end subroutine model_crust_2_0_broadcast
 
@@ -103,7 +113,7 @@
 !-------------------------------------------------------------------------------------------------
 !
 
-  subroutine model_crust(lat,lon,x,vp,vs,rho,moho,found_crust,elem_in_crust)
+  subroutine model_crust_2_0(lat,lon,x,vp,vs,rho,moho,found_crust,elem_in_crust)
 
   use constants
   use model_crust_2_0_par
@@ -117,21 +127,25 @@
 
   ! local parameters
   double precision :: h_sed,h_uc
-  double precision :: x3,x4,x5,x6,x7,scaleval
-  double precision,dimension(NLAYERS_CRUST):: vps,vss,rhos,thicks
+  double precision :: x3,x4,x5,x6,x7
+  double precision :: scaleval
+  double precision,dimension(CRUST_NP):: vps,vss,rhos,thicks
 
   ! initializes
   vp = ZERO
   vs = ZERO
   rho = ZERO
+  moho = ZERO
 
-  ! gets smoothed crust2.0 structure
-  call crust_CAPsmoothed(lat,lon,vps,vss,rhos,thicks,abbreviation, &
-                        code,thlr,velocp,velocs,dens)
+  ! gets smoothed structure
+  call crust_2_0_CAPsmoothed(lat,lon,vps,vss,rhos,thicks,abbreviation, &
+                        code,crust_thickness,crust_vp,crust_vs,crust_rho)
 
+  ! non-dimensionalization factor
   scaleval = ONE / R_EARTH_KM
 
   ! non-dimensionalizes thickness (given in km)
+  ! upper sediment
   x3 = ONE - thicks(3) * scaleval
   h_sed = thicks(3) + thicks(4)
   x4 = ONE - h_sed * scaleval
@@ -142,24 +156,22 @@
 
   ! checks moho value
   !moho = h_uc + thicks(6) + thicks(7)
-  !if( moho /= thicks(NLAYERS_CRUST) ) then
-  ! print*,'moho:',moho,thicks(NLAYERS_CRUST)
+  !if( moho /= thicks(CRUST_NP) ) then
+  ! print*,'moho:',moho,thicks(CRUST_NP)
   ! print*,'  lat/lon/x:',lat,lon,x
   !endif
 
-  ! No matter found_crust true or false, output moho thickness
+  ! no matter found_crust true or false, output moho thickness
   moho = (h_uc+thicks(6)+thicks(7)) * scaleval
 
   ! gets corresponding crustal velocities and density
   found_crust = .true.
-!  if(x > x3 .and. INCLUDE_SEDIMENTS_CRUST &
-!   .and. h_sed >= MINIMUM_SEDIMENT_THICKNESS) then
+
+  ! gets corresponding crustal velocities and density
   if(x > x3 .and. INCLUDE_SEDIMENTS_CRUST ) then
     vp = vps(3)
     vs = vss(3)
     rho = rhos(3)
-!  else if(x > x4 .and. INCLUDE_SEDIMENTS_CRUST &
-!   .and. h_sed >= MINIMUM_SEDIMENT_THICKNESS) then
   else if(x > x4 .and. INCLUDE_SEDIMENTS_CRUST ) then
     vp = vps(4)
     vs = vss(4)
@@ -195,13 +207,13 @@
     rho = rho * 1000.0d0 / RHOAV
  endif
 
- end subroutine model_crust
+ end subroutine model_crust_2_0
 
 !
 !-------------------------------------------------------------------------------------------------
 !
 
-  subroutine read_crust_model()
+  subroutine read_crust_2_0_model()
 
   use constants
   use model_crust_2_0_par
@@ -226,11 +238,11 @@
     write(IMAIN,*) 'error opening "', trim(CNtype2), '": ', ier
     call flush_IMAIN()
     ! stop
-    call exit_MPI(0, 'error model crust2.0')
+    call exit_MPI(0,'error model crust2.0')
   endif
 
-  do ila=1,NCAP_CRUST/2
-    read(1,*) icolat,(abbreviation(ila,i),i=1,NCAP_CRUST)
+  do ila=1,CRUST_NLA/2
+    read(1,*) icolat,(abbreviation(ila,i),i=1,CRUST_NLA)
   enddo
   close(1)
 
@@ -238,44 +250,43 @@
   open(unit=1,file=CNtype2_key_modif,status='old',action='read',iostat=ier)
   if ( ier /= 0 ) then
     write(IMAIN,*) 'error opening "', trim(CNtype2_key_modif), '": ', ier
-    call exit_MPI(0, 'error model crust2.0')
+    call exit_MPI(0,'error model crust2.0')
   endif
 
   h_moho_min = HUGEVAL
   h_moho_max = -HUGEVAL
 
-  do ikey=1,NKEYS_CRUST
+  do ikey=1,CRUST_NLO
     read (1,"(a2)") code(ikey)
-    read (1,*) (velocp(i,ikey),i=1,NLAYERS_CRUST)
-    read (1,*) (velocs(i,ikey),i=1,NLAYERS_CRUST)
-    read (1,*) (dens(i,ikey),i=1,NLAYERS_CRUST)
-    read (1,*) (thlr(i,ikey),i=1,NLAYERS_CRUST-1),thlr(NLAYERS_CRUST,ikey)
+    read (1,*) (crust_vp(i,ikey),i=1,CRUST_NP)
+    read (1,*) (crust_vs(i,ikey),i=1,CRUST_NP)
+    read (1,*) (crust_rho(i,ikey),i=1,CRUST_NP)
+    read (1,*) (crust_thickness(i,ikey),i=1,CRUST_NP-1),crust_thickness(CRUST_NP,ikey)
 
     ! limit moho thickness
-    if(thlr(NLAYERS_CRUST,ikey) > h_moho_max) h_moho_max = thlr(NLAYERS_CRUST,ikey)
-    if(thlr(NLAYERS_CRUST,ikey) < h_moho_min) h_moho_min = thlr(NLAYERS_CRUST,ikey)
+    if(crust_thickness(CRUST_NP,ikey) > h_moho_max) h_moho_max = crust_thickness(CRUST_NP,ikey)
+    if(crust_thickness(CRUST_NP,ikey) < h_moho_min) h_moho_min = crust_thickness(CRUST_NP,ikey)
   enddo
   close(1)
 
-  if(h_moho_min == HUGEVAL .or. h_moho_max == -HUGEVAL) &
-    stop 'incorrect moho depths in read_crust_model'
+  if(h_moho_min == HUGEVAL .or. h_moho_max == -HUGEVAL) stop 'incorrect moho depths in read_crust_2_0_model'
 
-  end subroutine read_crust_model
+  end subroutine read_crust_2_0_model
 
 !
 !-------------------------------------------------------------------------------------------------
 !
 
-  subroutine crust_CAPsmoothed(lat,lon,velp,vels,rho,thick,abbreviation,code,thlr,velocp,velocs,dens)
+  subroutine crust_2_0_CAPsmoothed(lat,lon,velp,vels,rho,thick,abbreviation,code,crust_thickness,crust_vp,crust_vs,crust_rho)
 
 ! crustal vp and vs in km/s, layer thickness in km
 !
-! crust2.0 is smoothed with a cap of size CAP using NTHETA points
+! crust2.0 gets smoothed with a cap of size CAP using NTHETA points
 ! in the theta direction and NPHI in the phi direction.
 ! The cap is first rotated to the North Pole for easier implementation.
 
   use constants
-  use model_crust_2_0_par,only: NLAYERS_CRUST,NKEYS_CRUST,NCAP_CRUST
+  use model_crust_2_0_par,only: CRUST_NP,CRUST_NLO,CRUST_NLA
 
   implicit none
 
@@ -285,11 +296,11 @@
 
   ! argument variables
   double precision :: lat,lon
-  double precision,dimension(NLAYERS_CRUST) :: rho,thick,velp,vels
-  double precision,dimension(NLAYERS_CRUST,NKEYS_CRUST) :: thlr,velocp,velocs,dens
+  double precision,dimension(CRUST_NP) :: rho,thick,velp,vels
+  double precision,dimension(CRUST_NP,CRUST_NLO) :: crust_thickness,crust_vp,crust_vs,crust_rho
 
-  character(len=2) :: code(NKEYS_CRUST)
-  character(len=2) :: abbreviation(NCAP_CRUST/2,NCAP_CRUST)
+  character(len=2) :: code(CRUST_NLO)
+  character(len=2) :: abbreviation(CRUST_NLA/2,CRUST_NLA)
 
   !-------------------------------
   ! work-around to avoid Jacobian problems when stretching mesh elements;
@@ -304,9 +315,10 @@
 
   ! local variables
   double precision :: xlon(NTHETA*NPHI),xlat(NTHETA*NPHI),weight(NTHETA*NPHI)
-  double precision :: rhol(NLAYERS_CRUST),thickl(NLAYERS_CRUST),velpl(NLAYERS_CRUST),velsl(NLAYERS_CRUST)
+  double precision :: rhol(CRUST_NP),thickl(CRUST_NP),velpl(CRUST_NP),velsl(CRUST_NP)
 
-  double precision :: weightl,cap_degree,dist
+  double precision :: weightl,cap_degree
+  double precision :: dist
   double precision :: h_sed
   integer :: i,icolat,ilon
   character(len=2) :: crustaltype
@@ -317,15 +329,17 @@
 
   ! fill in the hash table
   crustalhash_to_key = -1
-  do i=1,NKEYS_CRUST
+  do i=1,CRUST_NLO
     call hash_crustal_type(code(i), ihash)
-    if (crustalhash_to_key(ihash) /= -1) stop 'error in crust_CAPsmoothed: hash table collision'
+    if (crustalhash_to_key(ihash) /= -1) stop 'error in crust_2_0_CAPsmoothed: hash table collision'
     crustalhash_to_key(ihash) = i
   enddo
 
   ! checks latitude/longitude
-  if(lat > 90.0d0 .or. lat < -90.0d0 .or. lon > 180.0d0 .or. lon < -180.0d0) &
-    stop 'error in latitude/longitude range in crust'
+  if(lat > 90.0d0 .or. lat < -90.0d0 .or. lon > 180.0d0 .or. lon < -180.0d0) then
+    print*,'error in lat/lon:',lat,lon
+    stop 'error in latitude/longitude range in crust2.0'
+  endif
 
   ! makes sure lat/lon are within crust2.0 range
   if(lat==90.0d0) lat=89.9999d0
@@ -361,7 +375,7 @@
 
   ! loops over weight points
   do i=1,NTHETA*NPHI
-    ! gets crust values
+    ! gets lat/lon indices
     call icolat_ilon(xlat(i),xlon(i),icolat,ilon)
 
     crustaltype = abbreviation(icolat,ilon)
@@ -370,8 +384,9 @@
     crustalkey = crustalhash_to_key(ihash)
     if(crustalkey == -1) stop 'error in retrieving crust type key'
 
-    call get_crust_structure(crustalkey,velpl,velsl,rhol,thickl, &
-                            thlr,velocp,velocs,dens)
+    ! gets crust values
+    call get_crust_2_0_structure(crustalkey,velpl,velsl,rhol,thickl, &
+                            crust_thickness,crust_vp,crust_vs,crust_rho)
 
     ! sediment thickness
     h_sed = thickl(3) + thickl(4)
@@ -396,214 +411,39 @@
     vels(:) = vels(:) + weightl*velsl(:)
   enddo
 
-  end subroutine crust_CAPsmoothed
+  end subroutine crust_2_0_CAPsmoothed
 
 !
 !-------------------------------------------------------------------------------------------------
 !
 
-! hash table to define the crustal type using an integer instead of characters
-! because working with integers in the rest of the routines results in much faster code
-  subroutine hash_crustal_type(crustaltype, ihash)
+  subroutine get_crust_2_0_structure(ikey,vptyp,vstyp,rhtyp,thtp,crust_thickness,crust_vp,crust_vs,crust_rho)
 
-    implicit none
-
-    character(len=2), intent(in) :: crustaltype
-    integer, intent(out) :: ihash
-
-    ihash = iachar(crustaltype(1:1)) + 128*iachar(crustaltype(2:2)) + 1
-
-  end subroutine hash_crustal_type
-
-!
-!-------------------------------------------------------------------------------------------------
-!
-
-  subroutine icolat_ilon(xlat,xlon,icolat,ilon)
-
-  implicit none
-
-! argument variables
-  double precision :: xlat,xlon
-  integer :: icolat,ilon
-
-  if(xlat > 90.0d0 .or. xlat < -90.0d0 .or. xlon > 180.0d0 .or. xlon < -180.0d0) &
-    stop 'error in latitude/longitude range in icolat_ilon'
-
-  icolat = int(1+( (90.d0-xlat)*0.5d0 ))
-  if(icolat == 91) icolat = 90
-
-  ilon = int(1+( (180.d0+xlon)*0.5d0 ))
-  if(ilon == 181) ilon = 1
-
-  if(icolat>90 .or. icolat<1) stop 'error in routine icolat_ilon'
-  if(ilon<1 .or. ilon>180) stop 'error in routine icolat_ilon'
-
-  end subroutine icolat_ilon
-
-!
-!-------------------------------------------------------------------------------------------------
-!
-
-  subroutine get_crust_structure(ikey,vptyp,vstyp,rhtyp,thtp,thlr,velocp,velocs,dens)
-
-  use model_crust_2_0_par,only: NLAYERS_CRUST,NKEYS_CRUST
+  use model_crust_2_0_par,only: CRUST_NP,CRUST_NLO
 
   implicit none
 
   ! argument variables
-  double precision :: rhtyp(NLAYERS_CRUST),thtp(NLAYERS_CRUST)
-  double precision :: vptyp(NLAYERS_CRUST),vstyp(NLAYERS_CRUST)
-  double precision :: thlr(NLAYERS_CRUST,NKEYS_CRUST),velocp(NLAYERS_CRUST,NKEYS_CRUST)
-  double precision :: velocs(NLAYERS_CRUST,NKEYS_CRUST),dens(NLAYERS_CRUST,NKEYS_CRUST)
-  integer :: ikey
+  integer, intent(in) :: ikey
+  double precision, intent(out) :: rhtyp(CRUST_NP),thtp(CRUST_NP)
+  double precision, intent(out) :: vptyp(CRUST_NP),vstyp(CRUST_NP)
+  double precision :: crust_thickness(CRUST_NP,CRUST_NLO),crust_vp(CRUST_NP,CRUST_NLO)
+  double precision :: crust_vs(CRUST_NP,CRUST_NLO),crust_rho(CRUST_NP,CRUST_NLO)
 
   ! local variables
   integer :: i
 
-  do i=1,NLAYERS_CRUST
-    vptyp(i)=velocp(i,ikey)
-    vstyp(i)=velocs(i,ikey)
-    rhtyp(i)=dens(i,ikey)
-  enddo
-
-  do i=1,NLAYERS_CRUST-1
-    thtp(i)=thlr(i,ikey)
+  ! set vp,vs and rho for all layers
+  do i=1,CRUST_NP
+    vptyp(i)=crust_vp(i,ikey)
+    vstyp(i)=crust_vs(i,ikey)
+    rhtyp(i)=crust_rho(i,ikey)
+    thtp(i)=crust_thickness(i,ikey)
   enddo
 
   ! get distance to Moho from the bottom of the ocean or the ice
-  thtp(NLAYERS_CRUST) = thlr(NLAYERS_CRUST,ikey) - thtp(1) - thtp(2)
+  ! value could be used for checking, but is unused so far...
+  thtp(CRUST_NP) = thtp(CRUST_NP) - thtp(1) - thtp(2)
 
-  end subroutine get_crust_structure
-
-
-!
-!-------------------------------------------------------------------------------------------------
-!
-
-  subroutine CAP_vardegree(lon,lat,xlon,xlat,weight,CAP_DEGREE,NTHETA,NPHI)
-
-! calculates weighting points to smooth around lon/lat location with
-! a smoothing range of CAP_DEGREE
-!
-! The cap is rotated to the North Pole.
-!
-! returns: xlon,xlat,weight
-
-  use constants
-
-  implicit none
-
-  ! sampling rate
-  integer :: NTHETA
-  integer :: NPHI
-
-  ! smoothing size (in degrees)
-  double precision :: CAP_DEGREE
-
-  ! argument variables
-  double precision :: lat,lon
-  double precision,dimension(NTHETA*NPHI) :: xlon,xlat,weight
-
-  ! local variables
-  double precision :: CAP
-  double precision :: theta,phi,sint,cost,sinp,cosp,wght,total
-  double precision :: r_rot,theta_rot,phi_rot
-  double precision :: rotation_matrix(3,3),x(3),xc(3)
-  double precision :: dtheta,dphi,cap_area,dweight,pi_over_nphi
-  integer :: i,j,k,itheta,iphi
-
-  ! initializes
-  xlon(:) = ZERO
-  xlat(:) = ZERO
-  weight(:) = ZERO
-
-  ! checks cap degree size
-  if( CAP_DEGREE < TINYVAL ) then
-    ! no cap smoothing
-    print*,'error cap:',CAP_DEGREE
-    print*,'  lat/lon:',lat,lon
-    stop 'error cap_degree too small'
-  endif
-
-  ! pre-compute parameters
-  CAP = CAP_DEGREE * DEGREES_TO_RADIANS
-  dtheta = 0.5d0 * CAP / dble(NTHETA)
-  dphi = TWO_PI / dble(NPHI)
-
-  cap_area = TWO_PI * ( ONE - dcos(CAP) )
-  dweight = CAP / dble(NTHETA) * dphi / cap_area
-  pi_over_nphi = PI/dble(NPHI)
-
-  ! colatitude/longitude in radian
-  theta = (90.0d0 - lat ) * DEGREES_TO_RADIANS
-  phi = lon * DEGREES_TO_RADIANS
-
-  sint = dsin(theta)
-  cost = dcos(theta)
-  sinp = dsin(phi)
-  cosp = dcos(phi)
-
-  ! set up rotation matrix to go from cap at North pole to cap around point of interest
-  rotation_matrix(1,1) = cosp*cost
-  rotation_matrix(1,2) = -sinp
-  rotation_matrix(1,3) = cosp*sint
-  rotation_matrix(2,1) = sinp*cost
-  rotation_matrix(2,2) = cosp
-  rotation_matrix(2,3) = sinp*sint
-  rotation_matrix(3,1) = -sint
-  rotation_matrix(3,2) = ZERO
-  rotation_matrix(3,3) = cost
-
-  ! calculates points over a cap at the North pole and rotates them to specified lat/lon point
-  i = 0
-  total = ZERO
-  do itheta = 1,NTHETA
-
-    theta = dble(2*itheta-1)*dtheta
-    cost = dcos(theta)
-    sint = dsin(theta)
-    wght = sint*dweight
-
-    do iphi = 1,NPHI
-
-      i = i+1
-
-      ! get the weight associated with this integration point (same for all phi)
-      weight(i) = wght
-
-      total = total + weight(i)
-      phi = dble(2*iphi-1)*pi_over_nphi
-      cosp = dcos(phi)
-      sinp = dsin(phi)
-
-      ! x,y,z coordinates of integration point in cap at North pole
-      xc(1) = sint*cosp
-      xc(2) = sint*sinp
-      xc(3) = cost
-
-      ! get x,y,z coordinates in cap around point of interest
-      do j=1,3
-        x(j) = ZERO
-        do k=1,3
-          x(j) = x(j)+rotation_matrix(j,k)*xc(k)
-        enddo
-      enddo
-
-      ! get latitude and longitude (degrees) of integration point
-      call xyz_2_rthetaphi_dble(x(1),x(2),x(3),r_rot,theta_rot,phi_rot)
-      call reduce(theta_rot,phi_rot)
-      xlat(i) = (PI_OVER_TWO - theta_rot) * RADIANS_TO_DEGREES
-      xlon(i) = phi_rot * RADIANS_TO_DEGREES
-      if(xlon(i) > 180.0d0) xlon(i) = xlon(i) - 360.0d0
-
-    enddo
-
-  enddo
-  if(abs(total - ONE) > 0.001d0) then
-    print*,'error cap:',total,CAP_DEGREE
-    stop 'error in cap integration for variable degree'
-  endif
-
-  end subroutine CAP_vardegree
+  end subroutine get_crust_2_0_structure
 

--- a/src/meshfem3D/model_crustmaps.f90
+++ b/src/meshfem3D/model_crustmaps.f90
@@ -552,3 +552,176 @@
 
   end subroutine ibilinearmap
 
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+! hash table to define the crustal type using an integer instead of characters
+! because working with integers in the rest of the routines results in much faster code
+  subroutine hash_crustal_type(crustaltype, ihash)
+
+    implicit none
+
+    character(len=2), intent(in) :: crustaltype
+    integer, intent(out) :: ihash
+
+    ihash = iachar(crustaltype(1:1)) + 128*iachar(crustaltype(2:2)) + 1
+
+  end subroutine hash_crustal_type
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine icolat_ilon(xlat,xlon,icolat,ilon)
+
+  implicit none
+
+! argument variables
+  double precision :: xlat,xlon
+  integer :: icolat,ilon
+
+  if(xlat > 90.0d0 .or. xlat < -90.0d0 .or. xlon > 180.0d0 .or. xlon < -180.0d0) &
+    stop 'error in latitude/longitude range in icolat_ilon'
+
+  icolat = int(1+( (90.d0-xlat)*0.5d0 ))
+  if(icolat == 91) icolat = 90
+
+  ilon = int(1+( (180.d0+xlon)*0.5d0 ))
+  if(ilon == 181) ilon = 1
+
+  if(icolat>90 .or. icolat<1) stop 'error in routine icolat_ilon'
+  if(ilon<1 .or. ilon>180) stop 'error in routine icolat_ilon'
+
+  end subroutine icolat_ilon
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine CAP_vardegree(lon,lat,xlon,xlat,weight,CAP_DEGREE,NTHETA,NPHI)
+
+! calculates weighting points to smooth around lon/lat location with
+! a smoothing range of CAP_DEGREE
+!
+! The cap is rotated to the North Pole.
+!
+! returns: xlon,xlat,weight
+
+  use constants
+
+  implicit none
+
+  ! sampling rate
+  integer :: NTHETA
+  integer :: NPHI
+
+  ! smoothing size (in degrees)
+  double precision :: CAP_DEGREE
+
+  ! argument variables
+  double precision :: lat,lon
+  double precision,dimension(NTHETA*NPHI) :: xlon,xlat,weight
+
+  ! local variables
+  double precision :: CAP
+  double precision :: theta,phi,sint,cost,sinp,cosp,wght,total
+  double precision :: r_rot,theta_rot,phi_rot
+  double precision :: rotation_matrix(3,3),x(3),xc(3)
+  double precision :: dtheta,dphi,cap_area,dweight,pi_over_nphi
+  integer :: i,j,k,itheta,iphi
+
+  ! initializes
+  xlon(:) = ZERO
+  xlat(:) = ZERO
+  weight(:) = ZERO
+
+  ! checks cap degree size
+  if( CAP_DEGREE < TINYVAL ) then
+    ! no cap smoothing
+    print*,'error cap:',CAP_DEGREE
+    print*,'  lat/lon:',lat,lon
+    stop 'error cap_degree too small'
+  endif
+
+  ! pre-compute parameters
+  CAP = CAP_DEGREE * DEGREES_TO_RADIANS
+  dtheta = 0.5d0 * CAP / dble(NTHETA)
+  dphi = TWO_PI / dble(NPHI)
+
+  cap_area = TWO_PI * ( ONE - dcos(CAP) )
+  dweight = CAP / dble(NTHETA) * dphi / cap_area
+  pi_over_nphi = PI/dble(NPHI)
+
+  ! colatitude/longitude in radian
+  theta = (90.0d0 - lat ) * DEGREES_TO_RADIANS
+  phi = lon * DEGREES_TO_RADIANS
+
+  sint = dsin(theta)
+  cost = dcos(theta)
+  sinp = dsin(phi)
+  cosp = dcos(phi)
+
+  ! set up rotation matrix to go from cap at North pole to cap around point of interest
+  rotation_matrix(1,1) = cosp*cost
+  rotation_matrix(1,2) = -sinp
+  rotation_matrix(1,3) = cosp*sint
+  rotation_matrix(2,1) = sinp*cost
+  rotation_matrix(2,2) = cosp
+  rotation_matrix(2,3) = sinp*sint
+  rotation_matrix(3,1) = -sint
+  rotation_matrix(3,2) = ZERO
+  rotation_matrix(3,3) = cost
+
+  ! calculates points over a cap at the North pole and rotates them to specified lat/lon point
+  i = 0
+  total = ZERO
+  do itheta = 1,NTHETA
+
+    theta = dble(2*itheta-1)*dtheta
+    cost = dcos(theta)
+    sint = dsin(theta)
+    wght = sint*dweight
+
+    do iphi = 1,NPHI
+
+      i = i+1
+
+      ! get the weight associated with this integration point (same for all phi)
+      weight(i) = wght
+
+      total = total + weight(i)
+      phi = dble(2*iphi-1)*pi_over_nphi
+      cosp = dcos(phi)
+      sinp = dsin(phi)
+
+      ! x,y,z coordinates of integration point in cap at North pole
+      xc(1) = sint*cosp
+      xc(2) = sint*sinp
+      xc(3) = cost
+
+      ! get x,y,z coordinates in cap around point of interest
+      do j=1,3
+        x(j) = ZERO
+        do k=1,3
+          x(j) = x(j)+rotation_matrix(j,k)*xc(k)
+        enddo
+      enddo
+
+      ! get latitude and longitude (degrees) of integration point
+      call xyz_2_rthetaphi_dble(x(1),x(2),x(3),r_rot,theta_rot,phi_rot)
+      call reduce(theta_rot,phi_rot)
+      xlat(i) = (PI_OVER_TWO - theta_rot) * RADIANS_TO_DEGREES
+      xlon(i) = phi_rot * RADIANS_TO_DEGREES
+      if(xlon(i) > 180.0d0) xlon(i) = xlon(i) - 360.0d0
+
+    enddo
+
+  enddo
+  if(abs(total - ONE) > 0.001d0) then
+    print*,'error cap:',total,CAP_DEGREE
+    stop 'error in cap integration for variable degree'
+  endif
+
+  end subroutine CAP_vardegree
+

--- a/src/specfem3D/specfem3D_gpu_method_stubs.c
+++ b/src/specfem3D/specfem3D_gpu_method_stubs.c
@@ -65,13 +65,13 @@ void FC_FUNC_(transfer_asmbl_accel_to_device,
               TRANSFER_ASMBL_ACCEL_TO_DEVICE)(long* Mesh_pointer,
                                               realw* buffer_recv_vector,
                                               int* IREGION,
-                                              int* FORWARD_OR_ADJOINT) {} 
+                                              int* FORWARD_OR_ADJOINT) {}
 
 void FC_FUNC_(transfer_buffer_to_device_async,
               TRANSFER_BUFFER_TO_DEVICE_ASYNC)(long* Mesh_pointer,
                                              realw* buffer,
                                              int* IREGION,
-                                             int* FORWARD_OR_ADJOINT) {} 
+                                             int* FORWARD_OR_ADJOINT) {}
 
 void FC_FUNC_(sync_copy_from_device,
               SYNC_copy_FROM_DEVICE)(long* Mesh_pointer,
@@ -156,19 +156,19 @@ void FC_FUNC_(compute_add_sources_backward_gpu,
 
 void FC_FUNC_(compute_add_sources_adjoint_gpu,
               COMPUTE_ADD_SOURCES_ADJOINT_GPU)(long* Mesh_pointer,
-                                                int* h_nrec) {} 
+                                                int* h_nrec) {}
 
 void FC_FUNC_(transfer_adj_to_device,
               TRANSFER_ADJ_TO_DEVICE)(long* Mesh_pointer,
                                       int* h_nrec,
                                                 realw* h_adj_sourcearrays,
-                                      int* h_islice_selected_rec) {} 
+                                      int* h_islice_selected_rec) {}
 
 void FC_FUNC_(transfer_adj_to_device_async,
               TRANSFER_ADJ_TO_DEVICE_ASYNC)(long* Mesh_pointer,
                                             int* h_nrec,
                                             realw* h_adj_sourcearrays,
-                                            int* h_islice_selected_rec) {} 
+                                            int* h_islice_selected_rec) {}
 
 
 //
@@ -718,7 +718,7 @@ void FC_FUNC_(transfer_rmemory_cm_from_device,
                                                realw* R_yy,
                                                realw* R_xy,
                                                realw* R_xz,
-                                               realw* R_yz) {} 
+                                               realw* R_yz) {}
 void FC_FUNC_(transfer_b_rmemory_cm_to_device,
               TRANSFER_B_RMEMORY_CM_TO_DEVICE)(long* Mesh_pointer,
                                                realw* b_R_xx,
@@ -732,7 +732,7 @@ void FC_FUNC_(transfer_rmemory_ic_from_device,
                                                realw* R_yy,
                                                realw* R_xy,
                                                realw* R_xz,
-                                               realw* R_yz) {} 
+                                               realw* R_yz) {}
 
 void FC_FUNC_(transfer_b_rmemory_ic_to_device,
               TRANSFER_B_RMEMORY_IC_TO_DEVICE)(long* Mesh_pointer,
@@ -845,7 +845,7 @@ void FC_FUNC_(write_seismograms_transfer_gpu,
                                                int* number_receiver_global,
                                                int* ispec_selected_rec,
                                                int* ispec_selected_source,
-                                               int* ibool) {} 
+                                               int* ibool) {}
 
 void FC_FUNC_(transfer_seismo_from_device_async,
               TRANSFER_SEISMO_FROM_DEVICE_ASYNC)(long* Mesh_pointer_f,


### PR DESCRIPTION
..._0.f90;

also cleaned useless white spaces in all source files using a script
