### PR TITLE
for Ebru, bug fix to use a GLL model based on a s362ani reference model

### DIFF
--- a/setup/constants.h.in
+++ b/setup/constants.h.in
@@ -748,12 +748,14 @@
 ! to create a reference model based on 1D_REF but with 3D crust and 410/660 topography
   logical,parameter :: USE_1D_REFERENCE = .false.
 
+!!-- uncomment for using S362ANI as reference model
   integer, parameter :: GLL_REFERENCE_1D_MODEL = REFERENCE_MODEL_1DREF
-  integer, parameter :: GLL_REFERENCE_MODEL = THREE_D_MODEL_S29EA
+  integer, parameter :: GLL_REFERENCE_MODEL = THREE_D_MODEL_S362ANI
 
-!!-- uncomment for using S362ANI as reference model  (Hejun Zhu)
+!!-- uncomment for using S29EA as reference model
 !  integer, parameter :: GLL_REFERENCE_1D_MODEL = REFERENCE_MODEL_1DREF
-!  integer, parameter :: GLL_REFERENCE_MODEL = THREE_D_MODEL_S362ANI
+!  integer, parameter :: GLL_REFERENCE_MODEL = THREE_D_MODEL_S29EA
+
 
 !!-----------------------------------------------------------
 !!

--- a/src/gpu/assemble_MPI_vector_gpu.c
+++ b/src/gpu/assemble_MPI_vector_gpu.c
@@ -30,10 +30,10 @@
 #include <string.h>
 
 #include "mesh_constants_gpu.h"
+
 /* ----------------------------------------------------------------------------------------------- */
 // MPI transfer
 /* ----------------------------------------------------------------------------------------------- */
-
 
 // prepares and transfers the inter-element edge-nodes to the host to be MPI'd
 // (elements on boundary)
@@ -337,7 +337,10 @@ void FC_FUNC_(transfer_boun_from_device,
 #endif
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 // FORWARD_OR_ADJOINT == 1 for accel, and == 3 for b_accel
+
 extern EXTERN_LANG
 void FC_FUNC_ (transfer_asmbl_accel_to_device,
                TRANSFER_ASMBL_ACCEL_TO_DEVICE) (long *Mesh_pointer,
@@ -467,7 +470,7 @@ void FC_FUNC_ (transfer_asmbl_accel_to_device,
             // (cudaMemcpy implicitly synchronizes all other cuda operations)
             // copies vector buffer values to GPU
             print_CUDA_error_if_any(cudaMemcpy(mp->d_b_send_accel_buffer_crust_mantle.cuda, buffer_recv_vector,
-                                               NDIM*(mp->max_nibool_interfaces_cm)*(mp->num_interfaces_crust_mantle)*sizeof(realw),
+                                               size_mpi_buffer*sizeof(realw),
                                                cudaMemcpyHostToDevice),41000);
           }
 

--- a/src/gpu/boast/references/compute_acoustic_kernel.cu
+++ b/src/gpu/boast/references/compute_acoustic_kernel.cu
@@ -78,6 +78,8 @@ __device__ void compute_gradient_kernel(int ijk,
 
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 __global__ void compute_acoustic_kernel(int* ibool,
                                         realw* rhostore,
                                         realw* kappastore,

--- a/src/gpu/boast/references/compute_ani_kernel.cu
+++ b/src/gpu/boast/references/compute_ani_kernel.cu
@@ -50,6 +50,8 @@ __device__ void compute_strain_product(realw* prod,
   }
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 __global__ void compute_ani_kernel(realw* epsilondev_xx,
                                    realw* epsilondev_yy,
                                    realw* epsilondev_xy,

--- a/src/gpu/boast/references/compute_ani_undo_att_kernel.cu
+++ b/src/gpu/boast/references/compute_ani_undo_att_kernel.cu
@@ -104,6 +104,8 @@ __device__ void compute_element_strain_undo_att(int ispec,int ijk_ispec,
   *epsilon_trace_over_3 = templ;
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 __device__ void compute_strain_product_cuda(realw* prod,
                                             realw eps_trace_over_3,
                                             realw* epsdev,
@@ -150,6 +152,8 @@ __device__ void compute_strain_product_cuda(realw* prod,
     }
   }
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 __global__ void compute_ani_undo_att_kernel(realw* epsilondev_xx,
                                             realw* epsilondev_yy,

--- a/src/gpu/boast/references/compute_iso_undo_att_kernel.cu
+++ b/src/gpu/boast/references/compute_iso_undo_att_kernel.cu
@@ -104,6 +104,8 @@ __device__ void compute_element_strain_undo_att(int ispec,int ijk_ispec,
   *epsilon_trace_over_3 = templ;
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 __global__ void compute_iso_undo_att_kernel(realw* epsilondev_xx,
                                             realw* epsilondev_yy,
                                             realw* epsilondev_xy,

--- a/src/gpu/boast/references/inner_core_impl_kernel.cu
+++ b/src/gpu/boast/references/inner_core_impl_kernel.cu
@@ -1,6 +1,286 @@
-// from compute_forces_inner_core_cuda.cu
+#ifdef USE_TEXTURES_FIELDS
+//forward
+realw_texture d_displ_ic_tex;
+realw_texture d_accel_ic_tex;
+//backward/reconstructed
+realw_texture d_b_displ_ic_tex;
+realw_texture d_b_accel_ic_tex;
+// templates definitions
+template<int FORWARD_OR_ADJOINT> __device__ float texfetch_displ_ic(int x);
+template<int FORWARD_OR_ADJOINT> __device__ float texfetch_accel_ic(int x);
+// templates for texture fetching
+// FORWARD_OR_ADJOINT == 1 <- forward arrays
+template<> __device__ float texfetch_displ_ic<1>(int x) { return tex1Dfetch(d_displ_ic_tex, x); }
+template<> __device__ float texfetch_accel_ic<1>(int x) { return tex1Dfetch(d_accel_ic_tex, x); }
+// FORWARD_OR_ADJOINT == 3 <- backward/reconstructed arrays
+template<> __device__ float texfetch_displ_ic<3>(int x) { return tex1Dfetch(d_b_displ_ic_tex, x); }
+template<> __device__ float texfetch_accel_ic<3>(int x) { return tex1Dfetch(d_b_accel_ic_tex, x); }
+#endif
+
+
+/* ----------------------------------------------------------------------------------------------- */
+
+// elemental routines
+
+/* ----------------------------------------------------------------------------------------------- */
+
+// updates stress
+
+__device__ void compute_element_ic_att_stress(int tx,int working_element,
+                                             realw_p R_xx,
+                                             realw_p R_yy,
+                                             realw_p R_xy,
+                                             realw_p R_xz,
+                                             realw_p R_yz,
+                                             realw* sigma_xx,
+                                             realw* sigma_yy,
+                                             realw* sigma_zz,
+                                             realw* sigma_xy,
+                                             realw* sigma_xz,
+                                             realw* sigma_yz) {
+
+  realw R_xx_val,R_yy_val;
+  int offset_sls;
+
+  for(int i_sls = 0; i_sls < N_SLS; i_sls++){
+    // index
+    // note: index for R_xx,.. here is (i_sls,i,j,k,ispec) and not (i,j,k,ispec,i_sls) as in local version
+    //          local version: offset_sls = tx + NGLL3*(working_element + NSPEC*i_sls);
+    // indexing examples:
+    //   (i,j,k,ispec,i_sls) -> offset_sls = tx + NGLL3*(working_element + NSPEC*i_sls)
+    //   (i_sls,i,j,k,ispec) -> offset_sls = i_sls + N_SLS*(tx + NGLL3*working_element)
+    //   (i,j,k,i_sls,ispec) -> offset_sls = tx + NGLL3*(i_sls + N_SLS*working_element)
+    offset_sls = tx + NGLL3*(i_sls + N_SLS*working_element);
+
+    R_xx_val = R_xx[offset_sls];
+    R_yy_val = R_yy[offset_sls];
+
+    *sigma_xx = *sigma_xx - R_xx_val;
+    *sigma_yy = *sigma_yy - R_yy_val;
+    *sigma_zz = *sigma_zz + R_xx_val + R_yy_val;
+    *sigma_xy = *sigma_xy - R_xy[offset_sls];
+    *sigma_xz = *sigma_xz - R_xz[offset_sls];
+    *sigma_yz = *sigma_yz - R_yz[offset_sls];
+  }
+}
+
+/* ----------------------------------------------------------------------------------------------- */
+
+// updates R_memory
+
+__device__ void compute_element_ic_att_memory(int tx,int working_element,
+                                              realw_const_p d_muv,
+                                              realw_const_p factor_common,
+                                              realw_const_p alphaval,realw_const_p betaval,realw_const_p gammaval,
+                                              realw_p R_xx,realw_p R_yy,realw_p R_xy,realw_p R_xz,realw_p R_yz,
+                                              realw_p epsilondev_xx,realw_p epsilondev_yy,realw_p epsilondev_xy,
+                                              realw_p epsilondev_xz,realw_p epsilondev_yz,
+                                              realw epsilondev_xx_loc,realw epsilondev_yy_loc,realw epsilondev_xy_loc,
+                                              realw epsilondev_xz_loc,realw epsilondev_yz_loc,
+                                              int USE_3D_ATTENUATION_ARRAYS
+                                              ){
+
+  realw mul;
+  realw alphaval_loc,betaval_loc,gammaval_loc;
+  realw factor_loc,Sn,Snp1;
+  int offset_sls;
+
+  mul = d_muv[tx + NGLL3_PADDED * working_element];
+
+  // use Runge-Kutta scheme to march in time
+  for(int i_sls = 0; i_sls < N_SLS; i_sls++){
+    // indices
+    // note: index for R_xx,... here is (i,j,k,i_sls,ispec) and not (i,j,k,ispec,i_sls) as in local version
+    // index for R_xx(i,j,k,i_sls,ispec),..
+    offset_sls = tx + NGLL3*(i_sls + N_SLS*working_element);
+
+    if( USE_3D_ATTENUATION_ARRAYS ){
+      //mustore(i,j,k,ispec) * factor_common(i,j,k,i_sls,ispec)
+      factor_loc = mul * factor_common[offset_sls];
+    }else{
+      //mustore(i,j,k,ispec) * factor_common(1,1,1,i_sls,ispec)
+      factor_loc = mul * factor_common[i_sls + N_SLS*working_element];
+    }
+    alphaval_loc = alphaval[i_sls]; // (i_sls)
+    betaval_loc = betaval[i_sls];
+    gammaval_loc = gammaval[i_sls];
+
+    // term in xx
+    Sn   = factor_loc * epsilondev_xx[tx + NGLL3 * working_element]; //(i,j,k,ispec)
+    Snp1   = factor_loc * epsilondev_xx_loc; //(i,j,k)
+    R_xx[offset_sls] = alphaval_loc * R_xx[offset_sls] + betaval_loc * Sn + gammaval_loc * Snp1;
+
+    // term in yy
+    Sn   = factor_loc * epsilondev_yy[tx + NGLL3 * working_element];
+    Snp1   = factor_loc * epsilondev_yy_loc;
+    R_yy[offset_sls] = alphaval_loc * R_yy[offset_sls] + betaval_loc * Sn + gammaval_loc * Snp1;
+    // term in zz not computed since zero trace
+
+    // term in xy
+    Sn   = factor_loc * epsilondev_xy[tx + NGLL3 * working_element];
+    Snp1   = factor_loc * epsilondev_xy_loc;
+    R_xy[offset_sls] = alphaval_loc * R_xy[offset_sls] + betaval_loc * Sn + gammaval_loc * Snp1;
+
+    // term in xz
+    Sn   = factor_loc * epsilondev_xz[tx + NGLL3 * working_element];
+    Snp1   = factor_loc * epsilondev_xz_loc;
+    R_xz[offset_sls] = alphaval_loc * R_xz[offset_sls] + betaval_loc * Sn + gammaval_loc * Snp1;
+
+    // term in yz
+    Sn   = factor_loc * epsilondev_yz[tx + NGLL3 * working_element];
+    Snp1   = factor_loc * epsilondev_yz_loc;
+    R_yz[offset_sls] = alphaval_loc * R_yz[offset_sls] + betaval_loc * Sn + gammaval_loc * Snp1;
+  }
+}
+
+/* ----------------------------------------------------------------------------------------------- */
+
+// pre-computes gravity term
+
+__device__ void compute_element_ic_gravity(int tx,int working_element,
+                                           const int* d_ibool,
+                                           realw_const_p d_xstore,realw_const_p d_ystore,realw_const_p d_zstore,
+                                           realw_const_p d_minus_gravity_table,
+                                           realw_const_p d_minus_deriv_gravity_table,
+                                           realw_const_p d_density_table,
+                                           realw_const_p wgll_cube,
+                                           realw jacobianl,
+                                           realw* s_dummyx_loc,
+                                           realw* s_dummyy_loc,
+                                           realw* s_dummyz_loc,
+                                           realw* sigma_xx,
+                                           realw* sigma_yy,
+                                           realw* sigma_zz,
+                                           realw* sigma_xy,
+                                           realw* sigma_yx,
+                                           realw* sigma_xz,
+                                           realw* sigma_zx,
+                                           realw* sigma_yz,
+                                           realw* sigma_zy,
+                                           realw* rho_s_H1,
+                                           realw* rho_s_H2,
+                                           realw* rho_s_H3){
+
+  realw radius,theta,phi;
+  realw cos_theta,sin_theta,cos_phi,sin_phi;
+  realw minus_g,minus_dg;
+  realw rho;
+  realw gxl,gyl,gzl;
+  realw minus_g_over_radius,minus_dg_plus_g_over_radius;
+  realw cos_theta_sq,sin_theta_sq,cos_phi_sq,sin_phi_sq;
+  realw Hxxl,Hyyl,Hzzl,Hxyl,Hxzl,Hyzl;
+  realw sx_l,sy_l,sz_l;
+  realw factor;
+
+  // R_EARTH_KM is the radius of the bottom of the oceans
+  //const realw R_EARTH = 6371000.0f; // in m
+  //const realw R_EARTH_KM = 6371.0f; // in km
+  // uncomment line below for PREM with oceans
+  //const realw R_EARTH = 6368000.0f;
+  //const realw R_EARTH_KM = 6368.0f;
+
+  // compute non-symmetric terms for gravity
+
+  // use mesh coordinates to get theta and phi
+  // x y z contain r theta phi
+  int iglob = d_ibool[working_element*NGLL3 + tx]-1;
+
+  radius = d_xstore[iglob];
+  // make sure radius is never zero even for points at center of cube
+  // because we later divide by radius
+  if(radius < 100.f / (R_EARTH_KM*1000.0f)){ radius = 100.f / (R_EARTH_KM*1000.0f); }
+
+  theta = d_ystore[iglob];
+  phi = d_zstore[iglob];
+
+  if( sizeof( theta ) == sizeof( float ) ){
+    // float operations
+    // sincos function return sinus and cosine for given value
+    sincosf(theta, &sin_theta, &cos_theta);
+    sincosf(phi, &sin_phi, &cos_phi);
+  }else{
+    cos_theta = cos(theta);
+    sin_theta = sin(theta);
+    cos_phi = cos(phi);
+    sin_phi = sin(phi);
+  }
+
+  // for efficiency replace with lookup table every 100 m in radial direction
+  // note: radius in crust mantle should never be zero,
+  //          and arrays in C start from 0, thus we need to subtract -1
+  int int_radius = rint(radius * R_EARTH_KM * 10.0f ) - 1;
+  //make sure we never use below zero for point exactly at the center of the Earth
+  if( int_radius < 0 ){int_radius = 0;}
+
+  // get g, rho and dg/dr=dg
+  // spherical components of the gravitational acceleration
+  // for efficiency replace with lookup table every 100 m in radial direction
+  minus_g = d_minus_gravity_table[int_radius];
+  minus_dg = d_minus_deriv_gravity_table[int_radius];
+  rho = d_density_table[int_radius];
+
+  // Cartesian components of the gravitational acceleration
+  gxl = minus_g*sin_theta*cos_phi;
+  gyl = minus_g*sin_theta*sin_phi;
+  gzl = minus_g*cos_theta;
+
+  // Cartesian components of gradient of gravitational acceleration
+  // obtained from spherical components
+
+  minus_g_over_radius = minus_g / radius;
+  minus_dg_plus_g_over_radius = minus_dg - minus_g_over_radius;
+
+  cos_theta_sq = cos_theta*cos_theta;
+  sin_theta_sq = sin_theta*sin_theta;
+  cos_phi_sq = cos_phi*cos_phi;
+  sin_phi_sq = sin_phi*sin_phi;
+
+  Hxxl = minus_g_over_radius*(cos_phi_sq*cos_theta_sq + sin_phi_sq) + cos_phi_sq*minus_dg*sin_theta_sq;
+  Hyyl = minus_g_over_radius*(cos_phi_sq + cos_theta_sq*sin_phi_sq) + minus_dg*sin_phi_sq*sin_theta_sq;
+  Hzzl = cos_theta_sq*minus_dg + minus_g_over_radius*sin_theta_sq;
+  Hxyl = cos_phi*minus_dg_plus_g_over_radius*sin_phi*sin_theta_sq;
+  Hxzl = cos_phi*cos_theta*minus_dg_plus_g_over_radius*sin_theta;
+  Hyzl = cos_theta*minus_dg_plus_g_over_radius*sin_phi*sin_theta;
+
+  // get displacement and multiply by density to compute G tensor
+  sx_l = rho * s_dummyx_loc[tx];
+  sy_l = rho * s_dummyy_loc[tx];
+  sz_l = rho * s_dummyz_loc[tx];
+
+  // compute G tensor from s . g and add to sigma (not symmetric)
+  *sigma_xx = *sigma_xx + sy_l*gyl + sz_l*gzl;
+  *sigma_yy = *sigma_yy + sx_l*gxl + sz_l*gzl;
+  *sigma_zz = *sigma_zz + sx_l*gxl + sy_l*gyl;
+
+  *sigma_xy = *sigma_xy - sx_l * gyl;
+  *sigma_yx = *sigma_yx - sy_l * gxl;
+
+  *sigma_xz = *sigma_xz - sx_l * gzl;
+  *sigma_zx = *sigma_zx - sz_l * gxl;
+
+  *sigma_yz = *sigma_yz - sy_l * gzl;
+  *sigma_zy = *sigma_zy - sz_l * gyl;
+
+  // precompute vector
+  factor = jacobianl * wgll_cube[tx];
+  *rho_s_H1 = factor * (sx_l * Hxxl + sy_l * Hxyl + sz_l * Hxzl);
+  *rho_s_H2 = factor * (sx_l * Hxyl + sy_l * Hyyl + sz_l * Hyzl);
+  *rho_s_H3 = factor * (sx_l * Hxzl + sy_l * Hyzl + sz_l * Hzzl);
+}
+
+
+/* ----------------------------------------------------------------------------------------------- */
+
+// KERNEL 2
+//
+// for inner_core
+
+/* ----------------------------------------------------------------------------------------------- */
+
 template<int FORWARD_OR_ADJOINT> __global__ void
-#ifdef USE_LAUNCH_BOUNDS__launch_bounds__(NGLL3_PADDED,LAUNCH_MIN_BLOCKS)
+#ifdef USE_LAUNCH_BOUNDS
+// adds compiler specification
+__launch_bounds__(NGLL3_PADDED,LAUNCH_MIN_BLOCKS)
 #endif
 inner_core_impl_kernel(int nb_blocks_to_compute,
                        const int* d_ibool,

--- a/src/gpu/boast/references/outer_core_impl_kernel.cu
+++ b/src/gpu/boast/references/outer_core_impl_kernel.cu
@@ -11,10 +11,12 @@ typedef float * realw_p;
 typedef const float* __restrict__ realw_const_p;
 
 #ifdef USE_TEXTURES_FIELDS
-texture<realw, cudaTextureType1D, cudaReadModeElementType> d_displ_oc_tex;
-texture<realw, cudaTextureType1D, cudaReadModeElementType> d_accel_oc_tex;
-texture<realw, cudaTextureType1D, cudaReadModeElementType> d_b_displ_oc_tex;
-texture<realw, cudaTextureType1D, cudaReadModeElementType> d_b_accel_oc_tex;
+//forward
+realw_texture d_displ_oc_tex;
+realw_texture d_accel_oc_tex;
+//backward/reconstructed
+realw_texture d_b_displ_oc_tex;
+realw_texture d_b_accel_oc_tex;
 // templates definitions
 template<int FORWARD_OR_ADJOINT> __device__ float texfetch_displ_oc(int x);
 template<int FORWARD_OR_ADJOINT> __device__ float texfetch_accel_oc(int x);
@@ -27,9 +29,14 @@ template<> __device__ float texfetch_displ_oc<3>(int x) { return tex1Dfetch(d_b_
 template<> __device__ float texfetch_accel_oc<3>(int x) { return tex1Dfetch(d_b_accel_oc_tex, x); }
 #endif
 
-#ifdef USE_TEXTURES_CONSTANTS
-texture<realw, cudaTextureType1D, cudaReadModeElementType> d_hprime_xx_oc_tex;
-#endif
+
+/* ----------------------------------------------------------------------------------------------- */
+
+// elemental routines
+
+/* ----------------------------------------------------------------------------------------------- */
+
+// fluid rotation
 
 __device__ void compute_element_oc_rotation(int tx,int working_element,
                                             realw time,
@@ -73,6 +80,12 @@ __device__ void compute_element_oc_rotation(int tx,int working_element,
   d_B_array_rotation[tx + working_element*NGLL3] += source_euler_B;
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
+// KERNEL 2
+//
+// for outer core ( acoustic domain )
+/* ----------------------------------------------------------------------------------------------- */
 
 
 template<int FORWARD_OR_ADJOINT> __global__ void outer_core_impl_kernel(int nb_blocks_to_compute,

--- a/src/gpu/check_fields_gpu.c
+++ b/src/gpu/check_fields_gpu.c
@@ -177,6 +177,8 @@ const char *clGetErrorString (cl_int error) {
 }
 #endif
 
+/* ----------------------------------------------------------------------------------------------- */
+
 void exit_on_gpu_error (char *kernel_name) {
   //check to catch errors from previous operations
   // /!\ in opencl, we can't have information about the last ASYNC error
@@ -257,6 +259,8 @@ void exit_on_error (char *info) {
 #endif
   exit (EXIT_FAILURE);
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 #ifdef USE_CUDA
 void print_CUDA_error_if_any(cudaError_t err, int num) {
@@ -604,6 +608,8 @@ void FC_FUNC_ (check_norm_acoustic_from_device,
   exit_on_gpu_error ("after check_norm_acoustic_from_device");
 #endif
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 extern EXTERN_LANG
 void FC_FUNC_ (check_norm_elastic_from_device,

--- a/src/gpu/compute_coupling_gpu.c
+++ b/src/gpu/compute_coupling_gpu.c
@@ -129,6 +129,8 @@ skip_exec:;
 #endif
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 extern EXTERN_LANG
 void FC_FUNC_ (compute_coupling_fluid_icb_gpu,
                COMPUTE_COUPLING_FLUID_ICB_GPU) (long *Mesh_pointer_f,
@@ -327,6 +329,8 @@ skipexec: ;
   exit_on_gpu_error ("compute_coupling_CMB_fluid_gpu");
 #endif
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 extern EXTERN_LANG
 void FC_FUNC_ (compute_coupling_icb_fluid_gpu,

--- a/src/gpu/compute_forces_crust_mantle_gpu.c
+++ b/src/gpu/compute_forces_crust_mantle_gpu.c
@@ -48,6 +48,8 @@ __constant__ size_t d_hprimewgll_xx_tex_offset;
 #endif
 #endif
 
+/* ----------------------------------------------------------------------------------------------- */
+
 void crust_mantle (int nb_blocks_to_compute, Mesh *mp,
                    int iphase,
                    gpu_int_mem d_ibool,

--- a/src/gpu/compute_forces_inner_core_gpu.c
+++ b/src/gpu/compute_forces_inner_core_gpu.c
@@ -40,6 +40,8 @@ realw_texture d_b_accel_ic_tex;
 #endif
 #endif
 
+/* ----------------------------------------------------------------------------------------------- */
+
 void inner_core (int nb_blocks_to_compute, Mesh *mp,
                  int iphase,
                  gpu_int_mem d_ibool,

--- a/src/gpu/compute_forces_outer_core_gpu.c
+++ b/src/gpu/compute_forces_outer_core_gpu.c
@@ -40,6 +40,8 @@ realw_texture d_b_accel_oc_tex;
 #endif
 #endif
 
+/* ----------------------------------------------------------------------------------------------- */
+
 void outer_core (int nb_blocks_to_compute, Mesh *mp,
                  int iphase,
                  gpu_int_mem d_ibool,

--- a/src/gpu/compute_stacey_acoustic_gpu.c
+++ b/src/gpu/compute_stacey_acoustic_gpu.c
@@ -199,6 +199,8 @@ void FC_FUNC_ (compute_stacey_acoustic_gpu,
 #endif
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 extern EXTERN_LANG
 void FC_FUNC_ (compute_stacey_acoustic_backward_gpu,
                COMPUTE_STACEY_ACOUSTIC_BACKWARD_GPU) (long *Mesh_pointer_f,
@@ -251,7 +253,7 @@ void FC_FUNC_ (compute_stacey_acoustic_backward_gpu,
     break;
 
   default:
-    exit_on_error ("compute_stacey_acoustic_gpu: unknown interface type");
+    exit_on_error ("compute_stacey_acoustic_backward_gpu: unknown interface type");
     break;
   }
 
@@ -407,7 +409,7 @@ void FC_FUNC_ (compute_stacey_acoustic_undoatt_gpu,
     break;
 
   default:
-    exit_on_error ("compute_stacey_acoustic_gpu: unknown interface type");
+    exit_on_error ("compute_stacey_acoustic_undoatt_gpu: unknown interface type");
     break;
   }
 

--- a/src/gpu/compute_stacey_elastic_gpu.c
+++ b/src/gpu/compute_stacey_elastic_gpu.c
@@ -29,6 +29,8 @@
 
 #include "mesh_constants_gpu.h"
 
+/* ----------------------------------------------------------------------------------------------- */
+
 extern EXTERN_LANG
 void FC_FUNC_ (compute_stacey_elastic_gpu,
                COMPUTE_STACEY_ELASTIC_GPU) (long *Mesh_pointer_f,
@@ -198,6 +200,8 @@ void FC_FUNC_ (compute_stacey_elastic_gpu,
 #endif
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 extern EXTERN_LANG
 void FC_FUNC_ (compute_stacey_elastic_backward_gpu,
                COMPUTE_STACEY_ELASTIC_BACKWARD_GPU) (long *Mesh_pointer_f,
@@ -244,7 +248,7 @@ void FC_FUNC_ (compute_stacey_elastic_backward_gpu,
     break;
 
   default:
-    exit_on_error ("compute_stacey_elastic_gpu: unknown interface type");
+    exit_on_error ("compute_stacey_elastic_backward_gpu: unknown interface type");
     break;
   }
 

--- a/src/gpu/initialize_gpu.c
+++ b/src/gpu/initialize_gpu.c
@@ -253,6 +253,8 @@ exiting...\n");
 }
 #endif
 
+/* ----------------------------------------------------------------------------------------------- */
+
 #ifdef USE_OPENCL
 struct _mesh_opencl mocl;
 
@@ -564,7 +566,10 @@ static char *trim_and_default(char *s)
   return s;
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 enum gpu_runtime_e {COMPILE, CUDA, OPENCL};
+
 extern EXTERN_LANG
 void FC_FUNC_ (initialize_gpu_device,
                INITIALIZE_GPU_DEVICE) (int *runtime_f, char *platform_filter, char *device_filter, int *myrank_f, int *nb_devices) {

--- a/src/gpu/mesh_constants_gpu.h
+++ b/src/gpu/mesh_constants_gpu.h
@@ -115,8 +115,6 @@ typedef float realw;
 #define MAX(x, y)                  (((x) < (y)) ? (y) : (x))
 
 /*----------------------------------------------------------------------------------------------- */
-
-/*----------------------------------------------------------------------------------------------- */
 // GPU constant arrays
 /*----------------------------------------------------------------------------------------------- */
 // (must match constants.h definitions)
@@ -155,6 +153,7 @@ typedef float realw;
 #ifndef GPU_ASYNC_COPY
 #define GPU_ASYNC_COPY 1
 #endif
+
 /*----------------------------------------------------------------------------------------------- */
 
 // (optional) pre-processing directive used in kernels: if defined check that it is also set in src/shared/constants.h:
@@ -945,6 +944,7 @@ void synchronize_mpi ();
 void get_blocks_xy (int num_blocks, int *num_blocks_x, int *num_blocks_y);
 realw get_device_array_maximum_value (Mesh *mp, gpu_realw_mem *d_array, int size);
 
+/* ----------------------------------------------------------------------------------------------- */
 
 #ifndef TAKE_REF_OCL
 #define TAKE_REF_OCL(_buffer_)

--- a/src/gpu/noise_tomography_gpu.c
+++ b/src/gpu/noise_tomography_gpu.c
@@ -158,6 +158,8 @@ void FC_FUNC_ (noise_add_source_master_rec_gpu,
 #endif
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 extern EXTERN_LANG
 void FC_FUNC_ (noise_add_surface_movie_gpu,
                NOISE_ADD_SURFACE_MOVIE_GPU) (long *Mesh_pointer_f,

--- a/src/gpu/transfer_fields_gpu.c
+++ b/src/gpu/transfer_fields_gpu.c
@@ -29,6 +29,8 @@
 
 #include "mesh_constants_gpu.h"
 
+/* ----------------------------------------------------------------------------------------------- */
+
 // crust_mantle
 extern EXTERN_LANG
 void FC_FUNC_(transfer_fields_cm_to_device,
@@ -60,6 +62,8 @@ void FC_FUNC_(transfer_fields_cm_to_device,
   }
 #endif
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 // inner_core
 extern EXTERN_LANG
@@ -94,6 +98,8 @@ void FC_FUNC_(transfer_fields_ic_to_device,
   }
 #endif
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 // outer_core
 extern EXTERN_LANG
@@ -169,6 +175,8 @@ void FC_FUNC_(transfer_b_fields_cm_to_device,
 #endif
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 // inner_core
 extern EXTERN_LANG
 void FC_FUNC_(transfer_b_fields_ic_to_device,
@@ -205,6 +213,8 @@ void FC_FUNC_(transfer_b_fields_ic_to_device,
   }
 #endif
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 // outer_core
 extern EXTERN_LANG
@@ -610,9 +620,9 @@ void FC_FUNC_(transfer_displ_oc_from_device,
     print_CUDA_error_if_any(cudaMemcpy(displ,mp->d_displ_outer_core.cuda,sizeof(realw)*(*size),cudaMemcpyDeviceToHost),40006);
   }
 #endif
-  /* ----------------------------------------------------------------------------------------------- */
 }
 
+/* ----------------------------------------------------------------------------------------------- */
 
 extern EXTERN_LANG
 void FC_FUNC_(transfer_b_displ_oc_from_device,
@@ -776,6 +786,7 @@ void FC_FUNC_(transfer_accel_cm_from_device,
 }
 
 /* ----------------------------------------------------------------------------------------------- */
+
 extern EXTERN_LANG
 void FC_FUNC_(transfer_b_accel_cm_from_device,
               TRANSFER_B_ACCEL_CM_FROM_DEVICE)(int *size, realw *b_accel, long *Mesh_pointer_f) {
@@ -801,7 +812,6 @@ void FC_FUNC_(transfer_b_accel_cm_from_device,
 }
 
 /* ----------------------------------------------------------------------------------------------- */
-
 
 extern EXTERN_LANG
 void FC_FUNC_(transfer_accel_ic_from_device,
@@ -856,7 +866,6 @@ void FC_FUNC_(transfer_accel_oc_from_device,
 /* ----------------------------------------------------------------------------------------------- */
 // strain fields
 /* ----------------------------------------------------------------------------------------------- */
-
 
 // crust/mantle
 extern EXTERN_LANG
@@ -1128,6 +1137,29 @@ void FC_FUNC_(transfer_rmemory_cm_from_device,
 
   int size = N_SLS * NGLL3 * mp->NSPEC_CRUST_MANTLE;
 
+#ifdef USE_OPENCL
+  if (run_opencl) {
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_xx_crust_mantle.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_xx, 0, NULL, NULL));
+
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_yy_crust_mantle.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_yy, 0, NULL, NULL));
+
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_xy_crust_mantle.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_xy, 0, NULL, NULL));
+
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_xz_crust_mantle.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_xz, 0, NULL, NULL));
+
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_yz_crust_mantle.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_yz, 0, NULL, NULL));
+  }
+#endif
 #if USE_CUDA
   if(run_cuda) {
   print_CUDA_error_if_any(cudaMemcpy(R_xx,mp->d_R_xx_crust_mantle.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),360011);
@@ -1206,8 +1238,6 @@ void FC_FUNC_(transfer_b_rmemory_cm_to_device,
 }
 
 /* ----------------------------------------------------------------------------------------------- */
-
-
 // inner core
 
 extern EXTERN_LANG
@@ -1224,15 +1254,38 @@ void FC_FUNC_(transfer_rmemory_ic_from_device,
   Mesh* mp = (Mesh*)(*Mesh_pointer);
 
   int size = N_SLS*NGLL3*mp->NSPEC_INNER_CORE;
-#ifdef USE_CUDA
-    if (run_cuda) {
-  print_CUDA_error_if_any(cudaMemcpy(R_xx,mp->d_R_xx_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370011);
-  print_CUDA_error_if_any(cudaMemcpy(R_yy,mp->d_R_yy_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370012);
-  print_CUDA_error_if_any(cudaMemcpy(R_xy,mp->d_R_xy_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370013);
-  print_CUDA_error_if_any(cudaMemcpy(R_xz,mp->d_R_xz_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370014);
-  print_CUDA_error_if_any(cudaMemcpy(R_yz,mp->d_R_yz_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370015);
 
-}
+#ifdef USE_OPENCL
+  if (run_opencl) {
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_xx_inner_core.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_xx, 0, NULL, NULL));
+
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_yy_inner_core.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_yy, 0, NULL, NULL));
+
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_xy_inner_core.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_xy, 0, NULL, NULL));
+
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_xz_inner_core.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_xz, 0, NULL, NULL));
+
+    clCheck (clEnqueueReadBuffer(mocl.command_queue, mp->d_R_yz_inner_core.ocl, CL_TRUE, 0,
+                                 size * sizeof (realw),
+                                 R_yz, 0, NULL, NULL));
+  }
+#endif
+#ifdef USE_CUDA
+  if (run_cuda) {
+    print_CUDA_error_if_any(cudaMemcpy(R_xx,mp->d_R_xx_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370011);
+    print_CUDA_error_if_any(cudaMemcpy(R_yy,mp->d_R_yy_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370012);
+    print_CUDA_error_if_any(cudaMemcpy(R_xy,mp->d_R_xy_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370013);
+    print_CUDA_error_if_any(cudaMemcpy(R_xz,mp->d_R_xz_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370014);
+    print_CUDA_error_if_any(cudaMemcpy(R_yz,mp->d_R_yz_inner_core.cuda,size*sizeof(realw),cudaMemcpyDeviceToHost),370015);
+  }
 #endif
 #ifdef ENABLE_VERY_SLOW_ERROR_CHECKING
   exit_on_gpu_error("after transfer_rmemory_ic_from_device");
@@ -1579,9 +1632,8 @@ void FC_FUNC_(transfer_kernels_noise_to_host,
   }
 #endif
 }
+
 /* ----------------------------------------------------------------------------------------------- */
-
-
 // for Hess kernel calculations
 
 extern EXTERN_LANG

--- a/src/gpu/update_displacement_gpu.c
+++ b/src/gpu/update_displacement_gpu.c
@@ -144,7 +144,6 @@ void FC_FUNC_ (update_displacement_ic_gpu,
 //crust/mantle
 /*----------------------------------------------------------------------------------------------- */
 
-
 extern EXTERN_LANG
 void FC_FUNC_ (update_displacement_cm_gpu,
                UPDATE_DISPLACMENT_CM_GPU) (long *Mesh_pointer_f,
@@ -254,6 +253,8 @@ void FC_FUNC_ (update_displacement_cm_gpu,
 #endif
 
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 extern EXTERN_LANG
 void FC_FUNC_ (update_displacement_oc_gpu,
@@ -527,6 +528,8 @@ void FC_FUNC_ (multiply_accel_elastic_gpu,
 #endif
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 extern EXTERN_LANG
 void FC_FUNC_ (update_veloc_elastic_gpu,
                UPDATE_VELOC_ELASTIC_GPU) (long *Mesh_pointer,
@@ -652,6 +655,8 @@ void FC_FUNC_ (update_veloc_elastic_gpu,
 #endif
 }
 
+/* ----------------------------------------------------------------------------------------------- */
+
 extern EXTERN_LANG
 void FC_FUNC_ (multiply_accel_acoustic_gpu,
                MULTIPLY_ACCEL_ACOUSTIC_GPU) (long *Mesh_pointer,
@@ -722,6 +727,8 @@ void FC_FUNC_ (multiply_accel_acoustic_gpu,
   exit_on_gpu_error ("after multiply_accel_acoustic_gpu");
 #endif
 }
+
+/* ----------------------------------------------------------------------------------------------- */
 
 extern EXTERN_LANG
 void FC_FUNC_ (update_veloc_acoustic_gpu,

--- a/src/meshfem3D/meshfem3D_models.f90
+++ b/src/meshfem3D/meshfem3D_models.f90
@@ -26,9 +26,9 @@
 !=====================================================================
 
   subroutine meshfem3D_models_broadcast(myrank,NSPEC, &
-                        MIN_ATTENUATION_PERIOD,MAX_ATTENUATION_PERIOD,&
-                        R80,R220,R670,RCMB,RICB, &
-                        LOCAL_PATH)
+                                        MIN_ATTENUATION_PERIOD,MAX_ATTENUATION_PERIOD,&
+                                        R80,R220,R670,RCMB,RICB, &
+                                        LOCAL_PATH)
 
 ! preparing model parameter coefficients on all processes
 
@@ -36,12 +36,12 @@
 
   implicit none
 
-  integer myrank
+  integer :: myrank
   integer, dimension(MAX_NUM_REGIONS) :: NSPEC
 
-  integer MIN_ATTENUATION_PERIOD,MAX_ATTENUATION_PERIOD
+  integer :: MIN_ATTENUATION_PERIOD,MAX_ATTENUATION_PERIOD
 
-  double precision R80,R220,R670,RCMB,RICB
+  double precision :: R80,R220,R670,RCMB,RICB
 
   character(len=150) :: LOCAL_PATH
 

--- a/src/meshfem3D/model_1dref.f90
+++ b/src/meshfem3D/model_1dref.f90
@@ -54,11 +54,10 @@
   integer, parameter :: NR_REF = 750
 
   ! model_1dref_variables
-  double precision, dimension(NR_REF) :: &
-    Mref_V_radius_ref,Mref_V_density_ref, &
-    Mref_V_vpv_ref,Mref_V_vph_ref, &
-    Mref_V_vsv_ref,Mref_V_vsh_ref, &
-    Mref_V_eta_ref,Mref_V_Qkappa_ref,Mref_V_Qmu_ref
+  double precision, dimension(NR_REF) :: Mref_V_radius_ref,Mref_V_density_ref, &
+                                         Mref_V_vpv_ref,Mref_V_vph_ref, &
+                                         Mref_V_vsv_ref,Mref_V_vsh_ref, &
+                                         Mref_V_eta_ref,Mref_V_Qkappa_ref,Mref_V_Qmu_ref
 
   end module model_1dref_par
 

--- a/src/meshfem3D/model_gll_adios.F90
+++ b/src/meshfem3D/model_gll_adios.F90
@@ -72,15 +72,16 @@ subroutine read_gll_model_adios(myrank,MGLL_V,NSPEC)
 
   integer(kind=8) :: sel
 
+  ! only crust and mantle
+  write(file_name,'(a)') trim(PATHNAME_GLL_modeldir) // 'model_gll.bp'
+
+  ! user output
   if( myrank == 0) then
     write(IMAIN,*)
     write(IMAIN,*)'reading in model from ',trim(PATHNAME_GLL_modeldir)
+    write(IMAIN,*)'ADIOS file: ',trim(file_name)
+    call flush_IMAIN()
   endif
-
-  ! only crust and mantle
-  write(file_name,'(a,i6.6,a)')                                  &
-        PATHNAME_GLL_modeldir(1:len_trim(PATHNAME_GLL_modeldir)) &
-        // 'model_gll.bp'
 
   call world_get_comm(comm)
 
@@ -88,7 +89,7 @@ subroutine read_gll_model_adios(myrank,MGLL_V,NSPEC)
   call adios_read_init_method (ADIOS_READ_METHOD_BP, comm, "verbose=1", adios_err)
   call check_adios_err(myrank,adios_err)
 
-  call adios_read_open_file (adios_handle, file_name, 0, comm, adios_err)
+  call adios_read_open_file (adios_handle, trim(file_name), 0, comm, adios_err)
   if( adios_err /= 0 ) then
     print*,'error rank ',myrank,' opening adios file: ',trim(file_name)
     call check_adios_err(myrank,adios_err)
@@ -131,6 +132,9 @@ subroutine read_gll_model_adios(myrank,MGLL_V,NSPEC)
       MGLL_V%rho_new(:,:,:,1:nspec(IREGION_CRUST_MANTLE)), adios_err)
 
   call adios_perform_reads(adios_handle, adios_err)
+  call check_adios_err(myrank,adios_err)
+
   call adios_read_close(adios_handle, adios_err)
+  call check_adios_err(myrank,adios_err)
 
 end subroutine read_gll_model_adios

--- a/src/meshfem3D/write_AVS_DX_global_chunks_data_adios.f90
+++ b/src/meshfem3D/write_AVS_DX_global_chunks_data_adios.f90
@@ -44,7 +44,7 @@ module AVS_DX_global_chunks_mod
 contains
 
 
-subroutine define_AVS_DX_global_chunks_data(adios_group, &
+  subroutine define_AVS_DX_global_chunks_data(adios_group, &
                                             myrank,nspec,iboun,ibool, &
                                             mask_ibool, &
                                             npointot, &
@@ -223,9 +223,10 @@ subroutine define_AVS_DX_global_chunks_data(adios_group, &
   endif
 
 
-end subroutine define_AVS_DX_global_chunks_data
+  end subroutine define_AVS_DX_global_chunks_data
 
 !===============================================================================
+
   subroutine prepare_AVS_DX_global_chunks_data_adios(myrank,prname,nspec, &
                                                      iboun,ibool, idoubling,xstore,ystore,zstore,num_ibool_AVS_DX,mask_ibool, &
                                                      npointot,rhostore,kappavstore,muvstore,nspl,rspl,espl,espl2, &
@@ -827,7 +828,7 @@ end subroutine define_AVS_DX_global_chunks_data
     endif
   enddo
 
-! check that number of global points output is okay
+  ! check that number of global points output is okay
   if(numpoin /= npoin) &
     call exit_MPI(myrank,&
         'incorrect number of global points in AVS or DX file creation')
@@ -989,11 +990,12 @@ end subroutine define_AVS_DX_global_chunks_data
     call exit_MPI(myrank, &
         'incorrect number of surface elements in AVS or DX file creation')
 
-end subroutine prepare_AVS_DX_global_chunks_data_adios
+  end subroutine prepare_AVS_DX_global_chunks_data_adios
 
 !===============================================================================
-subroutine write_AVS_DX_global_chunks_data_adios(adios_handle, myrank, &
-    sizeprocs, avs_dx_adios, ISOTROPIC_3D_MANTLE)
+
+  subroutine write_AVS_DX_global_chunks_data_adios(adios_handle, myrank, &
+                                                   sizeprocs, avs_dx_adios, ISOTROPIC_3D_MANTLE)
 
   use adios_write_mod
   use adios_helpers_mod
@@ -1045,16 +1047,17 @@ subroutine write_AVS_DX_global_chunks_data_adios(adios_handle, myrank, &
 
   if(ISOTROPIC_3D_MANTLE) then
     call write_adios_global_1d_array(adios_handle, myrank, sizeprocs, nspec, &
-                                     "elements_chunks/dvp", avs_dx_adios%dvp)
+                                     "elements_faces/dvp", avs_dx_adios%dvp)
     call write_adios_global_1d_array(adios_handle, myrank, sizeprocs, nspec, &
-                                     "elements_chunks/dvs", avs_dx_adios%dvs)
+                                     "elements_faces/dvs", avs_dx_adios%dvs)
   endif
 
-end subroutine write_AVS_DX_global_chunks_data_adios
+  end subroutine write_AVS_DX_global_chunks_data_adios
 
 !===============================================================================
-subroutine free_AVS_DX_global_chunks_data_adios(myrank, avs_dx_adios, &
-    ISOTROPIC_3D_MANTLE)
+
+  subroutine free_AVS_DX_global_chunks_data_adios(myrank, avs_dx_adios, &
+                                                  ISOTROPIC_3D_MANTLE)
   implicit none
   !--- Arguments
   integer, intent(in) :: myrank
@@ -1103,6 +1106,7 @@ subroutine free_AVS_DX_global_chunks_data_adios(myrank, avs_dx_adios, &
 
   avs_dx_adios%npoin = 0
   avs_dx_adios%nspecface = 0
-end subroutine free_AVS_DX_global_chunks_data_adios
+
+  end subroutine free_AVS_DX_global_chunks_data_adios
 
 end module

--- a/src/shared/get_model_parameters.f90
+++ b/src/shared/get_model_parameters.f90
@@ -384,7 +384,7 @@
     THREE_D_MODEL = THREE_D_MODEL_PPM
     TRANSVERSE_ISOTROPY = .true. ! to use transverse-isotropic prem
 
-  else if(MODEL_ROOT == 'GLL') then
+  else if(MODEL_ROOT == 'GLL' .or. MODEL_ROOT == 'gll') then
     ! model will be given on local basis, at all GLL points,
     ! as from meshfem3d output from routine save_arrays_solver()
     ! based on model S29EA

--- a/src/shared/read_compute_parameters.f90
+++ b/src/shared/read_compute_parameters.f90
@@ -94,13 +94,13 @@
   ! turns on/off corresponding 1-D/3-D model flags
   ! and sets radius for each discontinuity and ocean density values
   call get_model_parameters(MODEL,REFERENCE_1D_MODEL,THREE_D_MODEL, &
-                        ANISOTROPIC_3D_MANTLE,ANISOTROPIC_INNER_CORE,ATTENUATION_3D, &
-                        CASE_3D,CRUSTAL,HETEROGEN_3D_MANTLE,HONOR_1D_SPHERICAL_MOHO, &
-                        ISOTROPIC_3D_MANTLE,ONE_CRUST,TRANSVERSE_ISOTROPY, &
-                        OCEANS,TOPOGRAPHY, &
-                        ROCEAN,RMIDDLE_CRUST,RMOHO,R80,R120,R220,R400,R600,R670,R771, &
-                        RTOPDDOUBLEPRIME,RCMB,RICB,RMOHO_FICTITIOUS_IN_MESHER, &
-                        R80_FICTITIOUS_IN_MESHER,RHO_TOP_OC,RHO_BOTTOM_OC,RHO_OCEANS)
+                            ANISOTROPIC_3D_MANTLE,ANISOTROPIC_INNER_CORE,ATTENUATION_3D, &
+                            CASE_3D,CRUSTAL,HETEROGEN_3D_MANTLE,HONOR_1D_SPHERICAL_MOHO, &
+                            ISOTROPIC_3D_MANTLE,ONE_CRUST,TRANSVERSE_ISOTROPY, &
+                            OCEANS,TOPOGRAPHY, &
+                            ROCEAN,RMIDDLE_CRUST,RMOHO,R80,R120,R220,R400,R600,R670,R771, &
+                            RTOPDDOUBLEPRIME,RCMB,RICB,RMOHO_FICTITIOUS_IN_MESHER, &
+                            R80_FICTITIOUS_IN_MESHER,RHO_TOP_OC,RHO_BOTTOM_OC,RHO_OCEANS)
 
   ! sets time step size and number of layers
   ! right distribution is determined based upon maximum value of NEX


### PR DESCRIPTION
main changes:
- bug fix for model s362ani (mainly dd() array); 
- bug fix for writing AVS_DX files in adios format;
  additional:
- updates cuda reference files
- adds OpenCL routines for transferring attenuation memory variables
- adds gpu support for isotropic kernels w/ undo_att set
  note: GPU routines are based upon wrong attenuation routine implementation, will need bug fix later on. currently, simulations incorporating full attenuation will produce wrong results on GPUs.
