### PR TITLE
updated BOAST sources to support version 0.9995+

### DIFF
--- a/src/gpu/boast/assemble_boundary_accel_on_device.rb
+++ b/src/gpu/boast/assemble_boundary_accel_on_device.rb
@@ -33,7 +33,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header
-      decl p
+      open p
       id         = Int("id")
       iglob      = Int("iglob")
       iloc       = Int("iloc")

--- a/src/gpu/boast/compute_acoustic_kernel.rb
+++ b/src/gpu/boast/compute_acoustic_kernel.rb
@@ -94,7 +94,7 @@ module BOAST
       make_specfem3d_header( :ngllx => n_gllx, :ngll2 => n_gll2, :ngll3 => n_gll3, :ngll3_padded => n_gll3_padded )
       sub_compute_gradient_kernel = compute_gradient_kernel(n_gllx, n_gll2, n_gll3, n_gll3_padded)
       print sub_compute_gradient_kernel
-      decl p
+      open p
         decl ispec            = Int("ispec")
         decl ijk              = Int("ijk")
         decl ijk_ispec        = Int("ijk_ispec")

--- a/src/gpu/boast/compute_add_sources_adjoint_kernel.rb
+++ b/src/gpu/boast/compute_add_sources_adjoint_kernel.rb
@@ -18,7 +18,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CUDA or get_lang == CL) then
       make_specfem3d_header( :ndim => n_dim, :ngllx => n_gllx )
-      decl p
+      open p
       ispec =      Int("ispec")
       iglob =      Int("iglob")
       irec_local = Int("irec_local")

--- a/src/gpu/boast/compute_add_sources_kernel.rb
+++ b/src/gpu/boast/compute_add_sources_kernel.rb
@@ -19,7 +19,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CUDA or get_lang == CL) then
       make_specfem3d_header( :ndim => n_dim, :ngllx => n_gllx, :double => true )
-      decl p
+      open p
       ispec =   Int( "ispec")
       iglob =   Int( "iglob")
       stf =     Real("stf")

--- a/src/gpu/boast/compute_ani_kernel.rb
+++ b/src/gpu/boast/compute_ani_kernel.rb
@@ -35,7 +35,7 @@ module BOAST
       make_specfem3d_header( :ngll3 => n_gll3 )
       sub_compute_strain_product =  compute_strain_product()
       print sub_compute_strain_product
-      decl p
+      open p
         decl i = Int("i")
         decl ispec = Int("ispec")
         decl ijk_ispec = Int("ijk_ispec")

--- a/src/gpu/boast/compute_ani_undo_att_kernel.rb
+++ b/src/gpu/boast/compute_ani_undo_att_kernel.rb
@@ -58,7 +58,7 @@ module BOAST
         print sub_compute_strain_product
       end
 
-      decl p
+      open p
 
       decl ispec = Int("ispec")
       decl ijk_ispec = Int("ijk_ispec")

--- a/src/gpu/boast/compute_coupling_fluid_CMB_kernel.rb
+++ b/src/gpu/boast/compute_coupling_fluid_CMB_kernel.rb
@@ -75,7 +75,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ndim => n_dim, :ngllx => n_gllx )
-      decl p
+      open p
       decl i = Int("i"), j = Int("j"), k = Int("k")
       decl iface =      Int("iface")
       decl k_corresp =  Int("k_corresp")

--- a/src/gpu/boast/compute_coupling_ocean_kernel.rb
+++ b/src/gpu/boast/compute_coupling_ocean_kernel.rb
@@ -20,7 +20,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ndim => n_dim )
-      decl p
+      open p
       decl ipoin = Int("ipoin")
       decl iglob = Int("iglob")
 

--- a/src/gpu/boast/compute_hess_kernel.rb
+++ b/src/gpu/boast/compute_hess_kernel.rb
@@ -19,7 +19,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ngll3 => n_gll3 )
-      decl p
+      open p
       decl ispec = Int("ispec")
       decl ijk_ispec = Int("ijk_ispec")
       decl iglob = Int("iglob")

--- a/src/gpu/boast/compute_iso_kernel.rb
+++ b/src/gpu/boast/compute_iso_kernel.rb
@@ -30,7 +30,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ngll3 => n_gll3 )
-      decl p
+      open p
         decl ispec = Int("ispec")
         decl ijk_ispec = Int("ijk_ispec")
         print ispec === get_group_id(0) + get_group_id(1)*get_num_groups(0)

--- a/src/gpu/boast/compute_rho_kernel.rb
+++ b/src/gpu/boast/compute_rho_kernel.rb
@@ -19,7 +19,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ngll3 => n_gll3 )
-      decl p
+      open p
         decl ispec = Int("ispec")
         decl ijk_ispec = Int("ijk_ispec")
         decl iglob = Int("iglob")

--- a/src/gpu/boast/compute_stacey_acoustic_kernel.rb
+++ b/src/gpu/boast/compute_stacey_acoustic_kernel.rb
@@ -52,7 +52,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ngllx => n_gllx, :ngll2 => n_gll2 )
-      decl p
+      open p
       decl igll = Int("igll")
       decl iface = Int("iface")
       decl i = Int("i"), j = Int("j"), k = Int("k")

--- a/src/gpu/boast/compute_stacey_elastic_kernel.rb
+++ b/src/gpu/boast/compute_stacey_elastic_kernel.rb
@@ -55,7 +55,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ndim => n_dim, :ngllx => n_gllx, :ngll2 => n_gll2 )
-      decl p
+      open p
       decl igll = Int("igll")
       decl iface = Int("iface")
       decl i = Int("i"), j = Int("j"), k = Int("k")

--- a/src/gpu/boast/compute_strain_kernel.rb
+++ b/src/gpu/boast/compute_strain_kernel.rb
@@ -40,7 +40,7 @@ module BOAST
       sub_compute_element_strain_undo_att = compute_element_strain_undo_att(n_gllx, n_gll2, n_gll3, n_gll3_padded )
       print sub_compute_element_strain_undo_att
 
-      decl p
+      open p
 
       decl ispec = Int("ispec")
       decl ijk_ispec = Int("ijk_ispec")

--- a/src/gpu/boast/compute_strength_noise_kernel.rb
+++ b/src/gpu/boast/compute_strength_noise_kernel.rb
@@ -26,7 +26,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ndim => n_dim, :ngllx => n_gllx, :ngll2 => n_gll2 )
-      decl p
+      open p
         decl iface = Int("iface")
         decl ispec = Int("ispec")
         decl igll  = Int("igll")

--- a/src/gpu/boast/get_maximum_scalar_kernel.rb
+++ b/src/gpu/boast/get_maximum_scalar_kernel.rb
@@ -25,7 +25,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CUDA or get_lang == CL) then
       make_specfem3d_header( :blocksize_transfer => block_size_transfer )
-      decl p
+      open p
       sdata = Real("sdata",  :local => true, :dim => [Dim(blocksize_transfer)] )
       tid =   Int("tid")
       bx =    Int("bx")

--- a/src/gpu/boast/inner_core_impl_kernel_forward.rb
+++ b/src/gpu/boast/inner_core_impl_kernel_forward.rb
@@ -597,7 +597,7 @@ module BOAST
         sub_compute_element_cm_tiso = compute_element_cm_tiso
         print sub_compute_element_cm_tiso
       end
-      decl p
+      open p
         if get_lang == CL then
           @@output.puts "#ifdef #{use_textures_fields}"
             decl d_displ_tex.sampler

--- a/src/gpu/boast/kernels.rb
+++ b/src/gpu/boast/kernels.rb
@@ -137,8 +137,8 @@ kerns.each { |kern|
     
     # writes out generate kernel
     if lang == :CUDA then
-      k = "#{v}" + k
-      f.puts k
+      k_s = "#{v}" + k.to_s
+      f.puts k_s
       if $options[:check] then
         puts "  building kernel"
         k.build( :LDFLAGS => " -L/usr/local/cuda-5.5.22/lib64", :NVCCFLAGS => "-arch sm_20 -O2 --compiler-options -Wall", :verbose => $options[:verbose] )
@@ -201,8 +201,8 @@ langs.each { |lang|
       require "./#{kern.to_s}.rb"
       BOAST::set_lang( BOAST::const_get(lang))
       k = BOAST::method(kern).call(false)
-      proto = k.procedure.decl(false)[0..-3]+";"
-      kern_proto_f.puts proto
+      BOAST::set_output( kern_proto_f )
+      k.procedure.decl
       kern_mk_f.puts "\t$O/#{kern.to_s}.cuda-kernel.o \\"
     elsif lang == :CL
       kern_inc_f.puts "#include \"#{kern.to_s}#{suffix}\""

--- a/src/gpu/boast/noise_add_source_master_rec_kernel.rb
+++ b/src/gpu/boast/noise_add_source_master_rec_kernel.rb
@@ -20,7 +20,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header(:ngll3 => n_gll3)
-      decl p
+      open p
         decl tx  = Int("tx")
         decl ispec = Int("ispec")
         decl iglob = Int("iglob")

--- a/src/gpu/boast/noise_add_surface_movie_kernel.rb
+++ b/src/gpu/boast/noise_add_surface_movie_kernel.rb
@@ -29,7 +29,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ndim => n_dim, :ngllx => n_gllx, :ngll2 => n_gll2)
-      decl p
+      open p
         decl igll  = Int("igll")
         decl iface  = Int("iface")
 

--- a/src/gpu/boast/noise_transfer_surface_to_host_kernel.rb
+++ b/src/gpu/boast/noise_transfer_surface_to_host_kernel.rb
@@ -21,7 +21,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ndim => n_dim, :ngllx => n_gllx, :ngll2 => n_gll2)
-      decl p
+      open p
         decl igll  = Int("igll")
         decl iface  = Int("iface")
 

--- a/src/gpu/boast/outer_core_impl_kernel_forward.rb
+++ b/src/gpu/boast/outer_core_impl_kernel_forward.rb
@@ -142,7 +142,7 @@ module BOAST
 #      end
       sub_kernel =  compute_element_oc_rotation(n_gll3)
       print sub_kernel
-      decl p
+      open p
         if get_lang == CL then
           @@output.puts "#ifdef #{use_textures_fields}"
             decl d_displ_oc_tex.sampler

--- a/src/gpu/boast/prepare_boundary_accel_on_device.rb
+++ b/src/gpu/boast/prepare_boundary_accel_on_device.rb
@@ -30,7 +30,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CUDA or get_lang == CL) then
       make_specfem3d_header
-      decl p
+      open p
       id =         Int("id")
       iglob =      Int("iglob")
       iloc =       Int("iloc")

--- a/src/gpu/boast/update_disp_veloc_kernel.rb
+++ b/src/gpu/boast/update_disp_veloc_kernel.rb
@@ -53,7 +53,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header
-      decl p
+      open p
       decl id = Int("id")
       print id === get_global_id(0) + get_group_id(1)*get_global_size(0)
       print If(id < size ) {

--- a/src/gpu/boast/write_seismograms_transfer_from_device_kernel.rb
+++ b/src/gpu/boast/write_seismograms_transfer_from_device_kernel.rb
@@ -31,7 +31,7 @@ module BOAST
       @@output.print File::read("references/#{function_name}.cu")
     elsif(get_lang == CL or get_lang == CUDA) then
       make_specfem3d_header( :ngll3 => n_gll3 )
-      decl p
+      open p
       blockID    = Int("blockID")
       tx         = Int("tx")
       iglob      = Int("iglob")

--- a/src/gpu/kernels.gen/assemble_boundary_accel_on_device.cu
+++ b/src/gpu/kernels.gen/assemble_boundary_accel_on_device.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -90,8 +90,8 @@ __global__ void assemble_boundary_accel_on_device(float * d_accel, const float *
   int iloc;
   int iinterface;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + ((gridDim.x) * (blockDim.x)) * (threadIdx.y + (blockIdx.y) * (blockDim.y));
-  for(iinterface=0; iinterface<=num_interfaces - (1); iinterface+=1){
-    if(id < d_nibool_interfaces[iinterface - (0)]){
+  for (iinterface = 0; iinterface <= num_interfaces - (1); iinterface += 1) {
+    if (id < d_nibool_interfaces[iinterface - (0)]) {
       iloc = id + (max_nibool_interfaces) * (iinterface);
       iglob = d_ibool_interfaces[iloc - (0)] - (1);
       atomicAdd(d_accel + (iglob) * (3) + 0, d_send_accel_buffer[(iloc) * (3) + 0 - (0)]);

--- a/src/gpu/kernels.gen/assemble_boundary_accel_on_device_cl.c
+++ b/src/gpu/kernels.gen/assemble_boundary_accel_on_device_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -101,8 +101,8 @@ __kernel void assemble_boundary_accel_on_device(__global float * d_accel, const 
   int iloc;\n\
   int iinterface;\n\
   id = get_global_id(0) + (get_global_size(0)) * (get_global_id(1));\n\
-  for(iinterface=0; iinterface<=num_interfaces - (1); iinterface+=1){\n\
-    if(id < d_nibool_interfaces[iinterface - (0)]){\n\
+  for (iinterface = 0; iinterface <= num_interfaces - (1); iinterface += 1) {\n\
+    if (id < d_nibool_interfaces[iinterface - (0)]) {\n\
       iloc = id + (max_nibool_interfaces) * (iinterface);\n\
       iglob = d_ibool_interfaces[iloc - (0)] - (1);\n\
       atomicAdd(d_accel + (iglob) * (3) + 0, d_send_accel_buffer[(iloc) * (3) + 0 - (0)]);\n\

--- a/src/gpu/kernels.gen/assemble_boundary_potential_on_device.cu
+++ b/src/gpu/kernels.gen/assemble_boundary_potential_on_device.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -90,8 +90,8 @@ __global__ void assemble_boundary_potential_on_device(float * d_potential_dot_do
   int iloc;
   int iinterface;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + ((gridDim.x) * (blockDim.x)) * (threadIdx.y + (blockIdx.y) * (blockDim.y));
-  for(iinterface=0; iinterface<=num_interfaces - (1); iinterface+=1){
-    if(id < d_nibool_interfaces[iinterface - (0)]){
+  for (iinterface = 0; iinterface <= num_interfaces - (1); iinterface += 1) {
+    if (id < d_nibool_interfaces[iinterface - (0)]) {
       iloc = id + (max_nibool_interfaces) * (iinterface);
       iglob = d_ibool_interfaces[iloc - (0)] - (1);
       atomicAdd(d_potential_dot_dot_acoustic + iglob, d_send_potential_dot_dot_buffer[iloc - (0)]);

--- a/src/gpu/kernels.gen/assemble_boundary_potential_on_device_cl.c
+++ b/src/gpu/kernels.gen/assemble_boundary_potential_on_device_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -101,8 +101,8 @@ __kernel void assemble_boundary_potential_on_device(__global float * d_potential
   int iloc;\n\
   int iinterface;\n\
   id = get_global_id(0) + (get_global_size(0)) * (get_global_id(1));\n\
-  for(iinterface=0; iinterface<=num_interfaces - (1); iinterface+=1){\n\
-    if(id < d_nibool_interfaces[iinterface - (0)]){\n\
+  for (iinterface = 0; iinterface <= num_interfaces - (1); iinterface += 1) {\n\
+    if (id < d_nibool_interfaces[iinterface - (0)]) {\n\
       iloc = id + (max_nibool_interfaces) * (iinterface);\n\
       iglob = d_ibool_interfaces[iloc - (0)] - (1);\n\
       atomicAdd(d_potential_dot_dot_acoustic + iglob, d_send_potential_dot_dot_buffer[iloc - (0)]);\n\

--- a/src/gpu/kernels.gen/compute_acoustic_kernel.cu
+++ b/src/gpu/kernels.gen/compute_acoustic_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -114,7 +114,7 @@ static __device__ void compute_gradient_kernel(const int ijk, const int ispec, c
   temp1l = 0.0f;
   temp2l = 0.0f;
   temp3l = 0.0f;
-  for(l=0; l<=NGLLX - (1); l+=1){
+  for (l = 0; l <= NGLLX - (1); l += 1) {
     hp1 = hprime_xx[(l) * (NGLLX) + I - (0)];
     hp2 = hprime_xx[(l) * (NGLLX) + J - (0)];
     hp3 = hprime_xx[(l) * (NGLLX) + K - (0)];
@@ -154,7 +154,7 @@ __global__ void compute_acoustic_kernel(const int * ibool, const float * rhostor
   __shared__ float scalar_field_displ[NGLL3 + 0 - (1) - (0) + 1];
   __shared__ float scalar_field_accel[NGLL3 + 0 - (1) - (0) + 1];
   ispec = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     ijk = threadIdx.x;
     ijk_ispec = ijk + (NGLL3) * (ispec);
     ijk_ispec_padded = ijk + (NGLL3_PADDED) * (ispec);

--- a/src/gpu/kernels.gen/compute_acoustic_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_acoustic_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -125,7 +125,7 @@ static void compute_gradient_kernel(const int ijk, const int ispec, const __loca
   temp1l = 0.0f;\n\
   temp2l = 0.0f;\n\
   temp3l = 0.0f;\n\
-  for(l=0; l<=NGLLX - (1); l+=1){\n\
+  for (l = 0; l <= NGLLX - (1); l += 1) {\n\
     hp1 = hprime_xx[(l) * (NGLLX) + I - (0)];\n\
     hp2 = hprime_xx[(l) * (NGLLX) + J - (0)];\n\
     hp3 = hprime_xx[(l) * (NGLLX) + K - (0)];\n\
@@ -165,7 +165,7 @@ __kernel void compute_acoustic_kernel(const __global int * ibool, const __global
   __local float scalar_field_displ[NGLL3 + 0 - (1) - (0) + 1];\n\
   __local float scalar_field_accel[NGLL3 + 0 - (1) - (0) + 1];\n\
   ispec = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     ijk = get_local_id(0);\n\
     ijk_ispec = ijk + (NGLL3) * (ispec);\n\
     ijk_ispec_padded = ijk + (NGLL3_PADDED) * (ispec);\n\

--- a/src/gpu/kernels.gen/compute_add_sources_adjoint_kernel.cu
+++ b/src/gpu/kernels.gen/compute_add_sources_adjoint_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -93,7 +93,7 @@ __global__ void compute_add_sources_adjoint_kernel(float * accel, const int nrec
   int j;
   int k;
   irec_local = blockIdx.x + (gridDim.x) * (blockIdx.y);
-  if(irec_local < nadj_rec_local){
+  if (irec_local < nadj_rec_local) {
     irec = pre_computed_irec[irec_local - (0)];
     ispec = ispec_selected_rec[irec - (0)] - (1);
     i = threadIdx.x;

--- a/src/gpu/kernels.gen/compute_add_sources_adjoint_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_add_sources_adjoint_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -104,7 +104,7 @@ __kernel void compute_add_sources_adjoint_kernel(__global float * accel, const i
   int j;\n\
   int k;\n\
   irec_local = get_group_id(0) + (get_num_groups(0)) * (get_group_id(1));\n\
-  if(irec_local < nadj_rec_local){\n\
+  if (irec_local < nadj_rec_local) {\n\
     irec = pre_computed_irec[irec_local - (0)];\n\
     ispec = ispec_selected_rec[irec - (0)] - (1);\n\
     i = get_local_id(0);\n\

--- a/src/gpu/kernels.gen/compute_add_sources_kernel.cu
+++ b/src/gpu/kernels.gen/compute_add_sources_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -96,8 +96,8 @@ __global__ void compute_add_sources_kernel(float * accel, const int * ibool, con
   j = threadIdx.y;
   k = threadIdx.z;
   isource = blockIdx.x + (gridDim.x) * (blockIdx.y);
-  if(isource < NSOURCES){
-    if(myrank == islice_selected_source[isource - (0)]){
+  if (isource < NSOURCES) {
+    if (myrank == islice_selected_source[isource - (0)]) {
       ispec = ispec_selected_source[isource - (0)] - (1);
       stf = stf_pre_compute[isource - (0)];
       iglob = ibool[INDEX4(NGLLX, NGLLX, NGLLX, i, j, k, ispec) - (0)] - (1);

--- a/src/gpu/kernels.gen/compute_add_sources_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_add_sources_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -109,8 +109,8 @@ __kernel void compute_add_sources_kernel(__global float * accel, const __global 
   j = get_local_id(1);\n\
   k = get_local_id(2);\n\
   isource = get_group_id(0) + (get_num_groups(0)) * (get_group_id(1));\n\
-  if(isource < NSOURCES){\n\
-    if(myrank == islice_selected_source[isource - (0)]){\n\
+  if (isource < NSOURCES) {\n\
+    if (myrank == islice_selected_source[isource - (0)]) {\n\
       ispec = ispec_selected_source[isource - (0)] - (1);\n\
       stf = stf_pre_compute[isource - (0)];\n\
       iglob = ibool[INDEX4(NGLLX, NGLLX, NGLLX, i, j, k, ispec) - (0)] - (1);\n\

--- a/src/gpu/kernels.gen/compute_ani_kernel.cu
+++ b/src/gpu/kernels.gen/compute_ani_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -103,15 +103,15 @@ static __device__ void compute_strain_product(float * prod, const float eps_trac
   b_eps[4 - (0)] = b_epsdev[3 - (0)];
   b_eps[5 - (0)] = b_epsdev[2 - (0)];
   p = 0;
-  for(i=0; i<=5; i+=1){
-    for(j=0; j<=5; j+=1){
+  for (i = 0; i <= 5; i += 1) {
+    for (j = 0; j <= 5; j += 1) {
       prod[p - (0)] = (eps[i - (0)]) * (b_eps[j - (0)]);
-      if(j > i){
+      if (j > i) {
         prod[p - (0)] = prod[p - (0)] + (eps[j - (0)]) * (b_eps[i - (0)]);
-        if(j > 2 && i < 3){
+        if (j > 2 && i < 3) {
           prod[p - (0)] = (prod[p - (0)]) * (2.0f);
         }
-        if(i > 2){
+        if (i > 2) {
           prod[p - (0)] = (prod[p - (0)]) * (4.0f);
         }
         p = p + 1;
@@ -129,7 +129,7 @@ __global__ void compute_ani_kernel(const float * epsilondev_xx, const float * ep
   float epsdev[5];
   float b_epsdev[5];
   ispec = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     ijk_ispec = threadIdx.x + (NGLL3) * (ispec);
     epsdev[0 - (0)] = epsilondev_xx[ijk_ispec - (0)];
     epsdev[1 - (0)] = epsilondev_yy[ijk_ispec - (0)];
@@ -144,7 +144,7 @@ __global__ void compute_ani_kernel(const float * epsilondev_xx, const float * ep
     eps_trace_over_3 = epsilon_trace_over_3[ijk_ispec - (0)];
     b_eps_trace_over_3 = b_epsilon_trace_over_3[ijk_ispec - (0)];
     compute_strain_product(prod, eps_trace_over_3, epsdev, b_eps_trace_over_3, b_epsdev);
-    for(i=0; i<=20; i+=1){
+    for (i = 0; i <= 20; i += 1) {
       cijkl_kl[i - (0) + (ijk_ispec - (0)) * (21)] = cijkl_kl[i - (0) + (ijk_ispec - (0)) * (21)] + (deltat) * (prod[i - (0)]);
     }
   }

--- a/src/gpu/kernels.gen/compute_ani_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_ani_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -114,15 +114,15 @@ static void compute_strain_product(float * prod, const float eps_trace_over_3, c
   b_eps[4 - (0)] = b_epsdev[3 - (0)];\n\
   b_eps[5 - (0)] = b_epsdev[2 - (0)];\n\
   p = 0;\n\
-  for(i=0; i<=5; i+=1){\n\
-    for(j=0; j<=5; j+=1){\n\
+  for (i = 0; i <= 5; i += 1) {\n\
+    for (j = 0; j <= 5; j += 1) {\n\
       prod[p - (0)] = (eps[i - (0)]) * (b_eps[j - (0)]);\n\
-      if(j > i){\n\
+      if (j > i) {\n\
         prod[p - (0)] = prod[p - (0)] + (eps[j - (0)]) * (b_eps[i - (0)]);\n\
-        if(j > 2 && i < 3){\n\
+        if (j > 2 && i < 3) {\n\
           prod[p - (0)] = (prod[p - (0)]) * (2.0f);\n\
         }\n\
-        if(i > 2){\n\
+        if (i > 2) {\n\
           prod[p - (0)] = (prod[p - (0)]) * (4.0f);\n\
         }\n\
         p = p + 1;\n\
@@ -140,7 +140,7 @@ __kernel void compute_ani_kernel(const __global float * epsilondev_xx, const __g
   float epsdev[5];\n\
   float b_epsdev[5];\n\
   ispec = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     ijk_ispec = get_local_id(0) + (NGLL3) * (ispec);\n\
     epsdev[0 - (0)] = epsilondev_xx[ijk_ispec - (0)];\n\
     epsdev[1 - (0)] = epsilondev_yy[ijk_ispec - (0)];\n\
@@ -155,7 +155,7 @@ __kernel void compute_ani_kernel(const __global float * epsilondev_xx, const __g
     eps_trace_over_3 = epsilon_trace_over_3[ijk_ispec - (0)];\n\
     b_eps_trace_over_3 = b_epsilon_trace_over_3[ijk_ispec - (0)];\n\
     compute_strain_product(prod, eps_trace_over_3, epsdev, b_eps_trace_over_3, b_epsdev);\n\
-    for(i=0; i<=20; i+=1){\n\
+    for (i = 0; i <= 20; i += 1) {\n\
       cijkl_kl[i - (0) + (ijk_ispec - (0)) * (21)] = cijkl_kl[i - (0) + (ijk_ispec - (0)) * (21)] + (deltat) * (prod[i - (0)]);\n\
     }\n\
   }\n\

--- a/src/gpu/kernels.gen/compute_ani_undo_att_kernel.cu
+++ b/src/gpu/kernels.gen/compute_ani_undo_att_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -135,7 +135,7 @@ static __device__ void compute_element_strain_undo_att(const int ispec, const in
   tempz1l = 0.0f;
   tempz2l = 0.0f;
   tempz3l = 0.0f;
-  for(l=0; l<=NGLLX - (1); l+=1){
+  for (l = 0; l <= NGLLX - (1); l += 1) {
     fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];
     tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
     tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
@@ -195,15 +195,15 @@ static __device__ void compute_strain_product(float * prod, const float eps_trac
   b_eps[4 - (0)] = b_epsdev[3 - (0)];
   b_eps[5 - (0)] = b_epsdev[2 - (0)];
   p = 0;
-  for(i=0; i<=5; i+=1){
-    for(j=0; j<=5; j+=1){
+  for (i = 0; i <= 5; i += 1) {
+    for (j = 0; j <= 5; j += 1) {
       prod[p - (0)] = (eps[i - (0)]) * (b_eps[j - (0)]);
-      if(j > i){
+      if (j > i) {
         prod[p - (0)] = prod[p - (0)] + (eps[j - (0)]) * (b_eps[i - (0)]);
-        if(j > 2 && i < 3){
+        if (j > 2 && i < 3) {
           prod[p - (0)] = (prod[p - (0)]) * (2.0f);
         }
-        if(i > 2){
+        if (i > 2) {
           prod[p - (0)] = (prod[p - (0)]) * (4.0f);
         }
         p = p + 1;
@@ -229,17 +229,17 @@ __global__ void compute_ani_undo_att_kernel(const float * epsilondev_xx, const f
   ispec = blockIdx.x + (blockIdx.y) * (gridDim.x);
   ijk_ispec = threadIdx.x + (NGLL3) * (ispec);
   tx = threadIdx.x;
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
     sh_hprime_xx[tx - (0)] = d_hprime_xx[tx - (0)];
   }
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     iglob = d_ibool[ijk_ispec - (0)] - (1);
     s_dummyx_loc[tx - (0)] = d_b_displ[0 - (0) + (iglob - (0)) * (3)];
     s_dummyy_loc[tx - (0)] = d_b_displ[1 - (0) + (iglob - (0)) * (3)];
     s_dummyz_loc[tx - (0)] = d_b_displ[2 - (0) + (iglob - (0)) * (3)];
   }
   __syncthreads();
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     epsdev[0 - (0)] = epsilondev_xx[ijk_ispec - (0)];
     epsdev[1 - (0)] = epsilondev_yy[ijk_ispec - (0)];
     epsdev[2 - (0)] = epsilondev_xy[ijk_ispec - (0)];
@@ -248,7 +248,7 @@ __global__ void compute_ani_undo_att_kernel(const float * epsilondev_xx, const f
     eps_trace_over_3 = epsilon_trace_over_3[ijk_ispec - (0)];
     compute_element_strain_undo_att(ispec, ijk_ispec, d_ibool, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc, d_xix, d_xiy, d_xiz, d_etax, d_etay, d_etaz, d_gammax, d_gammay, d_gammaz, sh_hprime_xx, b_epsdev,  &b_eps_trace_over_3);
     compute_strain_product(prod, eps_trace_over_3, epsdev, b_eps_trace_over_3, b_epsdev);
-    for(i=0; i<=20; i+=1){
+    for (i = 0; i <= 20; i += 1) {
       cijkl_kl[i - (0) + (ijk_ispec - (0)) * (21)] = cijkl_kl[i - (0) + (ijk_ispec - (0)) * (21)] + (deltat) * (prod[i - (0)]);
     }
   }

--- a/src/gpu/kernels.gen/compute_ani_undo_att_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_ani_undo_att_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -146,7 +146,7 @@ static void compute_element_strain_undo_att(const int ispec, const int ijk_ispec
   tempz1l = 0.0f;\n\
   tempz2l = 0.0f;\n\
   tempz3l = 0.0f;\n\
-  for(l=0; l<=NGLLX - (1); l+=1){\n\
+  for (l = 0; l <= NGLLX - (1); l += 1) {\n\
     fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];\n\
     tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
     tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
@@ -206,15 +206,15 @@ static void compute_strain_product(float * prod, const float eps_trace_over_3, c
   b_eps[4 - (0)] = b_epsdev[3 - (0)];\n\
   b_eps[5 - (0)] = b_epsdev[2 - (0)];\n\
   p = 0;\n\
-  for(i=0; i<=5; i+=1){\n\
-    for(j=0; j<=5; j+=1){\n\
+  for (i = 0; i <= 5; i += 1) {\n\
+    for (j = 0; j <= 5; j += 1) {\n\
       prod[p - (0)] = (eps[i - (0)]) * (b_eps[j - (0)]);\n\
-      if(j > i){\n\
+      if (j > i) {\n\
         prod[p - (0)] = prod[p - (0)] + (eps[j - (0)]) * (b_eps[i - (0)]);\n\
-        if(j > 2 && i < 3){\n\
+        if (j > 2 && i < 3) {\n\
           prod[p - (0)] = (prod[p - (0)]) * (2.0f);\n\
         }\n\
-        if(i > 2){\n\
+        if (i > 2) {\n\
           prod[p - (0)] = (prod[p - (0)]) * (4.0f);\n\
         }\n\
         p = p + 1;\n\
@@ -240,17 +240,17 @@ __kernel void compute_ani_undo_att_kernel(const __global float * epsilondev_xx, 
   ispec = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
   ijk_ispec = get_local_id(0) + (NGLL3) * (ispec);\n\
   tx = get_local_id(0);\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
     sh_hprime_xx[tx - (0)] = d_hprime_xx[tx - (0)];\n\
   }\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     iglob = d_ibool[ijk_ispec - (0)] - (1);\n\
     s_dummyx_loc[tx - (0)] = d_b_displ[0 - (0) + (iglob - (0)) * (3)];\n\
     s_dummyy_loc[tx - (0)] = d_b_displ[1 - (0) + (iglob - (0)) * (3)];\n\
     s_dummyz_loc[tx - (0)] = d_b_displ[2 - (0) + (iglob - (0)) * (3)];\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     epsdev[0 - (0)] = epsilondev_xx[ijk_ispec - (0)];\n\
     epsdev[1 - (0)] = epsilondev_yy[ijk_ispec - (0)];\n\
     epsdev[2 - (0)] = epsilondev_xy[ijk_ispec - (0)];\n\
@@ -259,7 +259,7 @@ __kernel void compute_ani_undo_att_kernel(const __global float * epsilondev_xx, 
     eps_trace_over_3 = epsilon_trace_over_3[ijk_ispec - (0)];\n\
     compute_element_strain_undo_att(ispec, ijk_ispec, d_ibool, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc, d_xix, d_xiy, d_xiz, d_etax, d_etay, d_etaz, d_gammax, d_gammay, d_gammaz, sh_hprime_xx, b_epsdev,  &b_eps_trace_over_3);\n\
     compute_strain_product(prod, eps_trace_over_3, epsdev, b_eps_trace_over_3, b_epsdev);\n\
-    for(i=0; i<=20; i+=1){\n\
+    for (i = 0; i <= 20; i += 1) {\n\
       cijkl_kl[i - (0) + (ijk_ispec - (0)) * (21)] = cijkl_kl[i - (0) + (ijk_ispec - (0)) * (21)] + (deltat) * (prod[i - (0)]);\n\
     }\n\
   }\n\

--- a/src/gpu/kernels.gen/compute_coupling_CMB_fluid_kernel.cu
+++ b/src/gpu/kernels.gen/compute_coupling_CMB_fluid_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -102,7 +102,7 @@ __global__ void compute_coupling_CMB_fluid_kernel(const float * displ_crust_mant
   i = threadIdx.x;
   j = threadIdx.y;
   iface = blockIdx.x + (gridDim.x) * (blockIdx.y);
-  if(iface < NSPEC2D_BOTTOM_CM){
+  if (iface < NSPEC2D_BOTTOM_CM) {
     ispec = ibelm_bottom_crust_mantle[iface - (0)] - (1);
     ispec_selected = ibelm_top_outer_core[iface - (0)] - (1);
     k = 0;
@@ -113,7 +113,7 @@ __global__ void compute_coupling_CMB_fluid_kernel(const float * displ_crust_mant
     nz = normal_top_outer_core[INDEX4(NDIM, NGLLX, NGLLX, 2, i, j, iface) - (0)];
     weight = (jacobian2D_top_outer_core[INDEX3(NGLLX, NGLLX, i, j, iface) - (0)]) * (wgllwgll_xy[INDEX2(NGLLX, i, j) - (0)]);
     iglob_cm = ibool_crust_mantle[INDEX4(NGLLX, NGLLX, NGLLX, i, j, k, ispec) - (0)] - (1);
-    if(GRAVITY){
+    if (GRAVITY) {
       pressure = (RHO_TOP_OC) * ((minus_g_cmb) * ((displ_crust_mantle[(iglob_cm) * (3) - (0)]) * (nx) + (displ_crust_mantle[(iglob_cm) * (3) + 1 - (0)]) * (ny) + (displ_crust_mantle[(iglob_cm) * (3) + 2 - (0)]) * (nz)) - (accel_outer_core[iglob_oc - (0)]));
     } else {
       pressure = ( -(RHO_TOP_OC)) * (accel_outer_core[iglob_oc - (0)]);

--- a/src/gpu/kernels.gen/compute_coupling_CMB_fluid_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_coupling_CMB_fluid_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -113,7 +113,7 @@ __kernel void compute_coupling_CMB_fluid_kernel(const __global float * displ_cru
   i = get_local_id(0);\n\
   j = get_local_id(1);\n\
   iface = get_group_id(0) + (get_num_groups(0)) * (get_group_id(1));\n\
-  if(iface < NSPEC2D_BOTTOM_CM){\n\
+  if (iface < NSPEC2D_BOTTOM_CM) {\n\
     ispec = ibelm_bottom_crust_mantle[iface - (0)] - (1);\n\
     ispec_selected = ibelm_top_outer_core[iface - (0)] - (1);\n\
     k = 0;\n\
@@ -124,7 +124,7 @@ __kernel void compute_coupling_CMB_fluid_kernel(const __global float * displ_cru
     nz = normal_top_outer_core[INDEX4(NDIM, NGLLX, NGLLX, 2, i, j, iface) - (0)];\n\
     weight = (jacobian2D_top_outer_core[INDEX3(NGLLX, NGLLX, i, j, iface) - (0)]) * (wgllwgll_xy[INDEX2(NGLLX, i, j) - (0)]);\n\
     iglob_cm = ibool_crust_mantle[INDEX4(NGLLX, NGLLX, NGLLX, i, j, k, ispec) - (0)] - (1);\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       pressure = (RHO_TOP_OC) * ((minus_g_cmb) * ((displ_crust_mantle[(iglob_cm) * (3) - (0)]) * (nx) + (displ_crust_mantle[(iglob_cm) * (3) + 1 - (0)]) * (ny) + (displ_crust_mantle[(iglob_cm) * (3) + 2 - (0)]) * (nz)) - (accel_outer_core[iglob_oc - (0)]));\n\
     } else {\n\
       pressure = ( -(RHO_TOP_OC)) * (accel_outer_core[iglob_oc - (0)]);\n\

--- a/src/gpu/kernels.gen/compute_coupling_ICB_fluid_kernel.cu
+++ b/src/gpu/kernels.gen/compute_coupling_ICB_fluid_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -102,7 +102,7 @@ __global__ void compute_coupling_ICB_fluid_kernel(const float * displ_inner_core
   i = threadIdx.x;
   j = threadIdx.y;
   iface = blockIdx.x + (gridDim.x) * (blockIdx.y);
-  if(iface < NSPEC2D_TOP_IC){
+  if (iface < NSPEC2D_TOP_IC) {
     ispec = ibelm_top_inner_core[iface - (0)] - (1);
     ispec_selected = ibelm_bottom_outer_core[iface - (0)] - (1);
     k = NGLLX - (1);
@@ -113,7 +113,7 @@ __global__ void compute_coupling_ICB_fluid_kernel(const float * displ_inner_core
     nz = normal_bottom_outer_core[INDEX4(NDIM, NGLLX, NGLLX, 2, i, j, iface) - (0)];
     weight = (jacobian2D_bottom_outer_core[INDEX3(NGLLX, NGLLX, i, j, iface) - (0)]) * (wgllwgll_xy[INDEX2(NGLLX, i, j) - (0)]);
     iglob_ic = ibool_inner_core[INDEX4(NGLLX, NGLLX, NGLLX, i, j, k, ispec) - (0)] - (1);
-    if(GRAVITY){
+    if (GRAVITY) {
       pressure = (RHO_BOTTOM_OC) * ((minus_g_icb) * ((displ_inner_core[(iglob_ic) * (3) - (0)]) * (nx) + (displ_inner_core[(iglob_ic) * (3) + 1 - (0)]) * (ny) + (displ_inner_core[(iglob_ic) * (3) + 2 - (0)]) * (nz)) - (accel_outer_core[iglob_oc - (0)]));
     } else {
       pressure = ( -(RHO_BOTTOM_OC)) * (accel_outer_core[iglob_oc - (0)]);

--- a/src/gpu/kernels.gen/compute_coupling_ICB_fluid_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_coupling_ICB_fluid_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -113,7 +113,7 @@ __kernel void compute_coupling_ICB_fluid_kernel(const __global float * displ_inn
   i = get_local_id(0);\n\
   j = get_local_id(1);\n\
   iface = get_group_id(0) + (get_num_groups(0)) * (get_group_id(1));\n\
-  if(iface < NSPEC2D_TOP_IC){\n\
+  if (iface < NSPEC2D_TOP_IC) {\n\
     ispec = ibelm_top_inner_core[iface - (0)] - (1);\n\
     ispec_selected = ibelm_bottom_outer_core[iface - (0)] - (1);\n\
     k = NGLLX - (1);\n\
@@ -124,7 +124,7 @@ __kernel void compute_coupling_ICB_fluid_kernel(const __global float * displ_inn
     nz = normal_bottom_outer_core[INDEX4(NDIM, NGLLX, NGLLX, 2, i, j, iface) - (0)];\n\
     weight = (jacobian2D_bottom_outer_core[INDEX3(NGLLX, NGLLX, i, j, iface) - (0)]) * (wgllwgll_xy[INDEX2(NGLLX, i, j) - (0)]);\n\
     iglob_ic = ibool_inner_core[INDEX4(NGLLX, NGLLX, NGLLX, i, j, k, ispec) - (0)] - (1);\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       pressure = (RHO_BOTTOM_OC) * ((minus_g_icb) * ((displ_inner_core[(iglob_ic) * (3) - (0)]) * (nx) + (displ_inner_core[(iglob_ic) * (3) + 1 - (0)]) * (ny) + (displ_inner_core[(iglob_ic) * (3) + 2 - (0)]) * (nz)) - (accel_outer_core[iglob_oc - (0)]));\n\
     } else {\n\
       pressure = ( -(RHO_BOTTOM_OC)) * (accel_outer_core[iglob_oc - (0)]);\n\

--- a/src/gpu/kernels.gen/compute_coupling_fluid_CMB_kernel.cu
+++ b/src/gpu/kernels.gen/compute_coupling_fluid_CMB_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -105,7 +105,7 @@ __global__ void compute_coupling_fluid_CMB_kernel(const float * displ_crust_mant
   i = threadIdx.x;
   j = threadIdx.y;
   iface = blockIdx.x + (gridDim.x) * (blockIdx.y);
-  if(iface < NSPEC2D_TOP_OC){
+  if (iface < NSPEC2D_TOP_OC) {
     ispec = ibelm_top_outer_core[iface - (0)] - (1);
     ispec_selected = ibelm_bottom_crust_mantle[iface - (0)] - (1);
     k = NGLLX - (1);

--- a/src/gpu/kernels.gen/compute_coupling_fluid_CMB_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_coupling_fluid_CMB_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -116,7 +116,7 @@ __kernel void compute_coupling_fluid_CMB_kernel(const __global float * displ_cru
   i = get_local_id(0);\n\
   j = get_local_id(1);\n\
   iface = get_group_id(0) + (get_num_groups(0)) * (get_group_id(1));\n\
-  if(iface < NSPEC2D_TOP_OC){\n\
+  if (iface < NSPEC2D_TOP_OC) {\n\
     ispec = ibelm_top_outer_core[iface - (0)] - (1);\n\
     ispec_selected = ibelm_bottom_crust_mantle[iface - (0)] - (1);\n\
     k = NGLLX - (1);\n\

--- a/src/gpu/kernels.gen/compute_coupling_fluid_ICB_kernel.cu
+++ b/src/gpu/kernels.gen/compute_coupling_fluid_ICB_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -105,7 +105,7 @@ __global__ void compute_coupling_fluid_ICB_kernel(const float * displ_inner_core
   i = threadIdx.x;
   j = threadIdx.y;
   iface = blockIdx.x + (gridDim.x) * (blockIdx.y);
-  if(iface < NSPEC2D_BOTTOM_OC){
+  if (iface < NSPEC2D_BOTTOM_OC) {
     ispec = ibelm_bottom_outer_core[iface - (0)] - (1);
     ispec_selected = ibelm_top_inner_core[iface - (0)] - (1);
     k = 0;

--- a/src/gpu/kernels.gen/compute_coupling_fluid_ICB_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_coupling_fluid_ICB_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -116,7 +116,7 @@ __kernel void compute_coupling_fluid_ICB_kernel(const __global float * displ_inn
   i = get_local_id(0);\n\
   j = get_local_id(1);\n\
   iface = get_group_id(0) + (get_num_groups(0)) * (get_group_id(1));\n\
-  if(iface < NSPEC2D_BOTTOM_OC){\n\
+  if (iface < NSPEC2D_BOTTOM_OC) {\n\
     ispec = ibelm_bottom_outer_core[iface - (0)] - (1);\n\
     ispec_selected = ibelm_top_inner_core[iface - (0)] - (1);\n\
     k = 0;\n\

--- a/src/gpu/kernels.gen/compute_coupling_ocean_kernel.cu
+++ b/src/gpu/kernels.gen/compute_coupling_ocean_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -96,7 +96,7 @@ __global__ void compute_coupling_ocean_kernel(float * accel_crust_mantle, const 
   float additional_term_y;
   float additional_term_z;
   ipoin = threadIdx.x + (blockIdx.x) * (blockDim.x) + ((gridDim.x) * (blockDim.x)) * (threadIdx.y + (blockIdx.y) * (blockDim.y));
-  if(ipoin < npoin_ocean_load){
+  if (ipoin < npoin_ocean_load) {
     iglob = ibool_ocean_load[ipoin - (0)] - (1);
     nx = normal_ocean_load[INDEX2(NDIM, 0, ipoin) - (0)];
     ny = normal_ocean_load[INDEX2(NDIM, 1, ipoin) - (0)];

--- a/src/gpu/kernels.gen/compute_coupling_ocean_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_coupling_ocean_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -107,7 +107,7 @@ __kernel void compute_coupling_ocean_kernel(__global float * accel_crust_mantle,
   float additional_term_y;\n\
   float additional_term_z;\n\
   ipoin = get_global_id(0) + (get_global_size(0)) * (get_global_id(1));\n\
-  if(ipoin < npoin_ocean_load){\n\
+  if (ipoin < npoin_ocean_load) {\n\
     iglob = ibool_ocean_load[ipoin - (0)] - (1);\n\
     nx = normal_ocean_load[INDEX2(NDIM, 0, ipoin) - (0)];\n\
     ny = normal_ocean_load[INDEX2(NDIM, 1, ipoin) - (0)];\n\

--- a/src/gpu/kernels.gen/compute_hess_kernel.cu
+++ b/src/gpu/kernels.gen/compute_hess_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -89,7 +89,7 @@ __global__ void compute_hess_kernel(const int * ibool, const float * accel, cons
   int ijk_ispec;
   int iglob;
   ispec = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(ispec < NSPEC_AB){
+  if (ispec < NSPEC_AB) {
     ijk_ispec = threadIdx.x + (NGLL3) * (ispec);
     iglob = ibool[ijk_ispec - (0)] - (1);
     hess_kl[ijk_ispec - (0)] = hess_kl[ijk_ispec - (0)] + (deltat) * ((accel[0 - (0) + (iglob - (0)) * (3)]) * (b_accel[0 - (0) + (iglob - (0)) * (3)]) + (accel[1 - (0) + (iglob - (0)) * (3)]) * (b_accel[1 - (0) + (iglob - (0)) * (3)]) + (accel[2 - (0) + (iglob - (0)) * (3)]) * (b_accel[2 - (0) + (iglob - (0)) * (3)]));

--- a/src/gpu/kernels.gen/compute_hess_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_hess_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -100,7 +100,7 @@ __kernel void compute_hess_kernel(const __global int * ibool, const __global flo
   int ijk_ispec;\n\
   int iglob;\n\
   ispec = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(ispec < NSPEC_AB){\n\
+  if (ispec < NSPEC_AB) {\n\
     ijk_ispec = get_local_id(0) + (NGLL3) * (ispec);\n\
     iglob = ibool[ijk_ispec - (0)] - (1);\n\
     hess_kl[ijk_ispec - (0)] = hess_kl[ijk_ispec - (0)] + (deltat) * ((accel[0 - (0) + (iglob - (0)) * (3)]) * (b_accel[0 - (0) + (iglob - (0)) * (3)]) + (accel[1 - (0) + (iglob - (0)) * (3)]) * (b_accel[1 - (0) + (iglob - (0)) * (3)]) + (accel[2 - (0) + (iglob - (0)) * (3)]) * (b_accel[2 - (0) + (iglob - (0)) * (3)]));\n\

--- a/src/gpu/kernels.gen/compute_iso_kernel.cu
+++ b/src/gpu/kernels.gen/compute_iso_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -88,7 +88,7 @@ __global__ void compute_iso_kernel(const float * epsilondev_xx, const float * ep
   int ispec;
   int ijk_ispec;
   ispec = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     ijk_ispec = threadIdx.x + (NGLL3) * (ispec);
     mu_kl[ijk_ispec - (0)] = mu_kl[ijk_ispec - (0)] + (deltat) * ((epsilondev_xx[ijk_ispec - (0)]) * (b_epsilondev_xx[ijk_ispec - (0)]) + (epsilondev_yy[ijk_ispec - (0)]) * (b_epsilondev_yy[ijk_ispec - (0)]) + (epsilondev_xx[ijk_ispec - (0)] + epsilondev_yy[ijk_ispec - (0)]) * (b_epsilondev_xx[ijk_ispec - (0)] + b_epsilondev_yy[ijk_ispec - (0)]) + ((epsilondev_xy[ijk_ispec - (0)]) * (b_epsilondev_xy[ijk_ispec - (0)]) + (epsilondev_xz[ijk_ispec - (0)]) * (b_epsilondev_xz[ijk_ispec - (0)]) + (epsilondev_yz[ijk_ispec - (0)]) * (b_epsilondev_yz[ijk_ispec - (0)])) * (2));
     kappa_kl[ijk_ispec - (0)] = kappa_kl[ijk_ispec - (0)] + (deltat) * (((epsilon_trace_over_3[ijk_ispec - (0)]) * (b_epsilon_trace_over_3[ijk_ispec - (0)])) * (9));

--- a/src/gpu/kernels.gen/compute_iso_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_iso_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -99,7 +99,7 @@ __kernel void compute_iso_kernel(const __global float * epsilondev_xx, const __g
   int ispec;\n\
   int ijk_ispec;\n\
   ispec = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     ijk_ispec = get_local_id(0) + (NGLL3) * (ispec);\n\
     mu_kl[ijk_ispec - (0)] = mu_kl[ijk_ispec - (0)] + (deltat) * ((epsilondev_xx[ijk_ispec - (0)]) * (b_epsilondev_xx[ijk_ispec - (0)]) + (epsilondev_yy[ijk_ispec - (0)]) * (b_epsilondev_yy[ijk_ispec - (0)]) + (epsilondev_xx[ijk_ispec - (0)] + epsilondev_yy[ijk_ispec - (0)]) * (b_epsilondev_xx[ijk_ispec - (0)] + b_epsilondev_yy[ijk_ispec - (0)]) + ((epsilondev_xy[ijk_ispec - (0)]) * (b_epsilondev_xy[ijk_ispec - (0)]) + (epsilondev_xz[ijk_ispec - (0)]) * (b_epsilondev_xz[ijk_ispec - (0)]) + (epsilondev_yz[ijk_ispec - (0)]) * (b_epsilondev_yz[ijk_ispec - (0)])) * (2));\n\
     kappa_kl[ijk_ispec - (0)] = kappa_kl[ijk_ispec - (0)] + (deltat) * (((epsilon_trace_over_3[ijk_ispec - (0)]) * (b_epsilon_trace_over_3[ijk_ispec - (0)])) * (9));\n\

--- a/src/gpu/kernels.gen/compute_iso_undo_att_kernel.cu
+++ b/src/gpu/kernels.gen/compute_iso_undo_att_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -135,7 +135,7 @@ static __device__ void compute_element_strain_undo_att(const int ispec, const in
   tempz1l = 0.0f;
   tempz2l = 0.0f;
   tempz3l = 0.0f;
-  for(l=0; l<=NGLLX - (1); l+=1){
+  for (l = 0; l <= NGLLX - (1); l += 1) {
     fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];
     tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
     tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
@@ -192,17 +192,17 @@ __global__ void compute_iso_undo_att_kernel(const float * epsilondev_xx, const f
   ispec = blockIdx.x + (blockIdx.y) * (gridDim.x);
   ijk_ispec = threadIdx.x + (NGLL3) * (ispec);
   tx = threadIdx.x;
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
     sh_hprime_xx[tx - (0)] = d_hprime_xx[tx - (0)];
   }
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     iglob = d_ibool[ijk_ispec - (0)] - (1);
     s_dummyx_loc[tx - (0)] = d_b_displ[0 - (0) + (iglob - (0)) * (3)];
     s_dummyy_loc[tx - (0)] = d_b_displ[1 - (0) + (iglob - (0)) * (3)];
     s_dummyz_loc[tx - (0)] = d_b_displ[2 - (0) + (iglob - (0)) * (3)];
   }
   __syncthreads();
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     epsdev[0 - (0)] = epsilondev_xx[ijk_ispec - (0)];
     epsdev[1 - (0)] = epsilondev_yy[ijk_ispec - (0)];
     epsdev[2 - (0)] = epsilondev_xy[ijk_ispec - (0)];

--- a/src/gpu/kernels.gen/compute_iso_undo_att_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_iso_undo_att_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -146,7 +146,7 @@ static void compute_element_strain_undo_att(const int ispec, const int ijk_ispec
   tempz1l = 0.0f;\n\
   tempz2l = 0.0f;\n\
   tempz3l = 0.0f;\n\
-  for(l=0; l<=NGLLX - (1); l+=1){\n\
+  for (l = 0; l <= NGLLX - (1); l += 1) {\n\
     fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];\n\
     tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
     tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
@@ -203,17 +203,17 @@ __kernel void compute_iso_undo_att_kernel(const __global float * epsilondev_xx, 
   ispec = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
   ijk_ispec = get_local_id(0) + (NGLL3) * (ispec);\n\
   tx = get_local_id(0);\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
     sh_hprime_xx[tx - (0)] = d_hprime_xx[tx - (0)];\n\
   }\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     iglob = d_ibool[ijk_ispec - (0)] - (1);\n\
     s_dummyx_loc[tx - (0)] = d_b_displ[0 - (0) + (iglob - (0)) * (3)];\n\
     s_dummyy_loc[tx - (0)] = d_b_displ[1 - (0) + (iglob - (0)) * (3)];\n\
     s_dummyz_loc[tx - (0)] = d_b_displ[2 - (0) + (iglob - (0)) * (3)];\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     epsdev[0 - (0)] = epsilondev_xx[ijk_ispec - (0)];\n\
     epsdev[1 - (0)] = epsilondev_yy[ijk_ispec - (0)];\n\
     epsdev[2 - (0)] = epsilondev_xy[ijk_ispec - (0)];\n\

--- a/src/gpu/kernels.gen/compute_rho_kernel.cu
+++ b/src/gpu/kernels.gen/compute_rho_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -89,7 +89,7 @@ __global__ void compute_rho_kernel(const int * ibool, const float * accel, const
   int ijk_ispec;
   int iglob;
   ispec = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     ijk_ispec = threadIdx.x + (NGLL3) * (ispec);
     iglob = ibool[ijk_ispec - (0)] - (1);
     rho_kl[ijk_ispec - (0)] = rho_kl[ijk_ispec - (0)] + (deltat) * ((accel[0 - (0) + (iglob - (0)) * (3)]) * (b_displ[0 - (0) + (iglob - (0)) * (3)]) + (accel[1 - (0) + (iglob - (0)) * (3)]) * (b_displ[1 - (0) + (iglob - (0)) * (3)]) + (accel[2 - (0) + (iglob - (0)) * (3)]) * (b_displ[2 - (0) + (iglob - (0)) * (3)]));

--- a/src/gpu/kernels.gen/compute_rho_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_rho_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -100,7 +100,7 @@ __kernel void compute_rho_kernel(const __global int * ibool, const __global floa
   int ijk_ispec;\n\
   int iglob;\n\
   ispec = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     ijk_ispec = get_local_id(0) + (NGLL3) * (ispec);\n\
     iglob = ibool[ijk_ispec - (0)] - (1);\n\
     rho_kl[ijk_ispec - (0)] = rho_kl[ijk_ispec - (0)] + (deltat) * ((accel[0 - (0) + (iglob - (0)) * (3)]) * (b_displ[0 - (0) + (iglob - (0)) * (3)]) + (accel[1 - (0) + (iglob - (0)) * (3)]) * (b_displ[1 - (0) + (iglob - (0)) * (3)]) + (accel[2 - (0) + (iglob - (0)) * (3)]) * (b_displ[2 - (0) + (iglob - (0)) * (3)]));\n\

--- a/src/gpu/kernels.gen/compute_stacey_acoustic_backward_kernel.cu
+++ b/src/gpu/kernels.gen/compute_stacey_acoustic_backward_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -94,62 +94,62 @@ __global__ void compute_stacey_acoustic_backward_kernel(float * b_potential_dot_
   int ispec;
   igll = threadIdx.x;
   iface = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(iface < num_abs_boundary_faces){
+  if (iface < num_abs_boundary_faces) {
     ispec = abs_boundary_ispec[iface - (0)] - (1);
-    switch(interface_type){
+    switch (interface_type) {
       case 4 :
-        if(nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0){
+        if (nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0) {
            return ;
         }
         i = 0;
         k = (igll) / (NGLLX);
         j = igll - ((k) * (NGLLX));
-        if(k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > njmax[INDEX2(2, 0, iface) - (0)] - (1)){
+        if (j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > njmax[INDEX2(2, 0, iface) - (0)] - (1)) {
            return ;
         }
         break;
       case 5 :
-        if(nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0){
+        if (nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0) {
            return ;
         }
         i = NGLLX - (1);
         k = (igll) / (NGLLX);
         j = igll - ((k) * (NGLLX));
-        if(k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)){
+        if (j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)) {
            return ;
         }
         break;
       case 6 :
-        if(nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0){
+        if (nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0) {
            return ;
         }
         j = 0;
         k = (igll) / (NGLLX);
         i = igll - ((k) * (NGLLX));
-        if(k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)){
+        if (i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)) {
            return ;
         }
         break;
       case 7 :
-        if(nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0){
+        if (nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0) {
            return ;
         }
         j = NGLLX - (1);
         k = (igll) / (NGLLX);
         i = igll - ((k) * (NGLLX));
-        if(k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)){
+        if (i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)) {
            return ;
         }
         break;
@@ -157,10 +157,10 @@ __global__ void compute_stacey_acoustic_backward_kernel(float * b_potential_dot_
         k = 0;
         j = (igll) / (NGLLX);
         i = igll - ((j) * (NGLLX));
-        if(j < 0 || j > NGLLX - (1)){
+        if (j < 0 || j > NGLLX - (1)) {
            return ;
         }
-        if(i < 0 || i > NGLLX - (1)){
+        if (i < 0 || i > NGLLX - (1)) {
            return ;
         }
         break;

--- a/src/gpu/kernels.gen/compute_stacey_acoustic_backward_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_stacey_acoustic_backward_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -105,62 +105,62 @@ __kernel void compute_stacey_acoustic_backward_kernel(__global float * b_potenti
   int ispec;\n\
   igll = get_local_id(0);\n\
   iface = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(iface < num_abs_boundary_faces){\n\
+  if (iface < num_abs_boundary_faces) {\n\
     ispec = abs_boundary_ispec[iface - (0)] - (1);\n\
-    switch(interface_type){\n\
+    switch (interface_type) {\n\
       case 4 :\n\
-        if(nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0){\n\
+        if (nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         i = 0;\n\
         k = (igll) / (NGLLX);\n\
         j = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > njmax[INDEX2(2, 0, iface) - (0)] - (1)){\n\
+        if (j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > njmax[INDEX2(2, 0, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\
       case 5 :\n\
-        if(nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0){\n\
+        if (nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         i = NGLLX - (1);\n\
         k = (igll) / (NGLLX);\n\
         j = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)){\n\
+        if (j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\
       case 6 :\n\
-        if(nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0){\n\
+        if (nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         j = 0;\n\
         k = (igll) / (NGLLX);\n\
         i = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)){\n\
+        if (i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\
       case 7 :\n\
-        if(nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0){\n\
+        if (nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         j = NGLLX - (1);\n\
         k = (igll) / (NGLLX);\n\
         i = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)){\n\
+        if (i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\
@@ -168,10 +168,10 @@ __kernel void compute_stacey_acoustic_backward_kernel(__global float * b_potenti
         k = 0;\n\
         j = (igll) / (NGLLX);\n\
         i = igll - ((j) * (NGLLX));\n\
-        if(j < 0 || j > NGLLX - (1)){\n\
+        if (j < 0 || j > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < 0 || i > NGLLX - (1)){\n\
+        if (i < 0 || i > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\

--- a/src/gpu/kernels.gen/compute_stacey_acoustic_kernel.cu
+++ b/src/gpu/kernels.gen/compute_stacey_acoustic_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -97,65 +97,65 @@ __global__ void compute_stacey_acoustic_kernel(const float * potential_dot_acous
   float fac1;
   igll = threadIdx.x;
   iface = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(iface < num_abs_boundary_faces){
+  if (iface < num_abs_boundary_faces) {
     ispec = abs_boundary_ispec[iface - (0)] - (1);
-    switch(interface_type){
+    switch (interface_type) {
       case 4 :
-        if(nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0){
+        if (nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0) {
            return ;
         }
         i = 0;
         k = (igll) / (NGLLX);
         j = igll - ((k) * (NGLLX));
-        if(k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > njmax[INDEX2(2, 0, iface) - (0)] - (1)){
+        if (j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > njmax[INDEX2(2, 0, iface) - (0)] - (1)) {
            return ;
         }
         fac1 = wgllwgll[(k) * (NGLLX) + j - (0)];
         break;
       case 5 :
-        if(nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0){
+        if (nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0) {
            return ;
         }
         i = NGLLX - (1);
         k = (igll) / (NGLLX);
         j = igll - ((k) * (NGLLX));
-        if(k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)){
+        if (j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)) {
            return ;
         }
         fac1 = wgllwgll[(k) * (NGLLX) + j - (0)];
         break;
       case 6 :
-        if(nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0){
+        if (nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0) {
            return ;
         }
         j = 0;
         k = (igll) / (NGLLX);
         i = igll - ((k) * (NGLLX));
-        if(k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)){
+        if (i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)) {
            return ;
         }
         fac1 = wgllwgll[(k) * (NGLLX) + i - (0)];
         break;
       case 7 :
-        if(nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0){
+        if (nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0) {
            return ;
         }
         j = NGLLX - (1);
         k = (igll) / (NGLLX);
         i = igll - ((k) * (NGLLX));
-        if(k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)){
+        if (i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)) {
            return ;
         }
         fac1 = wgllwgll[(k) * (NGLLX) + i - (0)];
@@ -164,10 +164,10 @@ __global__ void compute_stacey_acoustic_kernel(const float * potential_dot_acous
         k = 0;
         j = (igll) / (NGLLX);
         i = igll - ((j) * (NGLLX));
-        if(j < 0 || j > NGLLX - (1)){
+        if (j < 0 || j > NGLLX - (1)) {
            return ;
         }
-        if(i < 0 || i > NGLLX - (1)){
+        if (i < 0 || i > NGLLX - (1)) {
            return ;
         }
         fac1 = wgllwgll[(j) * (NGLLX) + i - (0)];
@@ -177,7 +177,7 @@ __global__ void compute_stacey_acoustic_kernel(const float * potential_dot_acous
     sn = (potential_dot_acoustic[iglob - (0)]) / (vpstore[INDEX4(NGLLX, NGLLX, NGLLX, i, j, k, ispec) - (0)]);
     jacobianw = (abs_boundary_jacobian2D[INDEX2(NGLL2, igll, iface) - (0)]) * (fac1);
     atomicAdd(potential_dot_dot_acoustic + iglob, ( -(sn)) * (jacobianw));
-    if(SAVE_FORWARD){
+    if (SAVE_FORWARD) {
       b_absorb_potential[INDEX2(NGLL2, igll, iface) - (0)] = (sn) * (jacobianw);
     }
   }

--- a/src/gpu/kernels.gen/compute_stacey_acoustic_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_stacey_acoustic_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -108,65 +108,65 @@ __kernel void compute_stacey_acoustic_kernel(const __global float * potential_do
   float fac1;\n\
   igll = get_local_id(0);\n\
   iface = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(iface < num_abs_boundary_faces){\n\
+  if (iface < num_abs_boundary_faces) {\n\
     ispec = abs_boundary_ispec[iface - (0)] - (1);\n\
-    switch(interface_type){\n\
+    switch (interface_type) {\n\
       case 4 :\n\
-        if(nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0){\n\
+        if (nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         i = 0;\n\
         k = (igll) / (NGLLX);\n\
         j = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > njmax[INDEX2(2, 0, iface) - (0)] - (1)){\n\
+        if (j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > njmax[INDEX2(2, 0, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(k) * (NGLLX) + j - (0)];\n\
         break;\n\
       case 5 :\n\
-        if(nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0){\n\
+        if (nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         i = NGLLX - (1);\n\
         k = (igll) / (NGLLX);\n\
         j = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)){\n\
+        if (j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(k) * (NGLLX) + j - (0)];\n\
         break;\n\
       case 6 :\n\
-        if(nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0){\n\
+        if (nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         j = 0;\n\
         k = (igll) / (NGLLX);\n\
         i = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)){\n\
+        if (i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(k) * (NGLLX) + i - (0)];\n\
         break;\n\
       case 7 :\n\
-        if(nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0){\n\
+        if (nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         j = NGLLX - (1);\n\
         k = (igll) / (NGLLX);\n\
         i = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)){\n\
+        if (i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(k) * (NGLLX) + i - (0)];\n\
@@ -175,10 +175,10 @@ __kernel void compute_stacey_acoustic_kernel(const __global float * potential_do
         k = 0;\n\
         j = (igll) / (NGLLX);\n\
         i = igll - ((j) * (NGLLX));\n\
-        if(j < 0 || j > NGLLX - (1)){\n\
+        if (j < 0 || j > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < 0 || i > NGLLX - (1)){\n\
+        if (i < 0 || i > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(j) * (NGLLX) + i - (0)];\n\
@@ -188,7 +188,7 @@ __kernel void compute_stacey_acoustic_kernel(const __global float * potential_do
     sn = (potential_dot_acoustic[iglob - (0)]) / (vpstore[INDEX4(NGLLX, NGLLX, NGLLX, i, j, k, ispec) - (0)]);\n\
     jacobianw = (abs_boundary_jacobian2D[INDEX2(NGLL2, igll, iface) - (0)]) * (fac1);\n\
     atomicAdd(potential_dot_dot_acoustic + iglob, ( -(sn)) * (jacobianw));\n\
-    if(SAVE_FORWARD){\n\
+    if (SAVE_FORWARD) {\n\
       b_absorb_potential[INDEX2(NGLL2, igll, iface) - (0)] = (sn) * (jacobianw);\n\
     }\n\
   }\n\

--- a/src/gpu/kernels.gen/compute_stacey_elastic_backward_kernel.cu
+++ b/src/gpu/kernels.gen/compute_stacey_elastic_backward_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -94,62 +94,62 @@ __global__ void compute_stacey_elastic_backward_kernel(float * b_accel, const fl
   int ispec;
   igll = threadIdx.x;
   iface = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(iface < num_abs_boundary_faces){
+  if (iface < num_abs_boundary_faces) {
     ispec = abs_boundary_ispec[iface - (0)] - (1);
-    switch(interface_type){
+    switch (interface_type) {
       case 0 :
-        if(nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0){
+        if (nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0) {
            return ;
         }
         i = 0;
         k = (igll) / (NGLLX);
         j = igll - ((k) * (NGLLX));
-        if(k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > NGLLX - (1)){
+        if (j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > NGLLX - (1)) {
            return ;
         }
         break;
       case 1 :
-        if(nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0){
+        if (nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0) {
            return ;
         }
         i = NGLLX - (1);
         k = (igll) / (NGLLX);
         j = igll - ((k) * (NGLLX));
-        if(k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)){
+        if (j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)) {
            return ;
         }
         break;
       case 2 :
-        if(nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0){
+        if (nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0) {
            return ;
         }
         j = 0;
         k = (igll) / (NGLLX);
         i = igll - ((k) * (NGLLX));
-        if(k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)){
+        if (i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)) {
            return ;
         }
         break;
       case 3 :
-        if(nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0){
+        if (nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0) {
            return ;
         }
         j = NGLLX - (1);
         k = (igll) / (NGLLX);
         i = igll - ((k) * (NGLLX));
-        if(k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)){
+        if (i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)) {
            return ;
         }
         break;

--- a/src/gpu/kernels.gen/compute_stacey_elastic_backward_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_stacey_elastic_backward_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -105,62 +105,62 @@ __kernel void compute_stacey_elastic_backward_kernel(__global float * b_accel, c
   int ispec;\n\
   igll = get_local_id(0);\n\
   iface = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(iface < num_abs_boundary_faces){\n\
+  if (iface < num_abs_boundary_faces) {\n\
     ispec = abs_boundary_ispec[iface - (0)] - (1);\n\
-    switch(interface_type){\n\
+    switch (interface_type) {\n\
       case 0 :\n\
-        if(nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0){\n\
+        if (nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         i = 0;\n\
         k = (igll) / (NGLLX);\n\
         j = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > NGLLX - (1)){\n\
+        if (j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\
       case 1 :\n\
-        if(nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0){\n\
+        if (nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         i = NGLLX - (1);\n\
         k = (igll) / (NGLLX);\n\
         j = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)){\n\
+        if (j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\
       case 2 :\n\
-        if(nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0){\n\
+        if (nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         j = 0;\n\
         k = (igll) / (NGLLX);\n\
         i = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)){\n\
+        if (i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\
       case 3 :\n\
-        if(nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0){\n\
+        if (nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         j = NGLLX - (1);\n\
         k = (igll) / (NGLLX);\n\
         i = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)){\n\
+        if (i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         break;\n\

--- a/src/gpu/kernels.gen/compute_stacey_elastic_kernel.cu
+++ b/src/gpu/kernels.gen/compute_stacey_elastic_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -108,65 +108,65 @@ __global__ void compute_stacey_elastic_kernel(const float * veloc, float * accel
   float fac1;
   igll = threadIdx.x;
   iface = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(iface < num_abs_boundary_faces){
+  if (iface < num_abs_boundary_faces) {
     ispec = abs_boundary_ispec[iface - (0)] - (1);
-    switch(interface_type){
+    switch (interface_type) {
       case 0 :
-        if(nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0){
+        if (nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0) {
            return ;
         }
         i = 0;
         k = (igll) / (NGLLX);
         j = igll - ((k) * (NGLLX));
-        if(k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > NGLLX - (1)){
+        if (j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > NGLLX - (1)) {
            return ;
         }
         fac1 = wgllwgll[(k) * (NGLLX) + j - (0)];
         break;
       case 1 :
-        if(nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0){
+        if (nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0) {
            return ;
         }
         i = NGLLX - (1);
         k = (igll) / (NGLLX);
         j = igll - ((k) * (NGLLX));
-        if(k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)){
+        if (j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)) {
            return ;
         }
         fac1 = wgllwgll[(k) * (NGLLX) + j - (0)];
         break;
       case 2 :
-        if(nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0){
+        if (nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0) {
            return ;
         }
         j = 0;
         k = (igll) / (NGLLX);
         i = igll - ((k) * (NGLLX));
-        if(k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)){
+        if (i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)) {
            return ;
         }
         fac1 = wgllwgll[(k) * (NGLLX) + i - (0)];
         break;
       case 3 :
-        if(nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0){
+        if (nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0) {
            return ;
         }
         j = NGLLX - (1);
         k = (igll) / (NGLLX);
         i = igll - ((k) * (NGLLX));
-        if(k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){
+        if (k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {
            return ;
         }
-        if(i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)){
+        if (i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)) {
            return ;
         }
         fac1 = wgllwgll[(k) * (NGLLX) + i - (0)];
@@ -189,7 +189,7 @@ __global__ void compute_stacey_elastic_kernel(const float * veloc, float * accel
     atomicAdd(accel + (iglob) * (3) + 0, ( -(tx)) * (jacobianw));
     atomicAdd(accel + (iglob) * (3) + 1, ( -(ty)) * (jacobianw));
     atomicAdd(accel + (iglob) * (3) + 2, ( -(tz)) * (jacobianw));
-    if(SAVE_FORWARD){
+    if (SAVE_FORWARD) {
       b_absorb_field[INDEX3(NDIM, NGLL2, 0, igll, iface) - (0)] = (tx) * (jacobianw);
       b_absorb_field[INDEX3(NDIM, NGLL2, 1, igll, iface) - (0)] = (ty) * (jacobianw);
       b_absorb_field[INDEX3(NDIM, NGLL2, 2, igll, iface) - (0)] = (tz) * (jacobianw);

--- a/src/gpu/kernels.gen/compute_stacey_elastic_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_stacey_elastic_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -119,65 +119,65 @@ __kernel void compute_stacey_elastic_kernel(const __global float * veloc, __glob
   float fac1;\n\
   igll = get_local_id(0);\n\
   iface = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(iface < num_abs_boundary_faces){\n\
+  if (iface < num_abs_boundary_faces) {\n\
     ispec = abs_boundary_ispec[iface - (0)] - (1);\n\
-    switch(interface_type){\n\
+    switch (interface_type) {\n\
       case 0 :\n\
-        if(nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0){\n\
+        if (nkmin_xi[INDEX2(2, 0, iface) - (0)] == 0 || njmin[INDEX2(2, 0, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         i = 0;\n\
         k = (igll) / (NGLLX);\n\
         j = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_xi[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > NGLLX - (1)){\n\
+        if (j < njmin[INDEX2(2, 0, iface) - (0)] - (1) || j > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(k) * (NGLLX) + j - (0)];\n\
         break;\n\
       case 1 :\n\
-        if(nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0){\n\
+        if (nkmin_xi[INDEX2(2, 1, iface) - (0)] == 0 || njmin[INDEX2(2, 1, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         i = NGLLX - (1);\n\
         k = (igll) / (NGLLX);\n\
         j = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_xi[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)){\n\
+        if (j < njmin[INDEX2(2, 1, iface) - (0)] - (1) || j > njmax[INDEX2(2, 1, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(k) * (NGLLX) + j - (0)];\n\
         break;\n\
       case 2 :\n\
-        if(nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0){\n\
+        if (nkmin_eta[INDEX2(2, 0, iface) - (0)] == 0 || nimin[INDEX2(2, 0, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         j = 0;\n\
         k = (igll) / (NGLLX);\n\
         i = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_eta[INDEX2(2, 0, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)){\n\
+        if (i < nimin[INDEX2(2, 0, iface) - (0)] - (1) || i > nimax[INDEX2(2, 0, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(k) * (NGLLX) + i - (0)];\n\
         break;\n\
       case 3 :\n\
-        if(nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0){\n\
+        if (nkmin_eta[INDEX2(2, 1, iface) - (0)] == 0 || nimin[INDEX2(2, 1, iface) - (0)] == 0) {\n\
            return ;\n\
         }\n\
         j = NGLLX - (1);\n\
         k = (igll) / (NGLLX);\n\
         i = igll - ((k) * (NGLLX));\n\
-        if(k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)){\n\
+        if (k < nkmin_eta[INDEX2(2, 1, iface) - (0)] - (1) || k > NGLLX - (1)) {\n\
            return ;\n\
         }\n\
-        if(i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)){\n\
+        if (i < nimin[INDEX2(2, 1, iface) - (0)] - (1) || i > nimax[INDEX2(2, 1, iface) - (0)] - (1)) {\n\
            return ;\n\
         }\n\
         fac1 = wgllwgll[(k) * (NGLLX) + i - (0)];\n\
@@ -200,7 +200,7 @@ __kernel void compute_stacey_elastic_kernel(const __global float * veloc, __glob
     atomicAdd(accel + (iglob) * (3) + 0, ( -(tx)) * (jacobianw));\n\
     atomicAdd(accel + (iglob) * (3) + 1, ( -(ty)) * (jacobianw));\n\
     atomicAdd(accel + (iglob) * (3) + 2, ( -(tz)) * (jacobianw));\n\
-    if(SAVE_FORWARD){\n\
+    if (SAVE_FORWARD) {\n\
       b_absorb_field[INDEX3(NDIM, NGLL2, 0, igll, iface) - (0)] = (tx) * (jacobianw);\n\
       b_absorb_field[INDEX3(NDIM, NGLL2, 1, igll, iface) - (0)] = (ty) * (jacobianw);\n\
       b_absorb_field[INDEX3(NDIM, NGLL2, 2, igll, iface) - (0)] = (tz) * (jacobianw);\n\

--- a/src/gpu/kernels.gen/compute_strain_kernel.cu
+++ b/src/gpu/kernels.gen/compute_strain_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -135,7 +135,7 @@ static __device__ void compute_element_strain_undo_att(const int ispec, const in
   tempz1l = 0.0f;
   tempz2l = 0.0f;
   tempz3l = 0.0f;
-  for(l=0; l<=NGLLX - (1); l+=1){
+  for (l = 0; l <= NGLLX - (1); l += 1) {
     fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];
     tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
     tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
@@ -190,19 +190,19 @@ __global__ void compute_strain_kernel(const float * d_displ, const float * d_vel
   ispec = blockIdx.x + (blockIdx.y) * (gridDim.x);
   ijk_ispec = threadIdx.x + (NGLL3) * (ispec);
   tx = threadIdx.x;
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
     sh_hprime_xx[tx - (0)] = d_hprime_xx[tx - (0)];
   }
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     iglob = d_ibool[ijk_ispec - (0)] - (1);
     s_dummyx_loc[tx - (0)] = d_displ[0 - (0) + (iglob - (0)) * (3)] + (deltat) * (d_veloc[0 - (0) + (iglob - (0)) * (3)]);
     s_dummyy_loc[tx - (0)] = d_displ[1 - (0) + (iglob - (0)) * (3)] + (deltat) * (d_veloc[1 - (0) + (iglob - (0)) * (3)]);
     s_dummyz_loc[tx - (0)] = d_displ[2 - (0) + (iglob - (0)) * (3)] + (deltat) * (d_veloc[2 - (0) + (iglob - (0)) * (3)]);
   }
   __syncthreads();
-  if(ispec < NSPEC){
+  if (ispec < NSPEC) {
     compute_element_strain_undo_att(ispec, ijk_ispec, d_ibool, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc, d_xix, d_xiy, d_xiz, d_etax, d_etay, d_etaz, d_gammax, d_gammay, d_gammaz, sh_hprime_xx, epsdev,  &eps_trace_over_3);
-    if(NSPEC_STRAIN_ONLY == 1){
+    if (NSPEC_STRAIN_ONLY == 1) {
       epsilon_trace_over_3[tx - (0)] = eps_trace_over_3;
     } else {
       epsilon_trace_over_3[ijk_ispec - (0)] = eps_trace_over_3;

--- a/src/gpu/kernels.gen/compute_strain_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_strain_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -146,7 +146,7 @@ static void compute_element_strain_undo_att(const int ispec, const int ijk_ispec
   tempz1l = 0.0f;\n\
   tempz2l = 0.0f;\n\
   tempz3l = 0.0f;\n\
-  for(l=0; l<=NGLLX - (1); l+=1){\n\
+  for (l = 0; l <= NGLLX - (1); l += 1) {\n\
     fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];\n\
     tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
     tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
@@ -201,19 +201,19 @@ __kernel void compute_strain_kernel(const __global float * d_displ, const __glob
   ispec = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
   ijk_ispec = get_local_id(0) + (NGLL3) * (ispec);\n\
   tx = get_local_id(0);\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
     sh_hprime_xx[tx - (0)] = d_hprime_xx[tx - (0)];\n\
   }\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     iglob = d_ibool[ijk_ispec - (0)] - (1);\n\
     s_dummyx_loc[tx - (0)] = d_displ[0 - (0) + (iglob - (0)) * (3)] + (deltat) * (d_veloc[0 - (0) + (iglob - (0)) * (3)]);\n\
     s_dummyy_loc[tx - (0)] = d_displ[1 - (0) + (iglob - (0)) * (3)] + (deltat) * (d_veloc[1 - (0) + (iglob - (0)) * (3)]);\n\
     s_dummyz_loc[tx - (0)] = d_displ[2 - (0) + (iglob - (0)) * (3)] + (deltat) * (d_veloc[2 - (0) + (iglob - (0)) * (3)]);\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(ispec < NSPEC){\n\
+  if (ispec < NSPEC) {\n\
     compute_element_strain_undo_att(ispec, ijk_ispec, d_ibool, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc, d_xix, d_xiy, d_xiz, d_etax, d_etay, d_etaz, d_gammax, d_gammay, d_gammaz, sh_hprime_xx, epsdev,  &eps_trace_over_3);\n\
-    if(NSPEC_STRAIN_ONLY == 1){\n\
+    if (NSPEC_STRAIN_ONLY == 1) {\n\
       epsilon_trace_over_3[tx - (0)] = eps_trace_over_3;\n\
     } else {\n\
       epsilon_trace_over_3[ijk_ispec - (0)] = eps_trace_over_3;\n\

--- a/src/gpu/kernels.gen/compute_strength_noise_kernel.cu
+++ b/src/gpu/kernels.gen/compute_strength_noise_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -95,7 +95,7 @@ __global__ void compute_strength_noise_kernel(const float * displ, const int * i
   int iglob;
   float eta;
   iface = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(iface < nspec_top){
+  if (iface < nspec_top) {
     ispec = ibelm_top[iface - (0)] - (1);
     igll = threadIdx.x;
     ipoin = igll + (NGLL2) * (iface);

--- a/src/gpu/kernels.gen/compute_strength_noise_kernel_cl.c
+++ b/src/gpu/kernels.gen/compute_strength_noise_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -106,7 +106,7 @@ __kernel void compute_strength_noise_kernel(const __global float * displ, const 
   int iglob;\n\
   float eta;\n\
   iface = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(iface < nspec_top){\n\
+  if (iface < nspec_top) {\n\
     ispec = ibelm_top[iface - (0)] - (1);\n\
     igll = get_local_id(0);\n\
     ipoin = igll + (NGLL2) * (iface);\n\

--- a/src/gpu/kernels.gen/crust_mantle_impl_kernel_adjoint.cu
+++ b/src/gpu/kernels.gen/crust_mantle_impl_kernel_adjoint.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -89,7 +89,7 @@ static __device__ void compute_element_cm_att_stress(const int tx, const int wor
   int i_sls;
   float R_xx_val;
   float R_yy_val;
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));
     R_xx_val = R_xx[offset - (0)];
     R_yy_val = R_yy[offset - (0)];
@@ -111,14 +111,14 @@ static __device__ void compute_element_cm_att_memory(const int tx, const int wor
   float factor_loc;
   float sn;
   float snp1;
-  if(ANISOTROPY){
+  if (ANISOTROPY) {
     mul = d_c44store[tx + (NGLL3_PADDED) * (working_element) - (0)];
   } else {
     mul = d_muv[tx + (NGLL3_PADDED) * (working_element) - (0)];
   }
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));
-    if(USE_3D_ATTENUATION_ARRAYS){
+    if (USE_3D_ATTENUATION_ARRAYS) {
       factor_loc = (mul) * (factor_common[offset - (0)]);
     } else {
       factor_loc = (mul) * (factor_common[i_sls + (N_SLS) * (working_element) - (0)]);
@@ -175,7 +175,7 @@ static __device__ void compute_element_cm_gravity(const int tx, const int iglob,
   float factor;
   int int_radius;
   radius = d_xstore[iglob - (0)];
-  if(radius < 1.5696123057604773e-05f){
+  if (radius < 1.5696123057604773e-05f) {
     radius = 1.5696123057604773e-05f;
   }
   theta = d_ystore[iglob - (0)];
@@ -183,7 +183,7 @@ static __device__ void compute_element_cm_gravity(const int tx, const int iglob,
   sincosf(theta,  &sin_theta,  &cos_theta);
   sincosf(phi,  &sin_phi,  &cos_phi);
   int_radius = rint(((radius) * (6371.0f)) * (10.0f)) - (1);
-  if(int_radius < 0){
+  if (int_radius < 0) {
     int_radius = 0;
   }
   minus_g = d_minus_gravity_table[int_radius - (0)];
@@ -266,7 +266,7 @@ static __device__ void compute_element_cm_aniso(const int offset, const float * 
   c55 = d_c55store[offset - (0)];
   c56 = d_c56store[offset - (0)];
   c66 = d_c66store[offset - (0)];
-  if(ATTENUATION){
+  if (ATTENUATION) {
     minus_sum_beta = one_minus_sum_beta_use - (1.0f);
     mul = (c44) * (minus_sum_beta);
     c11 = c11 + (mul) * (1.3333333333333333f);
@@ -293,7 +293,7 @@ static __device__ void compute_element_cm_iso(const int offset, const float * d_
   float kappal;
   kappal = d_kappavstore[offset - (0)];
   mul = d_muvstore[offset - (0)];
-  if(ATTENUATION){
+  if (ATTENUATION) {
     mul = (mul) * (one_minus_sum_beta_use);
   }
   lambdalplus2mul = kappal + (mul) * (1.3333333333333333f);
@@ -372,7 +372,7 @@ static __device__ void compute_element_cm_tiso(const int offset, const float * d
   muvl = d_muvstore[offset - (0)];
   kappahl = d_kappahstore[offset - (0)];
   muhl = d_muhstore[offset - (0)];
-  if(ATTENUATION){
+  if (ATTENUATION) {
     muvl = (muvl) * (one_minus_sum_beta_use);
     muhl = (muhl) * (one_minus_sum_beta_use);
   }
@@ -533,11 +533,11 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
   J = (tx - ((K) * (NGLL2))) / (NGLLX);
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);
-  if(active){
+  if (active) {
 #ifdef USE_MESH_COLORING_GPU
     working_element = bx;
 #else
-    if(use_mesh_coloring_gpu){
+    if (use_mesh_coloring_gpu) {
       working_element = bx;
     } else {
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);
@@ -554,7 +554,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     s_dummyz_loc[tx - (0)] = d_displ[2 - (0) + (iglob - (0)) * (3)];
 #endif
   }
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
 #ifdef USE_TEXTURES_CONSTANTS
     sh_hprime_xx[tx - (0)] = tex1Dfetch(d_hprime_xx_tex,tx);
     sh_hprimewgll_xx[tx - (0)] = tex1Dfetch(d_hprimewgll_xx_tex,tx);
@@ -564,7 +564,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
 #endif
   }
   __syncthreads();
-  if(active){
+  if (active) {
     tempx1l = 0.0f;
     tempx2l = 0.0f;
     tempx3l = 0.0f;
@@ -636,7 +636,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     tempy3l = tempy3l + (s_dummyy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);
     tempz3l = tempz3l + (s_dummyz_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];
       tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
       tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
@@ -676,43 +676,43 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     duxdyl_plus_duydxl = duxdyl + duydxl;
     duzdxl_plus_duxdzl = duzdxl + duxdzl;
     duzdyl_plus_duydzl = duzdyl + duydzl;
-    if(COMPUTE_AND_STORE_STRAIN){
+    if (COMPUTE_AND_STORE_STRAIN) {
       templ = (duxdxl + duydyl + duzdzl) * (0.3333333333333333f);
       epsilondev_xx_loc = duxdxl - (templ);
       epsilondev_yy_loc = duydyl - (templ);
       epsilondev_xy_loc = (duxdyl_plus_duydxl) * (0.5f);
       epsilondev_xz_loc = (duzdxl_plus_duxdzl) * (0.5f);
       epsilondev_yz_loc = (duzdyl_plus_duydzl) * (0.5f);
-      if(NSPEC_CRUST_MANTLE_STRAIN_ONLY == 1){
+      if (NSPEC_CRUST_MANTLE_STRAIN_ONLY == 1) {
         epsilon_trace_over_3[tx - (0)] = templ;
       } else {
         epsilon_trace_over_3[tx + (working_element) * (NGLL3) - (0)] = templ;
       }
     }
-    if(ATTENUATION){
-      if(USE_3D_ATTENUATION_ARRAYS){
+    if (ATTENUATION) {
+      if (USE_3D_ATTENUATION_ARRAYS) {
         one_minus_sum_beta_use = one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)];
       } else {
         one_minus_sum_beta_use = one_minus_sum_beta[working_element - (0)];
       }
     }
-    if(ANISOTROPY){
+    if (ANISOTROPY) {
       compute_element_cm_aniso(offset, d_c11store, d_c12store, d_c13store, d_c14store, d_c15store, d_c16store, d_c22store, d_c23store, d_c24store, d_c25store, d_c26store, d_c33store, d_c34store, d_c35store, d_c36store, d_c44store, d_c45store, d_c46store, d_c55store, d_c56store, d_c66store, ATTENUATION, one_minus_sum_beta_use, duxdxl, duxdyl, duxdzl, duydxl, duydyl, duydzl, duzdxl, duzdyl, duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
     } else {
-      if( ! d_ispec_is_tiso[working_element - (0)]){
+      if ( ! d_ispec_is_tiso[working_element - (0)]) {
         compute_element_cm_iso(offset, d_kappavstore, d_muvstore, ATTENUATION, one_minus_sum_beta_use, duxdxl, duydyl, duzdzl, duxdxl_plus_duydyl, duxdxl_plus_duzdzl, duydyl_plus_duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
       } else {
         compute_element_cm_tiso(offset, d_kappavstore, d_muvstore, d_kappahstore, d_muhstore, d_eta_anisostore, ATTENUATION, one_minus_sum_beta_use, duxdxl, duxdyl, duxdzl, duydxl, duydyl, duydzl, duzdxl, duzdyl, duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl, iglob, d_ystore, d_zstore,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
       }
     }
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {
       compute_element_cm_att_stress(tx, working_element, R_xx, R_yy, R_xy, R_xz, R_yz,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
     }
     sigma_yx = sigma_xy;
     sigma_zx = sigma_xz;
     sigma_zy = sigma_yz;
     jacobianl = (1.0f) / ((xixl) * ((etayl) * (gammazl) - ((etazl) * (gammayl))) - ((xiyl) * ((etaxl) * (gammazl) - ((etazl) * (gammaxl)))) + (xizl) * ((etaxl) * (gammayl) - ((etayl) * (gammaxl))));
-    if(GRAVITY){
+    if (GRAVITY) {
       compute_element_cm_gravity(tx, iglob, d_xstore, d_ystore, d_zstore, d_minus_gravity_table, d_minus_deriv_gravity_table, d_density_table, wgll_cube, jacobianl, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_yx,  &sigma_xz,  &sigma_zx,  &sigma_yz,  &sigma_zy,  &rho_s_H1,  &rho_s_H2,  &rho_s_H3);
     }
     s_tempx1[tx - (0)] = (jacobianl) * ((sigma_xx) * (xixl) + (sigma_yx) * (xiyl) + (sigma_zx) * (xizl));
@@ -726,7 +726,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     s_tempz3[tx - (0)] = (jacobianl) * ((sigma_xz) * (gammaxl) + (sigma_yz) * (gammayl) + (sigma_zz) * (gammazl));
   }
   __syncthreads();
-  if(active){
+  if (active) {
     tempx1l = 0.0f;
     tempx2l = 0.0f;
     tempx3l = 0.0f;
@@ -813,7 +813,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     tempy3l = tempy3l + (s_tempy3[offset - (0)]) * (fac3);
     tempz3l = tempz3l + (s_tempz3[offset - (0)]) * (fac3);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       fac1 = sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)];
       offset = (K) * (NGLL2) + (J) * (NGLLX) + l;
       tempx1l = tempx1l + (s_tempx1[offset - (0)]) * (fac1);
@@ -837,7 +837,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     sum_terms1 =  -((fac1) * (tempx1l) + (fac2) * (tempx2l) + (fac3) * (tempx3l));
     sum_terms2 =  -((fac1) * (tempy1l) + (fac2) * (tempy2l) + (fac3) * (tempy3l));
     sum_terms3 =  -((fac1) * (tempz1l) + (fac2) * (tempz2l) + (fac3) * (tempz3l));
-    if(GRAVITY){
+    if (GRAVITY) {
       sum_terms1 = sum_terms1 + rho_s_H1;
       sum_terms2 = sum_terms2 + rho_s_H2;
       sum_terms3 = sum_terms3 + rho_s_H3;
@@ -853,7 +853,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     d_accel[2 - (0) + (iglob - (0)) * (3)] = d_accel[2 - (0) + (iglob - (0)) * (3)] + sum_terms3;
 #endif
 #else
-    if(use_mesh_coloring_gpu){
+    if (use_mesh_coloring_gpu) {
 #ifdef USE_TEXTURES_FIELDS
       d_accel[0 - (0) + (iglob - (0)) * (3)] = tex1Dfetch(d_b_accel_cm_tex,(iglob) * (3) + 0) + sum_terms1;
       d_accel[1 - (0) + (iglob - (0)) * (3)] = tex1Dfetch(d_b_accel_cm_tex,(iglob) * (3) + 1) + sum_terms2;
@@ -869,10 +869,10 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
       atomicAdd(d_accel + (iglob) * (3) + 2, sum_terms3);
     }
 #endif
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {
       compute_element_cm_att_memory(tx, working_element, d_muvstore, factor_common, alphaval, betaval, gammaval, R_xx, R_yy, R_xy, R_xz, R_yz, epsilondev_xx, epsilondev_yy, epsilondev_xy, epsilondev_xz, epsilondev_yz, epsilondev_xx_loc, epsilondev_yy_loc, epsilondev_xy_loc, epsilondev_xz_loc, epsilondev_yz_loc, d_c44store, ANISOTROPY, USE_3D_ATTENUATION_ARRAYS);
     }
-    if(COMPUTE_AND_STORE_STRAIN){
+    if (COMPUTE_AND_STORE_STRAIN) {
       epsilondev_xx[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xx_loc;
       epsilondev_yy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_yy_loc;
       epsilondev_xy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xy_loc;

--- a/src/gpu/kernels.gen/crust_mantle_impl_kernel_adjoint_cl.c
+++ b/src/gpu/kernels.gen/crust_mantle_impl_kernel_adjoint_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -100,7 +100,7 @@ static void compute_element_cm_att_stress(const int tx, const int working_elemen
   int i_sls;\n\
   float R_xx_val;\n\
   float R_yy_val;\n\
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){\n\
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {\n\
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));\n\
     R_xx_val = R_xx[offset - (0)];\n\
     R_yy_val = R_yy[offset - (0)];\n\
@@ -122,14 +122,14 @@ static void compute_element_cm_att_memory(const int tx, const int working_elemen
   float factor_loc;\n\
   float sn;\n\
   float snp1;\n\
-  if(ANISOTROPY){\n\
+  if (ANISOTROPY) {\n\
     mul = d_c44store[tx + (NGLL3_PADDED) * (working_element) - (0)];\n\
   } else {\n\
     mul = d_muv[tx + (NGLL3_PADDED) * (working_element) - (0)];\n\
   }\n\
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){\n\
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {\n\
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));\n\
-    if(USE_3D_ATTENUATION_ARRAYS){\n\
+    if (USE_3D_ATTENUATION_ARRAYS) {\n\
       factor_loc = (mul) * (factor_common[offset - (0)]);\n\
     } else {\n\
       factor_loc = (mul) * (factor_common[i_sls + (N_SLS) * (working_element) - (0)]);\n\
@@ -186,7 +186,7 @@ static void compute_element_cm_gravity(const int tx, const int iglob, const __gl
   float factor;\n\
   int int_radius;\n\
   radius = d_xstore[iglob - (0)];\n\
-  if(radius < 1.5696123057604773e-05f){\n\
+  if (radius < 1.5696123057604773e-05f) {\n\
     radius = 1.5696123057604773e-05f;\n\
   }\n\
   theta = d_ystore[iglob - (0)];\n\
@@ -194,7 +194,7 @@ static void compute_element_cm_gravity(const int tx, const int iglob, const __gl
   sin_theta = sincos(theta,  &cos_theta);\n\
   sin_phi = sincos(phi,  &cos_phi);\n\
   int_radius = rint(((radius) * (6371.0f)) * (10.0f)) - (1);\n\
-  if(int_radius < 0){\n\
+  if (int_radius < 0) {\n\
     int_radius = 0;\n\
   }\n\
   minus_g = d_minus_gravity_table[int_radius - (0)];\n\
@@ -277,7 +277,7 @@ static void compute_element_cm_aniso(const int offset, const __global float * d_
   c55 = d_c55store[offset - (0)];\n\
   c56 = d_c56store[offset - (0)];\n\
   c66 = d_c66store[offset - (0)];\n\
-  if(ATTENUATION){\n\
+  if (ATTENUATION) {\n\
     minus_sum_beta = one_minus_sum_beta_use - (1.0f);\n\
     mul = (c44) * (minus_sum_beta);\n\
     c11 = c11 + (mul) * (1.3333333333333333f);\n\
@@ -304,7 +304,7 @@ static void compute_element_cm_iso(const int offset, const __global float * d_ka
   float kappal;\n\
   kappal = d_kappavstore[offset - (0)];\n\
   mul = d_muvstore[offset - (0)];\n\
-  if(ATTENUATION){\n\
+  if (ATTENUATION) {\n\
     mul = (mul) * (one_minus_sum_beta_use);\n\
   }\n\
   lambdalplus2mul = kappal + (mul) * (1.3333333333333333f);\n\
@@ -383,7 +383,7 @@ static void compute_element_cm_tiso(const int offset, const __global float * d_k
   muvl = d_muvstore[offset - (0)];\n\
   kappahl = d_kappahstore[offset - (0)];\n\
   muhl = d_muhstore[offset - (0)];\n\
-  if(ATTENUATION){\n\
+  if (ATTENUATION) {\n\
     muvl = (muvl) * (one_minus_sum_beta_use);\n\
     muhl = (muhl) * (one_minus_sum_beta_use);\n\
   }\n\
@@ -547,11 +547,11 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
   J = (tx - ((K) * (NGLL2))) / (NGLLX);\n\
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));\n\
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);\n\
-  if(active){\n\
+  if (active) {\n\
 #ifdef USE_MESH_COLORING_GPU\n\
     working_element = bx;\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
+    if (use_mesh_coloring_gpu) {\n\
       working_element = bx;\n\
     } else {\n\
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);\n\
@@ -568,7 +568,7 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
     s_dummyz_loc[tx - (0)] = d_displ[2 - (0) + (iglob - (0)) * (3)];\n\
 #endif\n\
   }\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
 #ifdef USE_TEXTURES_CONSTANTS\n\
     sh_hprime_xx[tx - (0)] = as_float(read_imageui(d_hprime_xx_tex, sampler_d_hprime_xx_tex, int2(tx,0)).x);\n\
     sh_hprimewgll_xx[tx - (0)] = as_float(read_imageui(d_hprimewgll_xx_tex, sampler_d_hprimewgll_xx_tex, int2(tx,0)).x);\n\
@@ -578,7 +578,7 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
 #endif\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     tempx1l = 0.0f;\n\
     tempx2l = 0.0f;\n\
     tempx3l = 0.0f;\n\
@@ -650,7 +650,7 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
     tempy3l = tempy3l + (s_dummyy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);\n\
     tempz3l = tempz3l + (s_dummyz_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];\n\
       tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
       tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
@@ -690,43 +690,43 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
     duxdyl_plus_duydxl = duxdyl + duydxl;\n\
     duzdxl_plus_duxdzl = duzdxl + duxdzl;\n\
     duzdyl_plus_duydzl = duzdyl + duydzl;\n\
-    if(COMPUTE_AND_STORE_STRAIN){\n\
+    if (COMPUTE_AND_STORE_STRAIN) {\n\
       templ = (duxdxl + duydyl + duzdzl) * (0.3333333333333333f);\n\
       epsilondev_xx_loc = duxdxl - (templ);\n\
       epsilondev_yy_loc = duydyl - (templ);\n\
       epsilondev_xy_loc = (duxdyl_plus_duydxl) * (0.5f);\n\
       epsilondev_xz_loc = (duzdxl_plus_duxdzl) * (0.5f);\n\
       epsilondev_yz_loc = (duzdyl_plus_duydzl) * (0.5f);\n\
-      if(NSPEC_CRUST_MANTLE_STRAIN_ONLY == 1){\n\
+      if (NSPEC_CRUST_MANTLE_STRAIN_ONLY == 1) {\n\
         epsilon_trace_over_3[tx - (0)] = templ;\n\
       } else {\n\
         epsilon_trace_over_3[tx + (working_element) * (NGLL3) - (0)] = templ;\n\
       }\n\
     }\n\
-    if(ATTENUATION){\n\
-      if(USE_3D_ATTENUATION_ARRAYS){\n\
+    if (ATTENUATION) {\n\
+      if (USE_3D_ATTENUATION_ARRAYS) {\n\
         one_minus_sum_beta_use = one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)];\n\
       } else {\n\
         one_minus_sum_beta_use = one_minus_sum_beta[working_element - (0)];\n\
       }\n\
     }\n\
-    if(ANISOTROPY){\n\
+    if (ANISOTROPY) {\n\
       compute_element_cm_aniso(offset, d_c11store, d_c12store, d_c13store, d_c14store, d_c15store, d_c16store, d_c22store, d_c23store, d_c24store, d_c25store, d_c26store, d_c33store, d_c34store, d_c35store, d_c36store, d_c44store, d_c45store, d_c46store, d_c55store, d_c56store, d_c66store, ATTENUATION, one_minus_sum_beta_use, duxdxl, duxdyl, duxdzl, duydxl, duydyl, duydzl, duzdxl, duzdyl, duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
     } else {\n\
-      if( ! d_ispec_is_tiso[working_element - (0)]){\n\
+      if ( ! d_ispec_is_tiso[working_element - (0)]) {\n\
         compute_element_cm_iso(offset, d_kappavstore, d_muvstore, ATTENUATION, one_minus_sum_beta_use, duxdxl, duydyl, duzdzl, duxdxl_plus_duydyl, duxdxl_plus_duzdzl, duydyl_plus_duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
       } else {\n\
         compute_element_cm_tiso(offset, d_kappavstore, d_muvstore, d_kappahstore, d_muhstore, d_eta_anisostore, ATTENUATION, one_minus_sum_beta_use, duxdxl, duxdyl, duxdzl, duydxl, duydyl, duydzl, duzdxl, duzdyl, duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl, iglob, d_ystore, d_zstore,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
       }\n\
     }\n\
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){\n\
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {\n\
       compute_element_cm_att_stress(tx, working_element, R_xx, R_yy, R_xy, R_xz, R_yz,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
     }\n\
     sigma_yx = sigma_xy;\n\
     sigma_zx = sigma_xz;\n\
     sigma_zy = sigma_yz;\n\
     jacobianl = (1.0f) / ((xixl) * ((etayl) * (gammazl) - ((etazl) * (gammayl))) - ((xiyl) * ((etaxl) * (gammazl) - ((etazl) * (gammaxl)))) + (xizl) * ((etaxl) * (gammayl) - ((etayl) * (gammaxl))));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       compute_element_cm_gravity(tx, iglob, d_xstore, d_ystore, d_zstore, d_minus_gravity_table, d_minus_deriv_gravity_table, d_density_table, wgll_cube, jacobianl, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_yx,  &sigma_xz,  &sigma_zx,  &sigma_yz,  &sigma_zy,  &rho_s_H1,  &rho_s_H2,  &rho_s_H3);\n\
     }\n\
     s_tempx1[tx - (0)] = (jacobianl) * ((sigma_xx) * (xixl) + (sigma_yx) * (xiyl) + (sigma_zx) * (xizl));\n\
@@ -740,7 +740,7 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
     s_tempz3[tx - (0)] = (jacobianl) * ((sigma_xz) * (gammaxl) + (sigma_yz) * (gammayl) + (sigma_zz) * (gammazl));\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     tempx1l = 0.0f;\n\
     tempx2l = 0.0f;\n\
     tempx3l = 0.0f;\n\
@@ -827,7 +827,7 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
     tempy3l = tempy3l + (s_tempy3[offset - (0)]) * (fac3);\n\
     tempz3l = tempz3l + (s_tempz3[offset - (0)]) * (fac3);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       fac1 = sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)];\n\
       offset = (K) * (NGLL2) + (J) * (NGLLX) + l;\n\
       tempx1l = tempx1l + (s_tempx1[offset - (0)]) * (fac1);\n\
@@ -851,7 +851,7 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
     sum_terms1 =  -((fac1) * (tempx1l) + (fac2) * (tempx2l) + (fac3) * (tempx3l));\n\
     sum_terms2 =  -((fac1) * (tempy1l) + (fac2) * (tempy2l) + (fac3) * (tempy3l));\n\
     sum_terms3 =  -((fac1) * (tempz1l) + (fac2) * (tempz2l) + (fac3) * (tempz3l));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       sum_terms1 = sum_terms1 + rho_s_H1;\n\
       sum_terms2 = sum_terms2 + rho_s_H2;\n\
       sum_terms3 = sum_terms3 + rho_s_H3;\n\
@@ -867,7 +867,7 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
     d_accel[2 - (0) + (iglob - (0)) * (3)] = d_accel[2 - (0) + (iglob - (0)) * (3)] + sum_terms3;\n\
 #endif\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
+    if (use_mesh_coloring_gpu) {\n\
 #ifdef USE_TEXTURES_FIELDS\n\
       d_accel[0 - (0) + (iglob - (0)) * (3)] = as_float(read_imageui(d_b_accel_cm_tex, sampler_d_b_accel_cm_tex, int2((iglob) * (3) + 0,0)).x) + sum_terms1;\n\
       d_accel[1 - (0) + (iglob - (0)) * (3)] = as_float(read_imageui(d_b_accel_cm_tex, sampler_d_b_accel_cm_tex, int2((iglob) * (3) + 1,0)).x) + sum_terms2;\n\
@@ -883,10 +883,10 @@ __kernel  void crust_mantle_impl_kernel_adjoint(const int nb_blocks_to_compute, 
       atomicAdd(d_accel + (iglob) * (3) + 2, sum_terms3);\n\
     }\n\
 #endif\n\
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){\n\
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {\n\
       compute_element_cm_att_memory(tx, working_element, d_muvstore, factor_common, alphaval, betaval, gammaval, R_xx, R_yy, R_xy, R_xz, R_yz, epsilondev_xx, epsilondev_yy, epsilondev_xy, epsilondev_xz, epsilondev_yz, epsilondev_xx_loc, epsilondev_yy_loc, epsilondev_xy_loc, epsilondev_xz_loc, epsilondev_yz_loc, d_c44store, ANISOTROPY, USE_3D_ATTENUATION_ARRAYS);\n\
     }\n\
-    if(COMPUTE_AND_STORE_STRAIN){\n\
+    if (COMPUTE_AND_STORE_STRAIN) {\n\
       epsilondev_xx[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xx_loc;\n\
       epsilondev_yy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_yy_loc;\n\
       epsilondev_xy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xy_loc;\n\

--- a/src/gpu/kernels.gen/crust_mantle_impl_kernel_forward.cu
+++ b/src/gpu/kernels.gen/crust_mantle_impl_kernel_forward.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -89,7 +89,7 @@ static __device__ void compute_element_cm_att_stress(const int tx, const int wor
   int i_sls;
   float R_xx_val;
   float R_yy_val;
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));
     R_xx_val = R_xx[offset - (0)];
     R_yy_val = R_yy[offset - (0)];
@@ -111,14 +111,14 @@ static __device__ void compute_element_cm_att_memory(const int tx, const int wor
   float factor_loc;
   float sn;
   float snp1;
-  if(ANISOTROPY){
+  if (ANISOTROPY) {
     mul = d_c44store[tx + (NGLL3_PADDED) * (working_element) - (0)];
   } else {
     mul = d_muv[tx + (NGLL3_PADDED) * (working_element) - (0)];
   }
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));
-    if(USE_3D_ATTENUATION_ARRAYS){
+    if (USE_3D_ATTENUATION_ARRAYS) {
       factor_loc = (mul) * (factor_common[offset - (0)]);
     } else {
       factor_loc = (mul) * (factor_common[i_sls + (N_SLS) * (working_element) - (0)]);
@@ -175,7 +175,7 @@ static __device__ void compute_element_cm_gravity(const int tx, const int iglob,
   float factor;
   int int_radius;
   radius = d_xstore[iglob - (0)];
-  if(radius < 1.5696123057604773e-05f){
+  if (radius < 1.5696123057604773e-05f) {
     radius = 1.5696123057604773e-05f;
   }
   theta = d_ystore[iglob - (0)];
@@ -183,7 +183,7 @@ static __device__ void compute_element_cm_gravity(const int tx, const int iglob,
   sincosf(theta,  &sin_theta,  &cos_theta);
   sincosf(phi,  &sin_phi,  &cos_phi);
   int_radius = rint(((radius) * (6371.0f)) * (10.0f)) - (1);
-  if(int_radius < 0){
+  if (int_radius < 0) {
     int_radius = 0;
   }
   minus_g = d_minus_gravity_table[int_radius - (0)];
@@ -266,7 +266,7 @@ static __device__ void compute_element_cm_aniso(const int offset, const float * 
   c55 = d_c55store[offset - (0)];
   c56 = d_c56store[offset - (0)];
   c66 = d_c66store[offset - (0)];
-  if(ATTENUATION){
+  if (ATTENUATION) {
     minus_sum_beta = one_minus_sum_beta_use - (1.0f);
     mul = (c44) * (minus_sum_beta);
     c11 = c11 + (mul) * (1.3333333333333333f);
@@ -293,7 +293,7 @@ static __device__ void compute_element_cm_iso(const int offset, const float * d_
   float kappal;
   kappal = d_kappavstore[offset - (0)];
   mul = d_muvstore[offset - (0)];
-  if(ATTENUATION){
+  if (ATTENUATION) {
     mul = (mul) * (one_minus_sum_beta_use);
   }
   lambdalplus2mul = kappal + (mul) * (1.3333333333333333f);
@@ -372,7 +372,7 @@ static __device__ void compute_element_cm_tiso(const int offset, const float * d
   muvl = d_muvstore[offset - (0)];
   kappahl = d_kappahstore[offset - (0)];
   muhl = d_muhstore[offset - (0)];
-  if(ATTENUATION){
+  if (ATTENUATION) {
     muvl = (muvl) * (one_minus_sum_beta_use);
     muhl = (muhl) * (one_minus_sum_beta_use);
   }
@@ -533,11 +533,11 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
   J = (tx - ((K) * (NGLL2))) / (NGLLX);
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);
-  if(active){
+  if (active) {
 #ifdef USE_MESH_COLORING_GPU
     working_element = bx;
 #else
-    if(use_mesh_coloring_gpu){
+    if (use_mesh_coloring_gpu) {
       working_element = bx;
     } else {
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);
@@ -554,7 +554,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     s_dummyz_loc[tx - (0)] = d_displ[2 - (0) + (iglob - (0)) * (3)];
 #endif
   }
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
 #ifdef USE_TEXTURES_CONSTANTS
     sh_hprime_xx[tx - (0)] = tex1Dfetch(d_hprime_xx_tex,tx);
     sh_hprimewgll_xx[tx - (0)] = tex1Dfetch(d_hprimewgll_xx_tex,tx);
@@ -564,7 +564,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
 #endif
   }
   __syncthreads();
-  if(active){
+  if (active) {
     tempx1l = 0.0f;
     tempx2l = 0.0f;
     tempx3l = 0.0f;
@@ -636,7 +636,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     tempy3l = tempy3l + (s_dummyy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);
     tempz3l = tempz3l + (s_dummyz_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];
       tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
       tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
@@ -676,43 +676,43 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     duxdyl_plus_duydxl = duxdyl + duydxl;
     duzdxl_plus_duxdzl = duzdxl + duxdzl;
     duzdyl_plus_duydzl = duzdyl + duydzl;
-    if(COMPUTE_AND_STORE_STRAIN){
+    if (COMPUTE_AND_STORE_STRAIN) {
       templ = (duxdxl + duydyl + duzdzl) * (0.3333333333333333f);
       epsilondev_xx_loc = duxdxl - (templ);
       epsilondev_yy_loc = duydyl - (templ);
       epsilondev_xy_loc = (duxdyl_plus_duydxl) * (0.5f);
       epsilondev_xz_loc = (duzdxl_plus_duxdzl) * (0.5f);
       epsilondev_yz_loc = (duzdyl_plus_duydzl) * (0.5f);
-      if(NSPEC_CRUST_MANTLE_STRAIN_ONLY == 1){
+      if (NSPEC_CRUST_MANTLE_STRAIN_ONLY == 1) {
         epsilon_trace_over_3[tx - (0)] = templ;
       } else {
         epsilon_trace_over_3[tx + (working_element) * (NGLL3) - (0)] = templ;
       }
     }
-    if(ATTENUATION){
-      if(USE_3D_ATTENUATION_ARRAYS){
+    if (ATTENUATION) {
+      if (USE_3D_ATTENUATION_ARRAYS) {
         one_minus_sum_beta_use = one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)];
       } else {
         one_minus_sum_beta_use = one_minus_sum_beta[working_element - (0)];
       }
     }
-    if(ANISOTROPY){
+    if (ANISOTROPY) {
       compute_element_cm_aniso(offset, d_c11store, d_c12store, d_c13store, d_c14store, d_c15store, d_c16store, d_c22store, d_c23store, d_c24store, d_c25store, d_c26store, d_c33store, d_c34store, d_c35store, d_c36store, d_c44store, d_c45store, d_c46store, d_c55store, d_c56store, d_c66store, ATTENUATION, one_minus_sum_beta_use, duxdxl, duxdyl, duxdzl, duydxl, duydyl, duydzl, duzdxl, duzdyl, duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
     } else {
-      if( ! d_ispec_is_tiso[working_element - (0)]){
+      if ( ! d_ispec_is_tiso[working_element - (0)]) {
         compute_element_cm_iso(offset, d_kappavstore, d_muvstore, ATTENUATION, one_minus_sum_beta_use, duxdxl, duydyl, duzdzl, duxdxl_plus_duydyl, duxdxl_plus_duzdzl, duydyl_plus_duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
       } else {
         compute_element_cm_tiso(offset, d_kappavstore, d_muvstore, d_kappahstore, d_muhstore, d_eta_anisostore, ATTENUATION, one_minus_sum_beta_use, duxdxl, duxdyl, duxdzl, duydxl, duydyl, duydzl, duzdxl, duzdyl, duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl, iglob, d_ystore, d_zstore,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
       }
     }
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {
       compute_element_cm_att_stress(tx, working_element, R_xx, R_yy, R_xy, R_xz, R_yz,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
     }
     sigma_yx = sigma_xy;
     sigma_zx = sigma_xz;
     sigma_zy = sigma_yz;
     jacobianl = (1.0f) / ((xixl) * ((etayl) * (gammazl) - ((etazl) * (gammayl))) - ((xiyl) * ((etaxl) * (gammazl) - ((etazl) * (gammaxl)))) + (xizl) * ((etaxl) * (gammayl) - ((etayl) * (gammaxl))));
-    if(GRAVITY){
+    if (GRAVITY) {
       compute_element_cm_gravity(tx, iglob, d_xstore, d_ystore, d_zstore, d_minus_gravity_table, d_minus_deriv_gravity_table, d_density_table, wgll_cube, jacobianl, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_yx,  &sigma_xz,  &sigma_zx,  &sigma_yz,  &sigma_zy,  &rho_s_H1,  &rho_s_H2,  &rho_s_H3);
     }
     s_tempx1[tx - (0)] = (jacobianl) * ((sigma_xx) * (xixl) + (sigma_yx) * (xiyl) + (sigma_zx) * (xizl));
@@ -726,7 +726,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     s_tempz3[tx - (0)] = (jacobianl) * ((sigma_xz) * (gammaxl) + (sigma_yz) * (gammayl) + (sigma_zz) * (gammazl));
   }
   __syncthreads();
-  if(active){
+  if (active) {
     tempx1l = 0.0f;
     tempx2l = 0.0f;
     tempx3l = 0.0f;
@@ -813,7 +813,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     tempy3l = tempy3l + (s_tempy3[offset - (0)]) * (fac3);
     tempz3l = tempz3l + (s_tempz3[offset - (0)]) * (fac3);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       fac1 = sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)];
       offset = (K) * (NGLL2) + (J) * (NGLLX) + l;
       tempx1l = tempx1l + (s_tempx1[offset - (0)]) * (fac1);
@@ -837,7 +837,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     sum_terms1 =  -((fac1) * (tempx1l) + (fac2) * (tempx2l) + (fac3) * (tempx3l));
     sum_terms2 =  -((fac1) * (tempy1l) + (fac2) * (tempy2l) + (fac3) * (tempy3l));
     sum_terms3 =  -((fac1) * (tempz1l) + (fac2) * (tempz2l) + (fac3) * (tempz3l));
-    if(GRAVITY){
+    if (GRAVITY) {
       sum_terms1 = sum_terms1 + rho_s_H1;
       sum_terms2 = sum_terms2 + rho_s_H2;
       sum_terms3 = sum_terms3 + rho_s_H3;
@@ -853,7 +853,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     d_accel[2 - (0) + (iglob - (0)) * (3)] = d_accel[2 - (0) + (iglob - (0)) * (3)] + sum_terms3;
 #endif
 #else
-    if(use_mesh_coloring_gpu){
+    if (use_mesh_coloring_gpu) {
 #ifdef USE_TEXTURES_FIELDS
       d_accel[0 - (0) + (iglob - (0)) * (3)] = tex1Dfetch(d_accel_cm_tex,(iglob) * (3) + 0) + sum_terms1;
       d_accel[1 - (0) + (iglob - (0)) * (3)] = tex1Dfetch(d_accel_cm_tex,(iglob) * (3) + 1) + sum_terms2;
@@ -869,10 +869,10 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
       atomicAdd(d_accel + (iglob) * (3) + 2, sum_terms3);
     }
 #endif
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {
       compute_element_cm_att_memory(tx, working_element, d_muvstore, factor_common, alphaval, betaval, gammaval, R_xx, R_yy, R_xy, R_xz, R_yz, epsilondev_xx, epsilondev_yy, epsilondev_xy, epsilondev_xz, epsilondev_yz, epsilondev_xx_loc, epsilondev_yy_loc, epsilondev_xy_loc, epsilondev_xz_loc, epsilondev_yz_loc, d_c44store, ANISOTROPY, USE_3D_ATTENUATION_ARRAYS);
     }
-    if(COMPUTE_AND_STORE_STRAIN){
+    if (COMPUTE_AND_STORE_STRAIN) {
       epsilondev_xx[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xx_loc;
       epsilondev_yy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_yy_loc;
       epsilondev_xy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xy_loc;

--- a/src/gpu/kernels.gen/crust_mantle_impl_kernel_forward_cl.c
+++ b/src/gpu/kernels.gen/crust_mantle_impl_kernel_forward_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -100,7 +100,7 @@ static void compute_element_cm_att_stress(const int tx, const int working_elemen
   int i_sls;\n\
   float R_xx_val;\n\
   float R_yy_val;\n\
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){\n\
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {\n\
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));\n\
     R_xx_val = R_xx[offset - (0)];\n\
     R_yy_val = R_yy[offset - (0)];\n\
@@ -122,14 +122,14 @@ static void compute_element_cm_att_memory(const int tx, const int working_elemen
   float factor_loc;\n\
   float sn;\n\
   float snp1;\n\
-  if(ANISOTROPY){\n\
+  if (ANISOTROPY) {\n\
     mul = d_c44store[tx + (NGLL3_PADDED) * (working_element) - (0)];\n\
   } else {\n\
     mul = d_muv[tx + (NGLL3_PADDED) * (working_element) - (0)];\n\
   }\n\
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){\n\
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {\n\
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));\n\
-    if(USE_3D_ATTENUATION_ARRAYS){\n\
+    if (USE_3D_ATTENUATION_ARRAYS) {\n\
       factor_loc = (mul) * (factor_common[offset - (0)]);\n\
     } else {\n\
       factor_loc = (mul) * (factor_common[i_sls + (N_SLS) * (working_element) - (0)]);\n\
@@ -186,7 +186,7 @@ static void compute_element_cm_gravity(const int tx, const int iglob, const __gl
   float factor;\n\
   int int_radius;\n\
   radius = d_xstore[iglob - (0)];\n\
-  if(radius < 1.5696123057604773e-05f){\n\
+  if (radius < 1.5696123057604773e-05f) {\n\
     radius = 1.5696123057604773e-05f;\n\
   }\n\
   theta = d_ystore[iglob - (0)];\n\
@@ -194,7 +194,7 @@ static void compute_element_cm_gravity(const int tx, const int iglob, const __gl
   sin_theta = sincos(theta,  &cos_theta);\n\
   sin_phi = sincos(phi,  &cos_phi);\n\
   int_radius = rint(((radius) * (6371.0f)) * (10.0f)) - (1);\n\
-  if(int_radius < 0){\n\
+  if (int_radius < 0) {\n\
     int_radius = 0;\n\
   }\n\
   minus_g = d_minus_gravity_table[int_radius - (0)];\n\
@@ -277,7 +277,7 @@ static void compute_element_cm_aniso(const int offset, const __global float * d_
   c55 = d_c55store[offset - (0)];\n\
   c56 = d_c56store[offset - (0)];\n\
   c66 = d_c66store[offset - (0)];\n\
-  if(ATTENUATION){\n\
+  if (ATTENUATION) {\n\
     minus_sum_beta = one_minus_sum_beta_use - (1.0f);\n\
     mul = (c44) * (minus_sum_beta);\n\
     c11 = c11 + (mul) * (1.3333333333333333f);\n\
@@ -304,7 +304,7 @@ static void compute_element_cm_iso(const int offset, const __global float * d_ka
   float kappal;\n\
   kappal = d_kappavstore[offset - (0)];\n\
   mul = d_muvstore[offset - (0)];\n\
-  if(ATTENUATION){\n\
+  if (ATTENUATION) {\n\
     mul = (mul) * (one_minus_sum_beta_use);\n\
   }\n\
   lambdalplus2mul = kappal + (mul) * (1.3333333333333333f);\n\
@@ -383,7 +383,7 @@ static void compute_element_cm_tiso(const int offset, const __global float * d_k
   muvl = d_muvstore[offset - (0)];\n\
   kappahl = d_kappahstore[offset - (0)];\n\
   muhl = d_muhstore[offset - (0)];\n\
-  if(ATTENUATION){\n\
+  if (ATTENUATION) {\n\
     muvl = (muvl) * (one_minus_sum_beta_use);\n\
     muhl = (muhl) * (one_minus_sum_beta_use);\n\
   }\n\
@@ -547,11 +547,11 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
   J = (tx - ((K) * (NGLL2))) / (NGLLX);\n\
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));\n\
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);\n\
-  if(active){\n\
+  if (active) {\n\
 #ifdef USE_MESH_COLORING_GPU\n\
     working_element = bx;\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
+    if (use_mesh_coloring_gpu) {\n\
       working_element = bx;\n\
     } else {\n\
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);\n\
@@ -568,7 +568,7 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
     s_dummyz_loc[tx - (0)] = d_displ[2 - (0) + (iglob - (0)) * (3)];\n\
 #endif\n\
   }\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
 #ifdef USE_TEXTURES_CONSTANTS\n\
     sh_hprime_xx[tx - (0)] = as_float(read_imageui(d_hprime_xx_tex, sampler_d_hprime_xx_tex, int2(tx,0)).x);\n\
     sh_hprimewgll_xx[tx - (0)] = as_float(read_imageui(d_hprimewgll_xx_tex, sampler_d_hprimewgll_xx_tex, int2(tx,0)).x);\n\
@@ -578,7 +578,7 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
 #endif\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     tempx1l = 0.0f;\n\
     tempx2l = 0.0f;\n\
     tempx3l = 0.0f;\n\
@@ -650,7 +650,7 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
     tempy3l = tempy3l + (s_dummyy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);\n\
     tempz3l = tempz3l + (s_dummyz_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];\n\
       tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
       tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
@@ -690,43 +690,43 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
     duxdyl_plus_duydxl = duxdyl + duydxl;\n\
     duzdxl_plus_duxdzl = duzdxl + duxdzl;\n\
     duzdyl_plus_duydzl = duzdyl + duydzl;\n\
-    if(COMPUTE_AND_STORE_STRAIN){\n\
+    if (COMPUTE_AND_STORE_STRAIN) {\n\
       templ = (duxdxl + duydyl + duzdzl) * (0.3333333333333333f);\n\
       epsilondev_xx_loc = duxdxl - (templ);\n\
       epsilondev_yy_loc = duydyl - (templ);\n\
       epsilondev_xy_loc = (duxdyl_plus_duydxl) * (0.5f);\n\
       epsilondev_xz_loc = (duzdxl_plus_duxdzl) * (0.5f);\n\
       epsilondev_yz_loc = (duzdyl_plus_duydzl) * (0.5f);\n\
-      if(NSPEC_CRUST_MANTLE_STRAIN_ONLY == 1){\n\
+      if (NSPEC_CRUST_MANTLE_STRAIN_ONLY == 1) {\n\
         epsilon_trace_over_3[tx - (0)] = templ;\n\
       } else {\n\
         epsilon_trace_over_3[tx + (working_element) * (NGLL3) - (0)] = templ;\n\
       }\n\
     }\n\
-    if(ATTENUATION){\n\
-      if(USE_3D_ATTENUATION_ARRAYS){\n\
+    if (ATTENUATION) {\n\
+      if (USE_3D_ATTENUATION_ARRAYS) {\n\
         one_minus_sum_beta_use = one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)];\n\
       } else {\n\
         one_minus_sum_beta_use = one_minus_sum_beta[working_element - (0)];\n\
       }\n\
     }\n\
-    if(ANISOTROPY){\n\
+    if (ANISOTROPY) {\n\
       compute_element_cm_aniso(offset, d_c11store, d_c12store, d_c13store, d_c14store, d_c15store, d_c16store, d_c22store, d_c23store, d_c24store, d_c25store, d_c26store, d_c33store, d_c34store, d_c35store, d_c36store, d_c44store, d_c45store, d_c46store, d_c55store, d_c56store, d_c66store, ATTENUATION, one_minus_sum_beta_use, duxdxl, duxdyl, duxdzl, duydxl, duydyl, duydzl, duzdxl, duzdyl, duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
     } else {\n\
-      if( ! d_ispec_is_tiso[working_element - (0)]){\n\
+      if ( ! d_ispec_is_tiso[working_element - (0)]) {\n\
         compute_element_cm_iso(offset, d_kappavstore, d_muvstore, ATTENUATION, one_minus_sum_beta_use, duxdxl, duydyl, duzdzl, duxdxl_plus_duydyl, duxdxl_plus_duzdzl, duydyl_plus_duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
       } else {\n\
         compute_element_cm_tiso(offset, d_kappavstore, d_muvstore, d_kappahstore, d_muhstore, d_eta_anisostore, ATTENUATION, one_minus_sum_beta_use, duxdxl, duxdyl, duxdzl, duydxl, duydyl, duydzl, duzdxl, duzdyl, duzdzl, duxdyl_plus_duydxl, duzdxl_plus_duxdzl, duzdyl_plus_duydzl, iglob, d_ystore, d_zstore,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
       }\n\
     }\n\
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){\n\
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {\n\
       compute_element_cm_att_stress(tx, working_element, R_xx, R_yy, R_xy, R_xz, R_yz,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
     }\n\
     sigma_yx = sigma_xy;\n\
     sigma_zx = sigma_xz;\n\
     sigma_zy = sigma_yz;\n\
     jacobianl = (1.0f) / ((xixl) * ((etayl) * (gammazl) - ((etazl) * (gammayl))) - ((xiyl) * ((etaxl) * (gammazl) - ((etazl) * (gammaxl)))) + (xizl) * ((etaxl) * (gammayl) - ((etayl) * (gammaxl))));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       compute_element_cm_gravity(tx, iglob, d_xstore, d_ystore, d_zstore, d_minus_gravity_table, d_minus_deriv_gravity_table, d_density_table, wgll_cube, jacobianl, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_yx,  &sigma_xz,  &sigma_zx,  &sigma_yz,  &sigma_zy,  &rho_s_H1,  &rho_s_H2,  &rho_s_H3);\n\
     }\n\
     s_tempx1[tx - (0)] = (jacobianl) * ((sigma_xx) * (xixl) + (sigma_yx) * (xiyl) + (sigma_zx) * (xizl));\n\
@@ -740,7 +740,7 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
     s_tempz3[tx - (0)] = (jacobianl) * ((sigma_xz) * (gammaxl) + (sigma_yz) * (gammayl) + (sigma_zz) * (gammazl));\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     tempx1l = 0.0f;\n\
     tempx2l = 0.0f;\n\
     tempx3l = 0.0f;\n\
@@ -827,7 +827,7 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
     tempy3l = tempy3l + (s_tempy3[offset - (0)]) * (fac3);\n\
     tempz3l = tempz3l + (s_tempz3[offset - (0)]) * (fac3);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       fac1 = sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)];\n\
       offset = (K) * (NGLL2) + (J) * (NGLLX) + l;\n\
       tempx1l = tempx1l + (s_tempx1[offset - (0)]) * (fac1);\n\
@@ -851,7 +851,7 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
     sum_terms1 =  -((fac1) * (tempx1l) + (fac2) * (tempx2l) + (fac3) * (tempx3l));\n\
     sum_terms2 =  -((fac1) * (tempy1l) + (fac2) * (tempy2l) + (fac3) * (tempy3l));\n\
     sum_terms3 =  -((fac1) * (tempz1l) + (fac2) * (tempz2l) + (fac3) * (tempz3l));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       sum_terms1 = sum_terms1 + rho_s_H1;\n\
       sum_terms2 = sum_terms2 + rho_s_H2;\n\
       sum_terms3 = sum_terms3 + rho_s_H3;\n\
@@ -867,7 +867,7 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
     d_accel[2 - (0) + (iglob - (0)) * (3)] = d_accel[2 - (0) + (iglob - (0)) * (3)] + sum_terms3;\n\
 #endif\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
+    if (use_mesh_coloring_gpu) {\n\
 #ifdef USE_TEXTURES_FIELDS\n\
       d_accel[0 - (0) + (iglob - (0)) * (3)] = as_float(read_imageui(d_accel_cm_tex, sampler_d_accel_cm_tex, int2((iglob) * (3) + 0,0)).x) + sum_terms1;\n\
       d_accel[1 - (0) + (iglob - (0)) * (3)] = as_float(read_imageui(d_accel_cm_tex, sampler_d_accel_cm_tex, int2((iglob) * (3) + 1,0)).x) + sum_terms2;\n\
@@ -883,10 +883,10 @@ __kernel  void crust_mantle_impl_kernel_forward(const int nb_blocks_to_compute, 
       atomicAdd(d_accel + (iglob) * (3) + 2, sum_terms3);\n\
     }\n\
 #endif\n\
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){\n\
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {\n\
       compute_element_cm_att_memory(tx, working_element, d_muvstore, factor_common, alphaval, betaval, gammaval, R_xx, R_yy, R_xy, R_xz, R_yz, epsilondev_xx, epsilondev_yy, epsilondev_xy, epsilondev_xz, epsilondev_yz, epsilondev_xx_loc, epsilondev_yy_loc, epsilondev_xy_loc, epsilondev_xz_loc, epsilondev_yz_loc, d_c44store, ANISOTROPY, USE_3D_ATTENUATION_ARRAYS);\n\
     }\n\
-    if(COMPUTE_AND_STORE_STRAIN){\n\
+    if (COMPUTE_AND_STORE_STRAIN) {\n\
       epsilondev_xx[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xx_loc;\n\
       epsilondev_yy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_yy_loc;\n\
       epsilondev_xy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xy_loc;\n\

--- a/src/gpu/kernels.gen/get_maximum_scalar_kernel.cu
+++ b/src/gpu/kernels.gen/get_maximum_scalar_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -96,16 +96,16 @@ __global__ void get_maximum_scalar_kernel(const float * array, const int size, f
   sdata[tid - (0)] = (i < size ? fabs(array[i - (0)]) : 0.0f);
   __syncthreads();
   s = (blockDim.x) / (2);
-  while(s > 0){
-    if(tid < s){
-      if(sdata[tid - (0)] < sdata[tid + s - (0)]){
+  while (s > 0) {
+    if (tid < s) {
+      if (sdata[tid - (0)] < sdata[tid + s - (0)]) {
         sdata[tid - (0)] = sdata[tid + s - (0)];
       }
     }
     s = s >> 1;
     __syncthreads();
   }
-  if(tid == 0){
+  if (tid == 0) {
     d_max[bx - (0)] = sdata[0 - (0)];
   }
 }

--- a/src/gpu/kernels.gen/get_maximum_scalar_kernel_cl.c
+++ b/src/gpu/kernels.gen/get_maximum_scalar_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -107,16 +107,16 @@ __kernel void get_maximum_scalar_kernel(const __global float * array, const int 
   sdata[tid - (0)] = (i < size ? fabs(array[i - (0)]) : 0.0f);\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
   s = (get_local_size(0)) / (2);\n\
-  while(s > 0){\n\
-    if(tid < s){\n\
-      if(sdata[tid - (0)] < sdata[tid + s - (0)]){\n\
+  while (s > 0) {\n\
+    if (tid < s) {\n\
+      if (sdata[tid - (0)] < sdata[tid + s - (0)]) {\n\
         sdata[tid - (0)] = sdata[tid + s - (0)];\n\
       }\n\
     }\n\
     s = s >> 1;\n\
     barrier(CLK_LOCAL_MEM_FENCE);\n\
   }\n\
-  if(tid == 0){\n\
+  if (tid == 0) {\n\
     d_max[bx - (0)] = sdata[0 - (0)];\n\
   }\n\
 }\n\

--- a/src/gpu/kernels.gen/get_maximum_vector_kernel.cu
+++ b/src/gpu/kernels.gen/get_maximum_vector_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -96,16 +96,16 @@ __global__ void get_maximum_vector_kernel(const float * array, const int size, f
   sdata[tid - (0)] = (i < size ? sqrt((array[(i) * (3) + 0 - (0)]) * (array[(i) * (3) + 0 - (0)]) + (array[(i) * (3) + 1 - (0)]) * (array[(i) * (3) + 1 - (0)]) + (array[(i) * (3) + 2 - (0)]) * (array[(i) * (3) + 2 - (0)])) : 0.0f);
   __syncthreads();
   s = (blockDim.x) / (2);
-  while(s > 0){
-    if(tid < s){
-      if(sdata[tid - (0)] < sdata[tid + s - (0)]){
+  while (s > 0) {
+    if (tid < s) {
+      if (sdata[tid - (0)] < sdata[tid + s - (0)]) {
         sdata[tid - (0)] = sdata[tid + s - (0)];
       }
     }
     s = s >> 1;
     __syncthreads();
   }
-  if(tid == 0){
+  if (tid == 0) {
     d_max[bx - (0)] = sdata[0 - (0)];
   }
 }

--- a/src/gpu/kernels.gen/get_maximum_vector_kernel_cl.c
+++ b/src/gpu/kernels.gen/get_maximum_vector_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -107,16 +107,16 @@ __kernel void get_maximum_vector_kernel(const __global float * array, const int 
   sdata[tid - (0)] = (i < size ? sqrt((array[(i) * (3) + 0 - (0)]) * (array[(i) * (3) + 0 - (0)]) + (array[(i) * (3) + 1 - (0)]) * (array[(i) * (3) + 1 - (0)]) + (array[(i) * (3) + 2 - (0)]) * (array[(i) * (3) + 2 - (0)])) : 0.0f);\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
   s = (get_local_size(0)) / (2);\n\
-  while(s > 0){\n\
-    if(tid < s){\n\
-      if(sdata[tid - (0)] < sdata[tid + s - (0)]){\n\
+  while (s > 0) {\n\
+    if (tid < s) {\n\
+      if (sdata[tid - (0)] < sdata[tid + s - (0)]) {\n\
         sdata[tid - (0)] = sdata[tid + s - (0)];\n\
       }\n\
     }\n\
     s = s >> 1;\n\
     barrier(CLK_LOCAL_MEM_FENCE);\n\
   }\n\
-  if(tid == 0){\n\
+  if (tid == 0) {\n\
     d_max[bx - (0)] = sdata[0 - (0)];\n\
   }\n\
 }\n\

--- a/src/gpu/kernels.gen/inner_core_impl_kernel_adjoint.cu
+++ b/src/gpu/kernels.gen/inner_core_impl_kernel_adjoint.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -92,7 +92,7 @@ static __device__ void compute_element_ic_att_stress(const int tx, const int wor
   int i_sls;
   float R_xx_val;
   float R_yy_val;
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));
     R_xx_val = R_xx[offset - (0)];
     R_yy_val = R_yy[offset - (0)];
@@ -115,9 +115,9 @@ static __device__ void compute_element_ic_att_memory(const int tx, const int wor
   float sn;
   float snp1;
   mul = d_muv[tx + (NGLL3_PADDED) * (working_element) - (0)];
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));
-    if(USE_3D_ATTENUATION_ARRAYS){
+    if (USE_3D_ATTENUATION_ARRAYS) {
       factor_loc = (mul) * (factor_common[offset - (0)]);
     } else {
       factor_loc = (mul) * (factor_common[i_sls + (N_SLS) * (working_element) - (0)]);
@@ -174,7 +174,7 @@ static __device__ void compute_element_ic_gravity(const int tx, const int iglob,
   float factor;
   int int_radius;
   radius = d_xstore[iglob - (0)];
-  if(radius < 1.5696123057604773e-05f){
+  if (radius < 1.5696123057604773e-05f) {
     radius = 1.5696123057604773e-05f;
   }
   theta = d_ystore[iglob - (0)];
@@ -182,7 +182,7 @@ static __device__ void compute_element_ic_gravity(const int tx, const int iglob,
   sincosf(theta,  &sin_theta,  &cos_theta);
   sincosf(phi,  &sin_phi,  &cos_phi);
   int_radius = rint(((radius) * (6371.0f)) * (10.0f)) - (1);
-  if(int_radius < 0){
+  if (int_radius < 0) {
     int_radius = 0;
   }
   minus_g = d_minus_gravity_table[int_radius - (0)];
@@ -326,17 +326,17 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
   J = (tx - ((K) * (NGLL2))) / (NGLLX);
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);
-  if(active){
+  if (active) {
 #ifdef USE_MESH_COLORING_GPU
     working_element = bx;
 #else
-    if(use_mesh_coloring_gpu){
+    if (use_mesh_coloring_gpu) {
       working_element = bx;
     } else {
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);
     }
 #endif
-    if(d_idoubling[working_element - (0)] == IFLAG_IN_FICTITIOUS_CUBE){
+    if (d_idoubling[working_element - (0)] == IFLAG_IN_FICTITIOUS_CUBE) {
       active = 0;
     } else {
       iglob = d_ibool[(working_element) * (NGLL3) + tx - (0)] - (1);
@@ -351,7 +351,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
 #endif
     }
   }
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
 #ifdef USE_TEXTURES_CONSTANTS
     sh_hprime_xx[tx - (0)] = tex1Dfetch(d_hprime_xx_ic_tex,tx);
     sh_hprimewgll_xx[tx - (0)] = tex1Dfetch(d_hprimewgll_xx_ic_tex,tx);
@@ -361,7 +361,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
 #endif
   }
   __syncthreads();
-  if(active){
+  if (active) {
     tempx1l = 0.0f;
     tempx2l = 0.0f;
     tempx3l = 0.0f;
@@ -433,7 +433,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     tempy3l = tempy3l + (s_dummyy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);
     tempz3l = tempz3l + (s_dummyz_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];
       tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
       tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
@@ -473,14 +473,14 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     duxdyl_plus_duydxl = duxdyl + duydxl;
     duzdxl_plus_duxdzl = duzdxl + duxdzl;
     duzdyl_plus_duydzl = duzdyl + duydzl;
-    if(COMPUTE_AND_STORE_STRAIN){
+    if (COMPUTE_AND_STORE_STRAIN) {
       templ = (duxdxl + duydyl + duzdzl) * (0.3333333333333333f);
       epsilondev_xx_loc = duxdxl - (templ);
       epsilondev_yy_loc = duydyl - (templ);
       epsilondev_xy_loc = (duxdyl_plus_duydxl) * (0.5f);
       epsilondev_xz_loc = (duzdxl_plus_duxdzl) * (0.5f);
       epsilondev_yz_loc = (duzdyl_plus_duydzl) * (0.5f);
-      if(NSPEC_INNER_CORE_STRAIN_ONLY == 1){
+      if (NSPEC_INNER_CORE_STRAIN_ONLY == 1) {
         epsilon_trace_over_3[tx - (0)] = templ;
       } else {
         epsilon_trace_over_3[tx + (working_element) * (NGLL3) - (0)] = templ;
@@ -488,8 +488,8 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     }
     kappal = d_kappavstore[offset - (0)];
     mul = d_muvstore[offset - (0)];
-    if(ATTENUATION){
-      if(USE_3D_ATTENUATION_ARRAYS){
+    if (ATTENUATION) {
+      if (USE_3D_ATTENUATION_ARRAYS) {
         mul_iso = (mul) * (one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)]);
         mul_aniso = (mul) * (one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)] - (1.0f));
       } else {
@@ -499,13 +499,13 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     } else {
       mul_iso = mul;
     }
-    if(ANISOTROPY){
+    if (ANISOTROPY) {
       c11 = d_c11store[offset - (0)];
       c12 = d_c12store[offset - (0)];
       c13 = d_c13store[offset - (0)];
       c33 = d_c33store[offset - (0)];
       c44 = d_c44store[offset - (0)];
-      if(ATTENUATION){
+      if (ATTENUATION) {
         c11 = c11 + (mul_aniso) * (1.3333333333333333f);
         c12 = c12 - ((mul_aniso) * (0.6666666666666666f));
         c13 = c13 - ((mul_aniso) * (0.6666666666666666f));
@@ -528,14 +528,14 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
       sigma_xz = (mul) * (duzdxl_plus_duxdzl);
       sigma_yz = (mul) * (duzdyl_plus_duydzl);
     }
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {
       compute_element_ic_att_stress(tx, working_element, R_xx, R_yy, R_xy, R_xz, R_yz,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
     }
     sigma_yx = sigma_xy;
     sigma_zx = sigma_xz;
     sigma_zy = sigma_yz;
     jacobianl = (1.0f) / ((xixl) * ((etayl) * (gammazl) - ((etazl) * (gammayl))) - ((xiyl) * ((etaxl) * (gammazl) - ((etazl) * (gammaxl)))) + (xizl) * ((etaxl) * (gammayl) - ((etayl) * (gammaxl))));
-    if(GRAVITY){
+    if (GRAVITY) {
       compute_element_ic_gravity(tx, iglob, d_xstore, d_ystore, d_zstore, d_minus_gravity_table, d_minus_deriv_gravity_table, d_density_table, wgll_cube, jacobianl, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_yx,  &sigma_xz,  &sigma_zx,  &sigma_yz,  &sigma_zy,  &rho_s_H1,  &rho_s_H2,  &rho_s_H3);
     }
     s_tempx1[tx - (0)] = (jacobianl) * ((sigma_xx) * (xixl) + (sigma_yx) * (xiyl) + (sigma_zx) * (xizl));
@@ -549,7 +549,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     s_tempz3[tx - (0)] = (jacobianl) * ((sigma_xz) * (gammaxl) + (sigma_yz) * (gammayl) + (sigma_zz) * (gammazl));
   }
   __syncthreads();
-  if(active){
+  if (active) {
     tempx1l = 0.0f;
     tempx2l = 0.0f;
     tempx3l = 0.0f;
@@ -636,7 +636,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     tempy3l = tempy3l + (s_tempy3[offset - (0)]) * (fac3);
     tempz3l = tempz3l + (s_tempz3[offset - (0)]) * (fac3);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       fac1 = sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)];
       offset = (K) * (NGLL2) + (J) * (NGLLX) + l;
       tempx1l = tempx1l + (s_tempx1[offset - (0)]) * (fac1);
@@ -660,7 +660,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     sum_terms1 =  -((fac1) * (tempx1l) + (fac2) * (tempx2l) + (fac3) * (tempx3l));
     sum_terms2 =  -((fac1) * (tempy1l) + (fac2) * (tempy2l) + (fac3) * (tempy3l));
     sum_terms3 =  -((fac1) * (tempz1l) + (fac2) * (tempz2l) + (fac3) * (tempz3l));
-    if(GRAVITY){
+    if (GRAVITY) {
       sum_terms1 = sum_terms1 + rho_s_H1;
       sum_terms2 = sum_terms2 + rho_s_H2;
       sum_terms3 = sum_terms3 + rho_s_H3;
@@ -676,8 +676,8 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     d_accel[2 - (0) + (iglob - (0)) * (3)] = d_accel[2 - (0) + (iglob - (0)) * (3)] + sum_terms3;
 #endif
 #else
-    if(use_mesh_coloring_gpu){
-      if(NSPEC_INNER_CORE > 1000){
+    if (use_mesh_coloring_gpu) {
+      if (NSPEC_INNER_CORE > 1000) {
 #ifdef USE_TEXTURES_FIELDS
         d_accel[0 - (0) + (iglob - (0)) * (3)] = tex1Dfetch(d_b_accel_ic_tex,(iglob) * (3) + 0) + sum_terms1;
         d_accel[1 - (0) + (iglob - (0)) * (3)] = tex1Dfetch(d_b_accel_ic_tex,(iglob) * (3) + 1) + sum_terms2;
@@ -698,10 +698,10 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
       atomicAdd(d_accel + (iglob) * (3) + 2, sum_terms3);
     }
 #endif
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {
       compute_element_ic_att_memory(tx, working_element, d_muvstore, factor_common, alphaval, betaval, gammaval, R_xx, R_yy, R_xy, R_xz, R_yz, epsilondev_xx, epsilondev_yy, epsilondev_xy, epsilondev_xz, epsilondev_yz, epsilondev_xx_loc, epsilondev_yy_loc, epsilondev_xy_loc, epsilondev_xz_loc, epsilondev_yz_loc, USE_3D_ATTENUATION_ARRAYS);
     }
-    if(COMPUTE_AND_STORE_STRAIN){
+    if (COMPUTE_AND_STORE_STRAIN) {
       epsilondev_xx[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xx_loc;
       epsilondev_yy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_yy_loc;
       epsilondev_xy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xy_loc;

--- a/src/gpu/kernels.gen/inner_core_impl_kernel_adjoint_cl.c
+++ b/src/gpu/kernels.gen/inner_core_impl_kernel_adjoint_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -103,7 +103,7 @@ static void compute_element_ic_att_stress(const int tx, const int working_elemen
   int i_sls;\n\
   float R_xx_val;\n\
   float R_yy_val;\n\
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){\n\
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {\n\
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));\n\
     R_xx_val = R_xx[offset - (0)];\n\
     R_yy_val = R_yy[offset - (0)];\n\
@@ -126,9 +126,9 @@ static void compute_element_ic_att_memory(const int tx, const int working_elemen
   float sn;\n\
   float snp1;\n\
   mul = d_muv[tx + (NGLL3_PADDED) * (working_element) - (0)];\n\
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){\n\
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {\n\
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));\n\
-    if(USE_3D_ATTENUATION_ARRAYS){\n\
+    if (USE_3D_ATTENUATION_ARRAYS) {\n\
       factor_loc = (mul) * (factor_common[offset - (0)]);\n\
     } else {\n\
       factor_loc = (mul) * (factor_common[i_sls + (N_SLS) * (working_element) - (0)]);\n\
@@ -185,7 +185,7 @@ static void compute_element_ic_gravity(const int tx, const int iglob, const __gl
   float factor;\n\
   int int_radius;\n\
   radius = d_xstore[iglob - (0)];\n\
-  if(radius < 1.5696123057604773e-05f){\n\
+  if (radius < 1.5696123057604773e-05f) {\n\
     radius = 1.5696123057604773e-05f;\n\
   }\n\
   theta = d_ystore[iglob - (0)];\n\
@@ -193,7 +193,7 @@ static void compute_element_ic_gravity(const int tx, const int iglob, const __gl
   sin_theta = sincos(theta,  &cos_theta);\n\
   sin_phi = sincos(phi,  &cos_phi);\n\
   int_radius = rint(((radius) * (6371.0f)) * (10.0f)) - (1);\n\
-  if(int_radius < 0){\n\
+  if (int_radius < 0) {\n\
     int_radius = 0;\n\
   }\n\
   minus_g = d_minus_gravity_table[int_radius - (0)];\n\
@@ -340,17 +340,17 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
   J = (tx - ((K) * (NGLL2))) / (NGLLX);\n\
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));\n\
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);\n\
-  if(active){\n\
+  if (active) {\n\
 #ifdef USE_MESH_COLORING_GPU\n\
     working_element = bx;\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
+    if (use_mesh_coloring_gpu) {\n\
       working_element = bx;\n\
     } else {\n\
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);\n\
     }\n\
 #endif\n\
-    if(d_idoubling[working_element - (0)] == IFLAG_IN_FICTITIOUS_CUBE){\n\
+    if (d_idoubling[working_element - (0)] == IFLAG_IN_FICTITIOUS_CUBE) {\n\
       active = 0;\n\
     } else {\n\
       iglob = d_ibool[(working_element) * (NGLL3) + tx - (0)] - (1);\n\
@@ -365,7 +365,7 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
 #endif\n\
     }\n\
   }\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
 #ifdef USE_TEXTURES_CONSTANTS\n\
     sh_hprime_xx[tx - (0)] = as_float(read_imageui(d_hprime_xx_ic_tex, sampler_d_hprime_xx_ic_tex, int2(tx,0)).x);\n\
     sh_hprimewgll_xx[tx - (0)] = as_float(read_imageui(d_hprimewgll_xx_ic_tex, sampler_d_hprimewgll_xx_ic_tex, int2(tx,0)).x);\n\
@@ -375,7 +375,7 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
 #endif\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     tempx1l = 0.0f;\n\
     tempx2l = 0.0f;\n\
     tempx3l = 0.0f;\n\
@@ -447,7 +447,7 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
     tempy3l = tempy3l + (s_dummyy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);\n\
     tempz3l = tempz3l + (s_dummyz_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];\n\
       tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
       tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
@@ -487,14 +487,14 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
     duxdyl_plus_duydxl = duxdyl + duydxl;\n\
     duzdxl_plus_duxdzl = duzdxl + duxdzl;\n\
     duzdyl_plus_duydzl = duzdyl + duydzl;\n\
-    if(COMPUTE_AND_STORE_STRAIN){\n\
+    if (COMPUTE_AND_STORE_STRAIN) {\n\
       templ = (duxdxl + duydyl + duzdzl) * (0.3333333333333333f);\n\
       epsilondev_xx_loc = duxdxl - (templ);\n\
       epsilondev_yy_loc = duydyl - (templ);\n\
       epsilondev_xy_loc = (duxdyl_plus_duydxl) * (0.5f);\n\
       epsilondev_xz_loc = (duzdxl_plus_duxdzl) * (0.5f);\n\
       epsilondev_yz_loc = (duzdyl_plus_duydzl) * (0.5f);\n\
-      if(NSPEC_INNER_CORE_STRAIN_ONLY == 1){\n\
+      if (NSPEC_INNER_CORE_STRAIN_ONLY == 1) {\n\
         epsilon_trace_over_3[tx - (0)] = templ;\n\
       } else {\n\
         epsilon_trace_over_3[tx + (working_element) * (NGLL3) - (0)] = templ;\n\
@@ -502,8 +502,8 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
     }\n\
     kappal = d_kappavstore[offset - (0)];\n\
     mul = d_muvstore[offset - (0)];\n\
-    if(ATTENUATION){\n\
-      if(USE_3D_ATTENUATION_ARRAYS){\n\
+    if (ATTENUATION) {\n\
+      if (USE_3D_ATTENUATION_ARRAYS) {\n\
         mul_iso = (mul) * (one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)]);\n\
         mul_aniso = (mul) * (one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)] - (1.0f));\n\
       } else {\n\
@@ -513,13 +513,13 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
     } else {\n\
       mul_iso = mul;\n\
     }\n\
-    if(ANISOTROPY){\n\
+    if (ANISOTROPY) {\n\
       c11 = d_c11store[offset - (0)];\n\
       c12 = d_c12store[offset - (0)];\n\
       c13 = d_c13store[offset - (0)];\n\
       c33 = d_c33store[offset - (0)];\n\
       c44 = d_c44store[offset - (0)];\n\
-      if(ATTENUATION){\n\
+      if (ATTENUATION) {\n\
         c11 = c11 + (mul_aniso) * (1.3333333333333333f);\n\
         c12 = c12 - ((mul_aniso) * (0.6666666666666666f));\n\
         c13 = c13 - ((mul_aniso) * (0.6666666666666666f));\n\
@@ -542,14 +542,14 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
       sigma_xz = (mul) * (duzdxl_plus_duxdzl);\n\
       sigma_yz = (mul) * (duzdyl_plus_duydzl);\n\
     }\n\
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){\n\
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {\n\
       compute_element_ic_att_stress(tx, working_element, R_xx, R_yy, R_xy, R_xz, R_yz,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
     }\n\
     sigma_yx = sigma_xy;\n\
     sigma_zx = sigma_xz;\n\
     sigma_zy = sigma_yz;\n\
     jacobianl = (1.0f) / ((xixl) * ((etayl) * (gammazl) - ((etazl) * (gammayl))) - ((xiyl) * ((etaxl) * (gammazl) - ((etazl) * (gammaxl)))) + (xizl) * ((etaxl) * (gammayl) - ((etayl) * (gammaxl))));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       compute_element_ic_gravity(tx, iglob, d_xstore, d_ystore, d_zstore, d_minus_gravity_table, d_minus_deriv_gravity_table, d_density_table, wgll_cube, jacobianl, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_yx,  &sigma_xz,  &sigma_zx,  &sigma_yz,  &sigma_zy,  &rho_s_H1,  &rho_s_H2,  &rho_s_H3);\n\
     }\n\
     s_tempx1[tx - (0)] = (jacobianl) * ((sigma_xx) * (xixl) + (sigma_yx) * (xiyl) + (sigma_zx) * (xizl));\n\
@@ -563,7 +563,7 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
     s_tempz3[tx - (0)] = (jacobianl) * ((sigma_xz) * (gammaxl) + (sigma_yz) * (gammayl) + (sigma_zz) * (gammazl));\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     tempx1l = 0.0f;\n\
     tempx2l = 0.0f;\n\
     tempx3l = 0.0f;\n\
@@ -650,7 +650,7 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
     tempy3l = tempy3l + (s_tempy3[offset - (0)]) * (fac3);\n\
     tempz3l = tempz3l + (s_tempz3[offset - (0)]) * (fac3);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       fac1 = sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)];\n\
       offset = (K) * (NGLL2) + (J) * (NGLLX) + l;\n\
       tempx1l = tempx1l + (s_tempx1[offset - (0)]) * (fac1);\n\
@@ -674,7 +674,7 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
     sum_terms1 =  -((fac1) * (tempx1l) + (fac2) * (tempx2l) + (fac3) * (tempx3l));\n\
     sum_terms2 =  -((fac1) * (tempy1l) + (fac2) * (tempy2l) + (fac3) * (tempy3l));\n\
     sum_terms3 =  -((fac1) * (tempz1l) + (fac2) * (tempz2l) + (fac3) * (tempz3l));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       sum_terms1 = sum_terms1 + rho_s_H1;\n\
       sum_terms2 = sum_terms2 + rho_s_H2;\n\
       sum_terms3 = sum_terms3 + rho_s_H3;\n\
@@ -690,8 +690,8 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
     d_accel[2 - (0) + (iglob - (0)) * (3)] = d_accel[2 - (0) + (iglob - (0)) * (3)] + sum_terms3;\n\
 #endif\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
-      if(NSPEC_INNER_CORE > 1000){\n\
+    if (use_mesh_coloring_gpu) {\n\
+      if (NSPEC_INNER_CORE > 1000) {\n\
 #ifdef USE_TEXTURES_FIELDS\n\
         d_accel[0 - (0) + (iglob - (0)) * (3)] = as_float(read_imageui(d_b_accel_ic_tex, sampler_d_b_accel_ic_tex, int2((iglob) * (3) + 0,0)).x) + sum_terms1;\n\
         d_accel[1 - (0) + (iglob - (0)) * (3)] = as_float(read_imageui(d_b_accel_ic_tex, sampler_d_b_accel_ic_tex, int2((iglob) * (3) + 1,0)).x) + sum_terms2;\n\
@@ -712,10 +712,10 @@ __kernel  void inner_core_impl_kernel_adjoint(const int nb_blocks_to_compute, co
       atomicAdd(d_accel + (iglob) * (3) + 2, sum_terms3);\n\
     }\n\
 #endif\n\
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){\n\
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {\n\
       compute_element_ic_att_memory(tx, working_element, d_muvstore, factor_common, alphaval, betaval, gammaval, R_xx, R_yy, R_xy, R_xz, R_yz, epsilondev_xx, epsilondev_yy, epsilondev_xy, epsilondev_xz, epsilondev_yz, epsilondev_xx_loc, epsilondev_yy_loc, epsilondev_xy_loc, epsilondev_xz_loc, epsilondev_yz_loc, USE_3D_ATTENUATION_ARRAYS);\n\
     }\n\
-    if(COMPUTE_AND_STORE_STRAIN){\n\
+    if (COMPUTE_AND_STORE_STRAIN) {\n\
       epsilondev_xx[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xx_loc;\n\
       epsilondev_yy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_yy_loc;\n\
       epsilondev_xy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xy_loc;\n\

--- a/src/gpu/kernels.gen/inner_core_impl_kernel_forward.cu
+++ b/src/gpu/kernels.gen/inner_core_impl_kernel_forward.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -92,7 +92,7 @@ static __device__ void compute_element_ic_att_stress(const int tx, const int wor
   int i_sls;
   float R_xx_val;
   float R_yy_val;
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));
     R_xx_val = R_xx[offset - (0)];
     R_yy_val = R_yy[offset - (0)];
@@ -115,9 +115,9 @@ static __device__ void compute_element_ic_att_memory(const int tx, const int wor
   float sn;
   float snp1;
   mul = d_muv[tx + (NGLL3_PADDED) * (working_element) - (0)];
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));
-    if(USE_3D_ATTENUATION_ARRAYS){
+    if (USE_3D_ATTENUATION_ARRAYS) {
       factor_loc = (mul) * (factor_common[offset - (0)]);
     } else {
       factor_loc = (mul) * (factor_common[i_sls + (N_SLS) * (working_element) - (0)]);
@@ -174,7 +174,7 @@ static __device__ void compute_element_ic_gravity(const int tx, const int iglob,
   float factor;
   int int_radius;
   radius = d_xstore[iglob - (0)];
-  if(radius < 1.5696123057604773e-05f){
+  if (radius < 1.5696123057604773e-05f) {
     radius = 1.5696123057604773e-05f;
   }
   theta = d_ystore[iglob - (0)];
@@ -182,7 +182,7 @@ static __device__ void compute_element_ic_gravity(const int tx, const int iglob,
   sincosf(theta,  &sin_theta,  &cos_theta);
   sincosf(phi,  &sin_phi,  &cos_phi);
   int_radius = rint(((radius) * (6371.0f)) * (10.0f)) - (1);
-  if(int_radius < 0){
+  if (int_radius < 0) {
     int_radius = 0;
   }
   minus_g = d_minus_gravity_table[int_radius - (0)];
@@ -326,17 +326,17 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
   J = (tx - ((K) * (NGLL2))) / (NGLLX);
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);
-  if(active){
+  if (active) {
 #ifdef USE_MESH_COLORING_GPU
     working_element = bx;
 #else
-    if(use_mesh_coloring_gpu){
+    if (use_mesh_coloring_gpu) {
       working_element = bx;
     } else {
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);
     }
 #endif
-    if(d_idoubling[working_element - (0)] == IFLAG_IN_FICTITIOUS_CUBE){
+    if (d_idoubling[working_element - (0)] == IFLAG_IN_FICTITIOUS_CUBE) {
       active = 0;
     } else {
       iglob = d_ibool[(working_element) * (NGLL3) + tx - (0)] - (1);
@@ -351,7 +351,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
 #endif
     }
   }
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
 #ifdef USE_TEXTURES_CONSTANTS
     sh_hprime_xx[tx - (0)] = tex1Dfetch(d_hprime_xx_ic_tex,tx);
     sh_hprimewgll_xx[tx - (0)] = tex1Dfetch(d_hprimewgll_xx_ic_tex,tx);
@@ -361,7 +361,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
 #endif
   }
   __syncthreads();
-  if(active){
+  if (active) {
     tempx1l = 0.0f;
     tempx2l = 0.0f;
     tempx3l = 0.0f;
@@ -433,7 +433,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     tempy3l = tempy3l + (s_dummyy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);
     tempz3l = tempz3l + (s_dummyz_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];
       tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
       tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);
@@ -473,14 +473,14 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     duxdyl_plus_duydxl = duxdyl + duydxl;
     duzdxl_plus_duxdzl = duzdxl + duxdzl;
     duzdyl_plus_duydzl = duzdyl + duydzl;
-    if(COMPUTE_AND_STORE_STRAIN){
+    if (COMPUTE_AND_STORE_STRAIN) {
       templ = (duxdxl + duydyl + duzdzl) * (0.3333333333333333f);
       epsilondev_xx_loc = duxdxl - (templ);
       epsilondev_yy_loc = duydyl - (templ);
       epsilondev_xy_loc = (duxdyl_plus_duydxl) * (0.5f);
       epsilondev_xz_loc = (duzdxl_plus_duxdzl) * (0.5f);
       epsilondev_yz_loc = (duzdyl_plus_duydzl) * (0.5f);
-      if(NSPEC_INNER_CORE_STRAIN_ONLY == 1){
+      if (NSPEC_INNER_CORE_STRAIN_ONLY == 1) {
         epsilon_trace_over_3[tx - (0)] = templ;
       } else {
         epsilon_trace_over_3[tx + (working_element) * (NGLL3) - (0)] = templ;
@@ -488,8 +488,8 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     }
     kappal = d_kappavstore[offset - (0)];
     mul = d_muvstore[offset - (0)];
-    if(ATTENUATION){
-      if(USE_3D_ATTENUATION_ARRAYS){
+    if (ATTENUATION) {
+      if (USE_3D_ATTENUATION_ARRAYS) {
         mul_iso = (mul) * (one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)]);
         mul_aniso = (mul) * (one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)] - (1.0f));
       } else {
@@ -499,13 +499,13 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     } else {
       mul_iso = mul;
     }
-    if(ANISOTROPY){
+    if (ANISOTROPY) {
       c11 = d_c11store[offset - (0)];
       c12 = d_c12store[offset - (0)];
       c13 = d_c13store[offset - (0)];
       c33 = d_c33store[offset - (0)];
       c44 = d_c44store[offset - (0)];
-      if(ATTENUATION){
+      if (ATTENUATION) {
         c11 = c11 + (mul_aniso) * (1.3333333333333333f);
         c12 = c12 - ((mul_aniso) * (0.6666666666666666f));
         c13 = c13 - ((mul_aniso) * (0.6666666666666666f));
@@ -528,14 +528,14 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
       sigma_xz = (mul) * (duzdxl_plus_duxdzl);
       sigma_yz = (mul) * (duzdyl_plus_duydzl);
     }
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {
       compute_element_ic_att_stress(tx, working_element, R_xx, R_yy, R_xy, R_xz, R_yz,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);
     }
     sigma_yx = sigma_xy;
     sigma_zx = sigma_xz;
     sigma_zy = sigma_yz;
     jacobianl = (1.0f) / ((xixl) * ((etayl) * (gammazl) - ((etazl) * (gammayl))) - ((xiyl) * ((etaxl) * (gammazl) - ((etazl) * (gammaxl)))) + (xizl) * ((etaxl) * (gammayl) - ((etayl) * (gammaxl))));
-    if(GRAVITY){
+    if (GRAVITY) {
       compute_element_ic_gravity(tx, iglob, d_xstore, d_ystore, d_zstore, d_minus_gravity_table, d_minus_deriv_gravity_table, d_density_table, wgll_cube, jacobianl, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_yx,  &sigma_xz,  &sigma_zx,  &sigma_yz,  &sigma_zy,  &rho_s_H1,  &rho_s_H2,  &rho_s_H3);
     }
     s_tempx1[tx - (0)] = (jacobianl) * ((sigma_xx) * (xixl) + (sigma_yx) * (xiyl) + (sigma_zx) * (xizl));
@@ -549,7 +549,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     s_tempz3[tx - (0)] = (jacobianl) * ((sigma_xz) * (gammaxl) + (sigma_yz) * (gammayl) + (sigma_zz) * (gammazl));
   }
   __syncthreads();
-  if(active){
+  if (active) {
     tempx1l = 0.0f;
     tempx2l = 0.0f;
     tempx3l = 0.0f;
@@ -636,7 +636,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     tempy3l = tempy3l + (s_tempy3[offset - (0)]) * (fac3);
     tempz3l = tempz3l + (s_tempz3[offset - (0)]) * (fac3);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       fac1 = sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)];
       offset = (K) * (NGLL2) + (J) * (NGLLX) + l;
       tempx1l = tempx1l + (s_tempx1[offset - (0)]) * (fac1);
@@ -660,7 +660,7 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     sum_terms1 =  -((fac1) * (tempx1l) + (fac2) * (tempx2l) + (fac3) * (tempx3l));
     sum_terms2 =  -((fac1) * (tempy1l) + (fac2) * (tempy2l) + (fac3) * (tempy3l));
     sum_terms3 =  -((fac1) * (tempz1l) + (fac2) * (tempz2l) + (fac3) * (tempz3l));
-    if(GRAVITY){
+    if (GRAVITY) {
       sum_terms1 = sum_terms1 + rho_s_H1;
       sum_terms2 = sum_terms2 + rho_s_H2;
       sum_terms3 = sum_terms3 + rho_s_H3;
@@ -676,8 +676,8 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
     d_accel[2 - (0) + (iglob - (0)) * (3)] = d_accel[2 - (0) + (iglob - (0)) * (3)] + sum_terms3;
 #endif
 #else
-    if(use_mesh_coloring_gpu){
-      if(NSPEC_INNER_CORE > 1000){
+    if (use_mesh_coloring_gpu) {
+      if (NSPEC_INNER_CORE > 1000) {
 #ifdef USE_TEXTURES_FIELDS
         d_accel[0 - (0) + (iglob - (0)) * (3)] = tex1Dfetch(d_accel_ic_tex,(iglob) * (3) + 0) + sum_terms1;
         d_accel[1 - (0) + (iglob - (0)) * (3)] = tex1Dfetch(d_accel_ic_tex,(iglob) * (3) + 1) + sum_terms2;
@@ -698,10 +698,10 @@ __launch_bounds__(NGLL3_PADDED, LAUNCH_MIN_BLOCKS)
       atomicAdd(d_accel + (iglob) * (3) + 2, sum_terms3);
     }
 #endif
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {
       compute_element_ic_att_memory(tx, working_element, d_muvstore, factor_common, alphaval, betaval, gammaval, R_xx, R_yy, R_xy, R_xz, R_yz, epsilondev_xx, epsilondev_yy, epsilondev_xy, epsilondev_xz, epsilondev_yz, epsilondev_xx_loc, epsilondev_yy_loc, epsilondev_xy_loc, epsilondev_xz_loc, epsilondev_yz_loc, USE_3D_ATTENUATION_ARRAYS);
     }
-    if(COMPUTE_AND_STORE_STRAIN){
+    if (COMPUTE_AND_STORE_STRAIN) {
       epsilondev_xx[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xx_loc;
       epsilondev_yy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_yy_loc;
       epsilondev_xy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xy_loc;

--- a/src/gpu/kernels.gen/inner_core_impl_kernel_forward_cl.c
+++ b/src/gpu/kernels.gen/inner_core_impl_kernel_forward_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -103,7 +103,7 @@ static void compute_element_ic_att_stress(const int tx, const int working_elemen
   int i_sls;\n\
   float R_xx_val;\n\
   float R_yy_val;\n\
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){\n\
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {\n\
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));\n\
     R_xx_val = R_xx[offset - (0)];\n\
     R_yy_val = R_yy[offset - (0)];\n\
@@ -126,9 +126,9 @@ static void compute_element_ic_att_memory(const int tx, const int working_elemen
   float sn;\n\
   float snp1;\n\
   mul = d_muv[tx + (NGLL3_PADDED) * (working_element) - (0)];\n\
-  for(i_sls=0; i_sls<=N_SLS - (1); i_sls+=1){\n\
+  for (i_sls = 0; i_sls <= N_SLS - (1); i_sls += 1) {\n\
     offset = tx + (NGLL3) * (i_sls + (N_SLS) * (working_element));\n\
-    if(USE_3D_ATTENUATION_ARRAYS){\n\
+    if (USE_3D_ATTENUATION_ARRAYS) {\n\
       factor_loc = (mul) * (factor_common[offset - (0)]);\n\
     } else {\n\
       factor_loc = (mul) * (factor_common[i_sls + (N_SLS) * (working_element) - (0)]);\n\
@@ -185,7 +185,7 @@ static void compute_element_ic_gravity(const int tx, const int iglob, const __gl
   float factor;\n\
   int int_radius;\n\
   radius = d_xstore[iglob - (0)];\n\
-  if(radius < 1.5696123057604773e-05f){\n\
+  if (radius < 1.5696123057604773e-05f) {\n\
     radius = 1.5696123057604773e-05f;\n\
   }\n\
   theta = d_ystore[iglob - (0)];\n\
@@ -193,7 +193,7 @@ static void compute_element_ic_gravity(const int tx, const int iglob, const __gl
   sin_theta = sincos(theta,  &cos_theta);\n\
   sin_phi = sincos(phi,  &cos_phi);\n\
   int_radius = rint(((radius) * (6371.0f)) * (10.0f)) - (1);\n\
-  if(int_radius < 0){\n\
+  if (int_radius < 0) {\n\
     int_radius = 0;\n\
   }\n\
   minus_g = d_minus_gravity_table[int_radius - (0)];\n\
@@ -340,17 +340,17 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
   J = (tx - ((K) * (NGLL2))) / (NGLLX);\n\
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));\n\
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);\n\
-  if(active){\n\
+  if (active) {\n\
 #ifdef USE_MESH_COLORING_GPU\n\
     working_element = bx;\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
+    if (use_mesh_coloring_gpu) {\n\
       working_element = bx;\n\
     } else {\n\
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);\n\
     }\n\
 #endif\n\
-    if(d_idoubling[working_element - (0)] == IFLAG_IN_FICTITIOUS_CUBE){\n\
+    if (d_idoubling[working_element - (0)] == IFLAG_IN_FICTITIOUS_CUBE) {\n\
       active = 0;\n\
     } else {\n\
       iglob = d_ibool[(working_element) * (NGLL3) + tx - (0)] - (1);\n\
@@ -365,7 +365,7 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
 #endif\n\
     }\n\
   }\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
 #ifdef USE_TEXTURES_CONSTANTS\n\
     sh_hprime_xx[tx - (0)] = as_float(read_imageui(d_hprime_xx_ic_tex, sampler_d_hprime_xx_ic_tex, int2(tx,0)).x);\n\
     sh_hprimewgll_xx[tx - (0)] = as_float(read_imageui(d_hprimewgll_xx_ic_tex, sampler_d_hprimewgll_xx_ic_tex, int2(tx,0)).x);\n\
@@ -375,7 +375,7 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
 #endif\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     tempx1l = 0.0f;\n\
     tempx2l = 0.0f;\n\
     tempx3l = 0.0f;\n\
@@ -447,7 +447,7 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
     tempy3l = tempy3l + (s_dummyy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);\n\
     tempz3l = tempz3l + (s_dummyz_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (fac3);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       fac1 = sh_hprime_xx[(l) * (NGLLX) + I - (0)];\n\
       tempx1l = tempx1l + (s_dummyx_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
       tempy1l = tempy1l + (s_dummyy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (fac1);\n\
@@ -487,14 +487,14 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
     duxdyl_plus_duydxl = duxdyl + duydxl;\n\
     duzdxl_plus_duxdzl = duzdxl + duxdzl;\n\
     duzdyl_plus_duydzl = duzdyl + duydzl;\n\
-    if(COMPUTE_AND_STORE_STRAIN){\n\
+    if (COMPUTE_AND_STORE_STRAIN) {\n\
       templ = (duxdxl + duydyl + duzdzl) * (0.3333333333333333f);\n\
       epsilondev_xx_loc = duxdxl - (templ);\n\
       epsilondev_yy_loc = duydyl - (templ);\n\
       epsilondev_xy_loc = (duxdyl_plus_duydxl) * (0.5f);\n\
       epsilondev_xz_loc = (duzdxl_plus_duxdzl) * (0.5f);\n\
       epsilondev_yz_loc = (duzdyl_plus_duydzl) * (0.5f);\n\
-      if(NSPEC_INNER_CORE_STRAIN_ONLY == 1){\n\
+      if (NSPEC_INNER_CORE_STRAIN_ONLY == 1) {\n\
         epsilon_trace_over_3[tx - (0)] = templ;\n\
       } else {\n\
         epsilon_trace_over_3[tx + (working_element) * (NGLL3) - (0)] = templ;\n\
@@ -502,8 +502,8 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
     }\n\
     kappal = d_kappavstore[offset - (0)];\n\
     mul = d_muvstore[offset - (0)];\n\
-    if(ATTENUATION){\n\
-      if(USE_3D_ATTENUATION_ARRAYS){\n\
+    if (ATTENUATION) {\n\
+      if (USE_3D_ATTENUATION_ARRAYS) {\n\
         mul_iso = (mul) * (one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)]);\n\
         mul_aniso = (mul) * (one_minus_sum_beta[tx + (working_element) * (NGLL3) - (0)] - (1.0f));\n\
       } else {\n\
@@ -513,13 +513,13 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
     } else {\n\
       mul_iso = mul;\n\
     }\n\
-    if(ANISOTROPY){\n\
+    if (ANISOTROPY) {\n\
       c11 = d_c11store[offset - (0)];\n\
       c12 = d_c12store[offset - (0)];\n\
       c13 = d_c13store[offset - (0)];\n\
       c33 = d_c33store[offset - (0)];\n\
       c44 = d_c44store[offset - (0)];\n\
-      if(ATTENUATION){\n\
+      if (ATTENUATION) {\n\
         c11 = c11 + (mul_aniso) * (1.3333333333333333f);\n\
         c12 = c12 - ((mul_aniso) * (0.6666666666666666f));\n\
         c13 = c13 - ((mul_aniso) * (0.6666666666666666f));\n\
@@ -542,14 +542,14 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
       sigma_xz = (mul) * (duzdxl_plus_duxdzl);\n\
       sigma_yz = (mul) * (duzdyl_plus_duydzl);\n\
     }\n\
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){\n\
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {\n\
       compute_element_ic_att_stress(tx, working_element, R_xx, R_yy, R_xy, R_xz, R_yz,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_xz,  &sigma_yz);\n\
     }\n\
     sigma_yx = sigma_xy;\n\
     sigma_zx = sigma_xz;\n\
     sigma_zy = sigma_yz;\n\
     jacobianl = (1.0f) / ((xixl) * ((etayl) * (gammazl) - ((etazl) * (gammayl))) - ((xiyl) * ((etaxl) * (gammazl) - ((etazl) * (gammaxl)))) + (xizl) * ((etaxl) * (gammayl) - ((etayl) * (gammaxl))));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       compute_element_ic_gravity(tx, iglob, d_xstore, d_ystore, d_zstore, d_minus_gravity_table, d_minus_deriv_gravity_table, d_density_table, wgll_cube, jacobianl, s_dummyx_loc, s_dummyy_loc, s_dummyz_loc,  &sigma_xx,  &sigma_yy,  &sigma_zz,  &sigma_xy,  &sigma_yx,  &sigma_xz,  &sigma_zx,  &sigma_yz,  &sigma_zy,  &rho_s_H1,  &rho_s_H2,  &rho_s_H3);\n\
     }\n\
     s_tempx1[tx - (0)] = (jacobianl) * ((sigma_xx) * (xixl) + (sigma_yx) * (xiyl) + (sigma_zx) * (xizl));\n\
@@ -563,7 +563,7 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
     s_tempz3[tx - (0)] = (jacobianl) * ((sigma_xz) * (gammaxl) + (sigma_yz) * (gammayl) + (sigma_zz) * (gammazl));\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     tempx1l = 0.0f;\n\
     tempx2l = 0.0f;\n\
     tempx3l = 0.0f;\n\
@@ -650,7 +650,7 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
     tempy3l = tempy3l + (s_tempy3[offset - (0)]) * (fac3);\n\
     tempz3l = tempz3l + (s_tempz3[offset - (0)]) * (fac3);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       fac1 = sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)];\n\
       offset = (K) * (NGLL2) + (J) * (NGLLX) + l;\n\
       tempx1l = tempx1l + (s_tempx1[offset - (0)]) * (fac1);\n\
@@ -674,7 +674,7 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
     sum_terms1 =  -((fac1) * (tempx1l) + (fac2) * (tempx2l) + (fac3) * (tempx3l));\n\
     sum_terms2 =  -((fac1) * (tempy1l) + (fac2) * (tempy2l) + (fac3) * (tempy3l));\n\
     sum_terms3 =  -((fac1) * (tempz1l) + (fac2) * (tempz2l) + (fac3) * (tempz3l));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       sum_terms1 = sum_terms1 + rho_s_H1;\n\
       sum_terms2 = sum_terms2 + rho_s_H2;\n\
       sum_terms3 = sum_terms3 + rho_s_H3;\n\
@@ -690,8 +690,8 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
     d_accel[2 - (0) + (iglob - (0)) * (3)] = d_accel[2 - (0) + (iglob - (0)) * (3)] + sum_terms3;\n\
 #endif\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
-      if(NSPEC_INNER_CORE > 1000){\n\
+    if (use_mesh_coloring_gpu) {\n\
+      if (NSPEC_INNER_CORE > 1000) {\n\
 #ifdef USE_TEXTURES_FIELDS\n\
         d_accel[0 - (0) + (iglob - (0)) * (3)] = as_float(read_imageui(d_accel_ic_tex, sampler_d_accel_ic_tex, int2((iglob) * (3) + 0,0)).x) + sum_terms1;\n\
         d_accel[1 - (0) + (iglob - (0)) * (3)] = as_float(read_imageui(d_accel_ic_tex, sampler_d_accel_ic_tex, int2((iglob) * (3) + 1,0)).x) + sum_terms2;\n\
@@ -712,10 +712,10 @@ __kernel  void inner_core_impl_kernel_forward(const int nb_blocks_to_compute, co
       atomicAdd(d_accel + (iglob) * (3) + 2, sum_terms3);\n\
     }\n\
 #endif\n\
-    if(ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY){\n\
+    if (ATTENUATION &&  ! PARTIAL_PHYS_DISPERSION_ONLY) {\n\
       compute_element_ic_att_memory(tx, working_element, d_muvstore, factor_common, alphaval, betaval, gammaval, R_xx, R_yy, R_xy, R_xz, R_yz, epsilondev_xx, epsilondev_yy, epsilondev_xy, epsilondev_xz, epsilondev_yz, epsilondev_xx_loc, epsilondev_yy_loc, epsilondev_xy_loc, epsilondev_xz_loc, epsilondev_yz_loc, USE_3D_ATTENUATION_ARRAYS);\n\
     }\n\
-    if(COMPUTE_AND_STORE_STRAIN){\n\
+    if (COMPUTE_AND_STORE_STRAIN) {\n\
       epsilondev_xx[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xx_loc;\n\
       epsilondev_yy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_yy_loc;\n\
       epsilondev_xy[tx + (working_element) * (NGLL3) - (0)] = epsilondev_xy_loc;\n\

--- a/src/gpu/kernels.gen/noise_add_source_master_rec_kernel.cu
+++ b/src/gpu/kernels.gen/noise_add_source_master_rec_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*

--- a/src/gpu/kernels.gen/noise_add_source_master_rec_kernel_cl.c
+++ b/src/gpu/kernels.gen/noise_add_source_master_rec_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*

--- a/src/gpu/kernels.gen/noise_add_surface_movie_kernel.cu
+++ b/src/gpu/kernels.gen/noise_add_surface_movie_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -89,7 +89,7 @@ __global__ void noise_add_surface_movie_kernel(float * accel, const int * ibool,
   int iface;
   igll = threadIdx.x;
   iface = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(iface < nspec_top){
+  if (iface < nspec_top) {
     int i;
     int j;
     int k;

--- a/src/gpu/kernels.gen/noise_add_surface_movie_kernel_cl.c
+++ b/src/gpu/kernels.gen/noise_add_surface_movie_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -100,7 +100,7 @@ __kernel void noise_add_surface_movie_kernel(__global float * accel, const __glo
   int iface;\n\
   igll = get_local_id(0);\n\
   iface = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(iface < nspec_top){\n\
+  if (iface < nspec_top) {\n\
     int i;\n\
     int j;\n\
     int k;\n\

--- a/src/gpu/kernels.gen/noise_transfer_surface_to_host_kernel.cu
+++ b/src/gpu/kernels.gen/noise_transfer_surface_to_host_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -89,7 +89,7 @@ __global__ void noise_transfer_surface_to_host_kernel(const int * ibelm_top, con
   int iface;
   igll = threadIdx.x;
   iface = blockIdx.x + (blockIdx.y) * (gridDim.x);
-  if(iface < nspec_top){
+  if (iface < nspec_top) {
     int i;
     int j;
     int k;

--- a/src/gpu/kernels.gen/noise_transfer_surface_to_host_kernel_cl.c
+++ b/src/gpu/kernels.gen/noise_transfer_surface_to_host_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -100,7 +100,7 @@ __kernel void noise_transfer_surface_to_host_kernel(const __global int * ibelm_t
   int iface;\n\
   igll = get_local_id(0);\n\
   iface = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
-  if(iface < nspec_top){\n\
+  if (iface < nspec_top) {\n\
     int i;\n\
     int j;\n\
     int k;\n\

--- a/src/gpu/kernels.gen/outer_core_impl_kernel_adjoint.cu
+++ b/src/gpu/kernels.gen/outer_core_impl_kernel_adjoint.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -165,11 +165,11 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
   J = (tx - ((K) * (NGLL2))) / (NGLLX);
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);
-  if(active){
+  if (active) {
 #ifdef USE_MESH_COLORING_GPU
     working_element = bx;
 #else
-    if(use_mesh_coloring_gpu){
+    if (use_mesh_coloring_gpu) {
       working_element = bx;
     } else {
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);
@@ -182,7 +182,7 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
     s_dummy_loc[tx - (0)] = d_potential[iglob - (0)];
 #endif
   }
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
 #ifdef USE_TEXTURES_CONSTANTS
     sh_hprime_xx[tx - (0)] = tex1Dfetch(d_hprime_xx_oc_tex,tx);
     sh_hprimewgll_xx[tx - (0)] = tex1Dfetch(d_hprimewgll_xx_oc_tex,tx);
@@ -192,7 +192,7 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
 #endif
   }
   __syncthreads();
-  if(active){
+  if (active) {
     temp1l = 0.0f;
     temp2l = 0.0f;
     temp3l = 0.0f;
@@ -213,7 +213,7 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
     temp2l = temp2l + (s_dummy_loc[(K) * (NGLL2) + (4) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(4) * (NGLLX) + J - (0)]);
     temp3l = temp3l + (s_dummy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(4) * (NGLLX) + K - (0)]);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       temp1l = temp1l + (s_dummy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + I - (0)]);
       temp2l = temp2l + (s_dummy_loc[(K) * (NGLL2) + (l) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + J - (0)]);
       temp3l = temp3l + (s_dummy_loc[(l) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + K - (0)]);
@@ -233,7 +233,7 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
     dpotentialdxl = (xixl) * (temp1l) + (etaxl) * (temp2l) + (gammaxl) * (temp3l);
     dpotentialdyl = (xiyl) * (temp1l) + (etayl) * (temp2l) + (gammayl) * (temp3l);
     dpotentialdzl = (xizl) * (temp1l) + (etazl) * (temp2l) + (gammazl) * (temp3l);
-    if(ROTATION){
+    if (ROTATION) {
       compute_element_oc_rotation(tx, working_element, time, two_omega_earth, deltat, d_A_array_rotation, d_B_array_rotation, dpotentialdxl, dpotentialdyl,  &dpotentialdx_with_rot,  &dpotentialdy_with_rot);
     } else {
       dpotentialdx_with_rot = dpotentialdxl;
@@ -245,7 +245,7 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
     sincosf(theta,  &sin_theta,  &cos_theta);
     sincosf(phi,  &sin_phi,  &cos_phi);
     int_radius = rint(((radius) * (R_EARTH_KM)) * (10.0f)) - (1);
-    if( ! GRAVITY){
+    if ( ! GRAVITY) {
       grad_x_ln_rho = ((sin_theta) * (cos_phi)) * (d_d_ln_density_dr_table[int_radius - (0)]);
       grad_y_ln_rho = ((sin_theta) * (sin_phi)) * (d_d_ln_density_dr_table[int_radius - (0)]);
       grad_z_ln_rho = (cos_theta) * (d_d_ln_density_dr_table[int_radius - (0)]);
@@ -263,7 +263,7 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
     s_temp3[tx - (0)] = (jacobianl) * ((gammaxl) * (dpotentialdx_with_rot) + (gammayl) * (dpotentialdy_with_rot) + (gammazl) * (dpotentialdzl));
   }
   __syncthreads();
-  if(active){
+  if (active) {
     temp1l = 0.0f;
     temp2l = 0.0f;
     temp3l = 0.0f;
@@ -284,14 +284,14 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
     temp2l = temp2l + (s_temp2[(K) * (NGLL2) + (4) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(J) * (NGLLX) + 4 - (0)]);
     temp3l = temp3l + (s_temp3[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(K) * (NGLLX) + 4 - (0)]);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       temp1l = temp1l + (s_temp1[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)]);
       temp2l = temp2l + (s_temp2[(K) * (NGLL2) + (l) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(J) * (NGLLX) + l - (0)]);
       temp3l = temp3l + (s_temp3[(l) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(K) * (NGLLX) + l - (0)]);
     }
 #endif
     sum_terms =  -((wgllwgll_yz[(K) * (NGLLX) + J - (0)]) * (temp1l) + (wgllwgll_xz[(K) * (NGLLX) + I - (0)]) * (temp2l) + (wgllwgll_xy[(J) * (NGLLX) + I - (0)]) * (temp3l));
-    if(GRAVITY){
+    if (GRAVITY) {
       sum_terms = sum_terms + gravity_term;
     }
 #ifdef USE_MESH_COLORING_GPU
@@ -301,8 +301,8 @@ __global__ void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, c
     d_potential_dot_dot[iglob - (0)] = d_potential_dot_dot[iglob - (0)] + sum_terms;
 #endif
 #else
-    if(use_mesh_coloring_gpu){
-      if(NSPEC_OUTER_CORE > 1000){
+    if (use_mesh_coloring_gpu) {
+      if (NSPEC_OUTER_CORE > 1000) {
 #ifdef USE_TEXTURES_FIELDS
         d_potential_dot_dot[iglob - (0)] = tex1Dfetch(d_b_accel_oc_tex,iglob) + sum_terms;
 #else

--- a/src/gpu/kernels.gen/outer_core_impl_kernel_adjoint_cl.c
+++ b/src/gpu/kernels.gen/outer_core_impl_kernel_adjoint_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -184,11 +184,11 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
   J = (tx - ((K) * (NGLL2))) / (NGLLX);\n\
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));\n\
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);\n\
-  if(active){\n\
+  if (active) {\n\
 #ifdef USE_MESH_COLORING_GPU\n\
     working_element = bx;\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
+    if (use_mesh_coloring_gpu) {\n\
       working_element = bx;\n\
     } else {\n\
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);\n\
@@ -201,7 +201,7 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
     s_dummy_loc[tx - (0)] = d_potential[iglob - (0)];\n\
 #endif\n\
   }\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
 #ifdef USE_TEXTURES_CONSTANTS\n\
     sh_hprime_xx[tx - (0)] = as_float(read_imageui(d_hprime_xx_oc_tex, sampler_d_hprime_xx_oc_tex, int2(tx,0)).x);\n\
     sh_hprimewgll_xx[tx - (0)] = as_float(read_imageui(d_hprimewgll_xx_oc_tex, sampler_d_hprimewgll_xx_oc_tex, int2(tx,0)).x);\n\
@@ -211,7 +211,7 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
 #endif\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     temp1l = 0.0f;\n\
     temp2l = 0.0f;\n\
     temp3l = 0.0f;\n\
@@ -232,7 +232,7 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
     temp2l = temp2l + (s_dummy_loc[(K) * (NGLL2) + (4) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(4) * (NGLLX) + J - (0)]);\n\
     temp3l = temp3l + (s_dummy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(4) * (NGLLX) + K - (0)]);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       temp1l = temp1l + (s_dummy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + I - (0)]);\n\
       temp2l = temp2l + (s_dummy_loc[(K) * (NGLL2) + (l) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + J - (0)]);\n\
       temp3l = temp3l + (s_dummy_loc[(l) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + K - (0)]);\n\
@@ -252,7 +252,7 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
     dpotentialdxl = (xixl) * (temp1l) + (etaxl) * (temp2l) + (gammaxl) * (temp3l);\n\
     dpotentialdyl = (xiyl) * (temp1l) + (etayl) * (temp2l) + (gammayl) * (temp3l);\n\
     dpotentialdzl = (xizl) * (temp1l) + (etazl) * (temp2l) + (gammazl) * (temp3l);\n\
-    if(ROTATION){\n\
+    if (ROTATION) {\n\
       compute_element_oc_rotation(tx, working_element, time, two_omega_earth, deltat, d_A_array_rotation, d_B_array_rotation, dpotentialdxl, dpotentialdyl,  &dpotentialdx_with_rot,  &dpotentialdy_with_rot);\n\
     } else {\n\
       dpotentialdx_with_rot = dpotentialdxl;\n\
@@ -264,7 +264,7 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
     sin_theta = sincos(theta,  &cos_theta);\n\
     sin_phi = sincos(phi,  &cos_phi);\n\
     int_radius = rint(((radius) * (R_EARTH_KM)) * (10.0f)) - (1);\n\
-    if( ! GRAVITY){\n\
+    if ( ! GRAVITY) {\n\
       grad_x_ln_rho = ((sin_theta) * (cos_phi)) * (d_d_ln_density_dr_table[int_radius - (0)]);\n\
       grad_y_ln_rho = ((sin_theta) * (sin_phi)) * (d_d_ln_density_dr_table[int_radius - (0)]);\n\
       grad_z_ln_rho = (cos_theta) * (d_d_ln_density_dr_table[int_radius - (0)]);\n\
@@ -282,7 +282,7 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
     s_temp3[tx - (0)] = (jacobianl) * ((gammaxl) * (dpotentialdx_with_rot) + (gammayl) * (dpotentialdy_with_rot) + (gammazl) * (dpotentialdzl));\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     temp1l = 0.0f;\n\
     temp2l = 0.0f;\n\
     temp3l = 0.0f;\n\
@@ -303,14 +303,14 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
     temp2l = temp2l + (s_temp2[(K) * (NGLL2) + (4) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(J) * (NGLLX) + 4 - (0)]);\n\
     temp3l = temp3l + (s_temp3[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(K) * (NGLLX) + 4 - (0)]);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       temp1l = temp1l + (s_temp1[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)]);\n\
       temp2l = temp2l + (s_temp2[(K) * (NGLL2) + (l) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(J) * (NGLLX) + l - (0)]);\n\
       temp3l = temp3l + (s_temp3[(l) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(K) * (NGLLX) + l - (0)]);\n\
     }\n\
 #endif\n\
     sum_terms =  -((wgllwgll_yz[(K) * (NGLLX) + J - (0)]) * (temp1l) + (wgllwgll_xz[(K) * (NGLLX) + I - (0)]) * (temp2l) + (wgllwgll_xy[(J) * (NGLLX) + I - (0)]) * (temp3l));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       sum_terms = sum_terms + gravity_term;\n\
     }\n\
 #ifdef USE_MESH_COLORING_GPU\n\
@@ -320,8 +320,8 @@ __kernel void outer_core_impl_kernel_adjoint(const int nb_blocks_to_compute, con
     d_potential_dot_dot[iglob - (0)] = d_potential_dot_dot[iglob - (0)] + sum_terms;\n\
 #endif\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
-      if(NSPEC_OUTER_CORE > 1000){\n\
+    if (use_mesh_coloring_gpu) {\n\
+      if (NSPEC_OUTER_CORE > 1000) {\n\
 #ifdef USE_TEXTURES_FIELDS\n\
         d_potential_dot_dot[iglob - (0)] = as_float(read_imageui(d_b_accel_oc_tex, sampler_d_b_accel_oc_tex, int2(iglob,0)).x) + sum_terms;\n\
 #else\n\

--- a/src/gpu/kernels.gen/outer_core_impl_kernel_forward.cu
+++ b/src/gpu/kernels.gen/outer_core_impl_kernel_forward.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -165,11 +165,11 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
   J = (tx - ((K) * (NGLL2))) / (NGLLX);
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);
-  if(active){
+  if (active) {
 #ifdef USE_MESH_COLORING_GPU
     working_element = bx;
 #else
-    if(use_mesh_coloring_gpu){
+    if (use_mesh_coloring_gpu) {
       working_element = bx;
     } else {
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);
@@ -182,7 +182,7 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
     s_dummy_loc[tx - (0)] = d_potential[iglob - (0)];
 #endif
   }
-  if(tx < NGLL2){
+  if (tx < NGLL2) {
 #ifdef USE_TEXTURES_CONSTANTS
     sh_hprime_xx[tx - (0)] = tex1Dfetch(d_hprime_xx_oc_tex,tx);
     sh_hprimewgll_xx[tx - (0)] = tex1Dfetch(d_hprimewgll_xx_oc_tex,tx);
@@ -192,7 +192,7 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
 #endif
   }
   __syncthreads();
-  if(active){
+  if (active) {
     temp1l = 0.0f;
     temp2l = 0.0f;
     temp3l = 0.0f;
@@ -213,7 +213,7 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
     temp2l = temp2l + (s_dummy_loc[(K) * (NGLL2) + (4) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(4) * (NGLLX) + J - (0)]);
     temp3l = temp3l + (s_dummy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(4) * (NGLLX) + K - (0)]);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       temp1l = temp1l + (s_dummy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + I - (0)]);
       temp2l = temp2l + (s_dummy_loc[(K) * (NGLL2) + (l) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + J - (0)]);
       temp3l = temp3l + (s_dummy_loc[(l) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + K - (0)]);
@@ -233,7 +233,7 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
     dpotentialdxl = (xixl) * (temp1l) + (etaxl) * (temp2l) + (gammaxl) * (temp3l);
     dpotentialdyl = (xiyl) * (temp1l) + (etayl) * (temp2l) + (gammayl) * (temp3l);
     dpotentialdzl = (xizl) * (temp1l) + (etazl) * (temp2l) + (gammazl) * (temp3l);
-    if(ROTATION){
+    if (ROTATION) {
       compute_element_oc_rotation(tx, working_element, time, two_omega_earth, deltat, d_A_array_rotation, d_B_array_rotation, dpotentialdxl, dpotentialdyl,  &dpotentialdx_with_rot,  &dpotentialdy_with_rot);
     } else {
       dpotentialdx_with_rot = dpotentialdxl;
@@ -245,7 +245,7 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
     sincosf(theta,  &sin_theta,  &cos_theta);
     sincosf(phi,  &sin_phi,  &cos_phi);
     int_radius = rint(((radius) * (R_EARTH_KM)) * (10.0f)) - (1);
-    if( ! GRAVITY){
+    if ( ! GRAVITY) {
       grad_x_ln_rho = ((sin_theta) * (cos_phi)) * (d_d_ln_density_dr_table[int_radius - (0)]);
       grad_y_ln_rho = ((sin_theta) * (sin_phi)) * (d_d_ln_density_dr_table[int_radius - (0)]);
       grad_z_ln_rho = (cos_theta) * (d_d_ln_density_dr_table[int_radius - (0)]);
@@ -263,7 +263,7 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
     s_temp3[tx - (0)] = (jacobianl) * ((gammaxl) * (dpotentialdx_with_rot) + (gammayl) * (dpotentialdy_with_rot) + (gammazl) * (dpotentialdzl));
   }
   __syncthreads();
-  if(active){
+  if (active) {
     temp1l = 0.0f;
     temp2l = 0.0f;
     temp3l = 0.0f;
@@ -284,14 +284,14 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
     temp2l = temp2l + (s_temp2[(K) * (NGLL2) + (4) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(J) * (NGLLX) + 4 - (0)]);
     temp3l = temp3l + (s_temp3[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(K) * (NGLLX) + 4 - (0)]);
 #else
-    for(l=0; l<=NGLLX - (1); l+=1){
+    for (l = 0; l <= NGLLX - (1); l += 1) {
       temp1l = temp1l + (s_temp1[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)]);
       temp2l = temp2l + (s_temp2[(K) * (NGLL2) + (l) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(J) * (NGLLX) + l - (0)]);
       temp3l = temp3l + (s_temp3[(l) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(K) * (NGLLX) + l - (0)]);
     }
 #endif
     sum_terms =  -((wgllwgll_yz[(K) * (NGLLX) + J - (0)]) * (temp1l) + (wgllwgll_xz[(K) * (NGLLX) + I - (0)]) * (temp2l) + (wgllwgll_xy[(J) * (NGLLX) + I - (0)]) * (temp3l));
-    if(GRAVITY){
+    if (GRAVITY) {
       sum_terms = sum_terms + gravity_term;
     }
 #ifdef USE_MESH_COLORING_GPU
@@ -301,8 +301,8 @@ __global__ void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, c
     d_potential_dot_dot[iglob - (0)] = d_potential_dot_dot[iglob - (0)] + sum_terms;
 #endif
 #else
-    if(use_mesh_coloring_gpu){
-      if(NSPEC_OUTER_CORE > 1000){
+    if (use_mesh_coloring_gpu) {
+      if (NSPEC_OUTER_CORE > 1000) {
 #ifdef USE_TEXTURES_FIELDS
         d_potential_dot_dot[iglob - (0)] = tex1Dfetch(d_accel_oc_tex,iglob) + sum_terms;
 #else

--- a/src/gpu/kernels.gen/outer_core_impl_kernel_forward_cl.c
+++ b/src/gpu/kernels.gen/outer_core_impl_kernel_forward_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -184,11 +184,11 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
   J = (tx - ((K) * (NGLL2))) / (NGLLX);\n\
   I = tx - ((K) * (NGLL2)) - ((J) * (NGLLX));\n\
   active = (tx < NGLL3 && bx < nb_blocks_to_compute ? 1 : 0);\n\
-  if(active){\n\
+  if (active) {\n\
 #ifdef USE_MESH_COLORING_GPU\n\
     working_element = bx;\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
+    if (use_mesh_coloring_gpu) {\n\
       working_element = bx;\n\
     } else {\n\
       working_element = d_phase_ispec_inner[bx + (num_phase_ispec) * (d_iphase - (1)) - (0)] - (1);\n\
@@ -201,7 +201,7 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
     s_dummy_loc[tx - (0)] = d_potential[iglob - (0)];\n\
 #endif\n\
   }\n\
-  if(tx < NGLL2){\n\
+  if (tx < NGLL2) {\n\
 #ifdef USE_TEXTURES_CONSTANTS\n\
     sh_hprime_xx[tx - (0)] = as_float(read_imageui(d_hprime_xx_oc_tex, sampler_d_hprime_xx_oc_tex, int2(tx,0)).x);\n\
     sh_hprimewgll_xx[tx - (0)] = as_float(read_imageui(d_hprimewgll_xx_oc_tex, sampler_d_hprimewgll_xx_oc_tex, int2(tx,0)).x);\n\
@@ -211,7 +211,7 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
 #endif\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     temp1l = 0.0f;\n\
     temp2l = 0.0f;\n\
     temp3l = 0.0f;\n\
@@ -232,7 +232,7 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
     temp2l = temp2l + (s_dummy_loc[(K) * (NGLL2) + (4) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(4) * (NGLLX) + J - (0)]);\n\
     temp3l = temp3l + (s_dummy_loc[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(4) * (NGLLX) + K - (0)]);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       temp1l = temp1l + (s_dummy_loc[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + I - (0)]);\n\
       temp2l = temp2l + (s_dummy_loc[(K) * (NGLL2) + (l) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + J - (0)]);\n\
       temp3l = temp3l + (s_dummy_loc[(l) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprime_xx[(l) * (NGLLX) + K - (0)]);\n\
@@ -252,7 +252,7 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
     dpotentialdxl = (xixl) * (temp1l) + (etaxl) * (temp2l) + (gammaxl) * (temp3l);\n\
     dpotentialdyl = (xiyl) * (temp1l) + (etayl) * (temp2l) + (gammayl) * (temp3l);\n\
     dpotentialdzl = (xizl) * (temp1l) + (etazl) * (temp2l) + (gammazl) * (temp3l);\n\
-    if(ROTATION){\n\
+    if (ROTATION) {\n\
       compute_element_oc_rotation(tx, working_element, time, two_omega_earth, deltat, d_A_array_rotation, d_B_array_rotation, dpotentialdxl, dpotentialdyl,  &dpotentialdx_with_rot,  &dpotentialdy_with_rot);\n\
     } else {\n\
       dpotentialdx_with_rot = dpotentialdxl;\n\
@@ -264,7 +264,7 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
     sin_theta = sincos(theta,  &cos_theta);\n\
     sin_phi = sincos(phi,  &cos_phi);\n\
     int_radius = rint(((radius) * (R_EARTH_KM)) * (10.0f)) - (1);\n\
-    if( ! GRAVITY){\n\
+    if ( ! GRAVITY) {\n\
       grad_x_ln_rho = ((sin_theta) * (cos_phi)) * (d_d_ln_density_dr_table[int_radius - (0)]);\n\
       grad_y_ln_rho = ((sin_theta) * (sin_phi)) * (d_d_ln_density_dr_table[int_radius - (0)]);\n\
       grad_z_ln_rho = (cos_theta) * (d_d_ln_density_dr_table[int_radius - (0)]);\n\
@@ -282,7 +282,7 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
     s_temp3[tx - (0)] = (jacobianl) * ((gammaxl) * (dpotentialdx_with_rot) + (gammayl) * (dpotentialdy_with_rot) + (gammazl) * (dpotentialdzl));\n\
   }\n\
   barrier(CLK_LOCAL_MEM_FENCE);\n\
-  if(active){\n\
+  if (active) {\n\
     temp1l = 0.0f;\n\
     temp2l = 0.0f;\n\
     temp3l = 0.0f;\n\
@@ -303,14 +303,14 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
     temp2l = temp2l + (s_temp2[(K) * (NGLL2) + (4) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(J) * (NGLLX) + 4 - (0)]);\n\
     temp3l = temp3l + (s_temp3[(4) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(K) * (NGLLX) + 4 - (0)]);\n\
 #else\n\
-    for(l=0; l<=NGLLX - (1); l+=1){\n\
+    for (l = 0; l <= NGLLX - (1); l += 1) {\n\
       temp1l = temp1l + (s_temp1[(K) * (NGLL2) + (J) * (NGLLX) + l - (0)]) * (sh_hprimewgll_xx[(I) * (NGLLX) + l - (0)]);\n\
       temp2l = temp2l + (s_temp2[(K) * (NGLL2) + (l) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(J) * (NGLLX) + l - (0)]);\n\
       temp3l = temp3l + (s_temp3[(l) * (NGLL2) + (J) * (NGLLX) + I - (0)]) * (sh_hprimewgll_xx[(K) * (NGLLX) + l - (0)]);\n\
     }\n\
 #endif\n\
     sum_terms =  -((wgllwgll_yz[(K) * (NGLLX) + J - (0)]) * (temp1l) + (wgllwgll_xz[(K) * (NGLLX) + I - (0)]) * (temp2l) + (wgllwgll_xy[(J) * (NGLLX) + I - (0)]) * (temp3l));\n\
-    if(GRAVITY){\n\
+    if (GRAVITY) {\n\
       sum_terms = sum_terms + gravity_term;\n\
     }\n\
 #ifdef USE_MESH_COLORING_GPU\n\
@@ -320,8 +320,8 @@ __kernel void outer_core_impl_kernel_forward(const int nb_blocks_to_compute, con
     d_potential_dot_dot[iglob - (0)] = d_potential_dot_dot[iglob - (0)] + sum_terms;\n\
 #endif\n\
 #else\n\
-    if(use_mesh_coloring_gpu){\n\
-      if(NSPEC_OUTER_CORE > 1000){\n\
+    if (use_mesh_coloring_gpu) {\n\
+      if (NSPEC_OUTER_CORE > 1000) {\n\
 #ifdef USE_TEXTURES_FIELDS\n\
         d_potential_dot_dot[iglob - (0)] = as_float(read_imageui(d_accel_oc_tex, sampler_d_accel_oc_tex, int2(iglob,0)).x) + sum_terms;\n\
 #else\n\

--- a/src/gpu/kernels.gen/prepare_boundary_accel_on_device.cu
+++ b/src/gpu/kernels.gen/prepare_boundary_accel_on_device.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -90,8 +90,8 @@ __global__ void prepare_boundary_accel_on_device(const float * d_accel, float * 
   int iloc;
   int iinterface;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + ((gridDim.x) * (blockDim.x)) * (threadIdx.y + (blockIdx.y) * (blockDim.y));
-  for(iinterface=0; iinterface<=num_interfaces - (1); iinterface+=1){
-    if(id < d_nibool_interfaces[iinterface - (0)]){
+  for (iinterface = 0; iinterface <= num_interfaces - (1); iinterface += 1) {
+    if (id < d_nibool_interfaces[iinterface - (0)]) {
       iloc = id + (max_nibool_interfaces) * (iinterface);
       iglob = d_ibool_interfaces[iloc - (0)] - (1);
       d_send_accel_buffer[(iloc) * (3) + 0 - (0)] = d_accel[(iglob) * (3) + 0 - (0)];

--- a/src/gpu/kernels.gen/prepare_boundary_accel_on_device_cl.c
+++ b/src/gpu/kernels.gen/prepare_boundary_accel_on_device_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -101,8 +101,8 @@ __kernel void prepare_boundary_accel_on_device(const __global float * d_accel, _
   int iloc;\n\
   int iinterface;\n\
   id = get_global_id(0) + (get_global_size(0)) * (get_global_id(1));\n\
-  for(iinterface=0; iinterface<=num_interfaces - (1); iinterface+=1){\n\
-    if(id < d_nibool_interfaces[iinterface - (0)]){\n\
+  for (iinterface = 0; iinterface <= num_interfaces - (1); iinterface += 1) {\n\
+    if (id < d_nibool_interfaces[iinterface - (0)]) {\n\
       iloc = id + (max_nibool_interfaces) * (iinterface);\n\
       iglob = d_ibool_interfaces[iloc - (0)] - (1);\n\
       d_send_accel_buffer[(iloc) * (3) + 0 - (0)] = d_accel[(iglob) * (3) + 0 - (0)];\n\

--- a/src/gpu/kernels.gen/prepare_boundary_potential_on_device.cu
+++ b/src/gpu/kernels.gen/prepare_boundary_potential_on_device.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -90,8 +90,8 @@ __global__ void prepare_boundary_potential_on_device(const float * d_potential_d
   int iloc;
   int iinterface;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + ((gridDim.x) * (blockDim.x)) * (threadIdx.y + (blockIdx.y) * (blockDim.y));
-  for(iinterface=0; iinterface<=num_interfaces - (1); iinterface+=1){
-    if(id < d_nibool_interfaces[iinterface - (0)]){
+  for (iinterface = 0; iinterface <= num_interfaces - (1); iinterface += 1) {
+    if (id < d_nibool_interfaces[iinterface - (0)]) {
       iloc = id + (max_nibool_interfaces) * (iinterface);
       iglob = d_ibool_interfaces[iloc - (0)] - (1);
       d_send_potential_dot_dot_buffer[iloc - (0)] = d_potential_dot_dot_acoustic[iglob - (0)];

--- a/src/gpu/kernels.gen/prepare_boundary_potential_on_device_cl.c
+++ b/src/gpu/kernels.gen/prepare_boundary_potential_on_device_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -101,8 +101,8 @@ __kernel void prepare_boundary_potential_on_device(const __global float * d_pote
   int iloc;\n\
   int iinterface;\n\
   id = get_global_id(0) + (get_global_size(0)) * (get_global_id(1));\n\
-  for(iinterface=0; iinterface<=num_interfaces - (1); iinterface+=1){\n\
-    if(id < d_nibool_interfaces[iinterface - (0)]){\n\
+  for (iinterface = 0; iinterface <= num_interfaces - (1); iinterface += 1) {\n\
+    if (id < d_nibool_interfaces[iinterface - (0)]) {\n\
       iloc = id + (max_nibool_interfaces) * (iinterface);\n\
       iglob = d_ibool_interfaces[iloc - (0)] - (1);\n\
       d_send_potential_dot_dot_buffer[iloc - (0)] = d_potential_dot_dot_acoustic[iglob - (0)];\n\

--- a/src/gpu/kernels.gen/update_accel_acoustic_kernel.cu
+++ b/src/gpu/kernels.gen/update_accel_acoustic_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -87,7 +87,7 @@
 __global__ void update_accel_acoustic_kernel(float * accel, const int size, const float * rmass){
   int id;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + (blockIdx.y) * ((gridDim.x) * (blockDim.x));
-  if(id < size){
+  if (id < size) {
     accel[id - (0)] = (accel[id - (0)]) * (rmass[id - (0)]);
   }
 }

--- a/src/gpu/kernels.gen/update_accel_acoustic_kernel_cl.c
+++ b/src/gpu/kernels.gen/update_accel_acoustic_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -98,7 +98,7 @@ inline void atomicAdd(volatile __global float *source, const float val) {\n\
 __kernel void update_accel_acoustic_kernel(__global float * accel, const int size, const __global float * rmass){\n\
   int id;\n\
   id = get_global_id(0) + (get_group_id(1)) * (get_global_size(0));\n\
-  if(id < size){\n\
+  if (id < size) {\n\
     accel[id - (0)] = (accel[id - (0)]) * (rmass[id - (0)]);\n\
   }\n\
 }\n\

--- a/src/gpu/kernels.gen/update_accel_elastic_kernel.cu
+++ b/src/gpu/kernels.gen/update_accel_elastic_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -87,7 +87,7 @@
 __global__ void update_accel_elastic_kernel(float * accel, const float * veloc, const int size, const float two_omega_earth, const float * rmassx, const float * rmassy, const float * rmassz){
   int id;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + (blockIdx.y) * ((gridDim.x) * (blockDim.x));
-  if(id < size){
+  if (id < size) {
     accel[(id) * (3) - (0)] = (accel[(id) * (3) - (0)]) * (rmassx[id - (0)]) + (two_omega_earth) * (veloc[(id) * (3) + 1 - (0)]);
     accel[(id) * (3) + 1 - (0)] = (accel[(id) * (3) + 1 - (0)]) * (rmassy[id - (0)]) - ((two_omega_earth) * (veloc[(id) * (3) - (0)]));
     accel[(id) * (3) + 2 - (0)] = (accel[(id) * (3) + 2 - (0)]) * (rmassz[id - (0)]);

--- a/src/gpu/kernels.gen/update_accel_elastic_kernel_cl.c
+++ b/src/gpu/kernels.gen/update_accel_elastic_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -98,7 +98,7 @@ inline void atomicAdd(volatile __global float *source, const float val) {\n\
 __kernel void update_accel_elastic_kernel(__global float * accel, const __global float * veloc, const int size, const float two_omega_earth, const __global float * rmassx, const __global float * rmassy, const __global float * rmassz){\n\
   int id;\n\
   id = get_global_id(0) + (get_group_id(1)) * (get_global_size(0));\n\
-  if(id < size){\n\
+  if (id < size) {\n\
     accel[(id) * (3) - (0)] = (accel[(id) * (3) - (0)]) * (rmassx[id - (0)]) + (two_omega_earth) * (veloc[(id) * (3) + 1 - (0)]);\n\
     accel[(id) * (3) + 1 - (0)] = (accel[(id) * (3) + 1 - (0)]) * (rmassy[id - (0)]) - ((two_omega_earth) * (veloc[(id) * (3) - (0)]));\n\
     accel[(id) * (3) + 2 - (0)] = (accel[(id) * (3) + 2 - (0)]) * (rmassz[id - (0)]);\n\

--- a/src/gpu/kernels.gen/update_disp_veloc_kernel.cu
+++ b/src/gpu/kernels.gen/update_disp_veloc_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -87,7 +87,7 @@
 __global__ void update_disp_veloc_kernel(float * displ, float * veloc, float * accel, const int size, const float deltat, const float deltatsqover2, const float deltatover2){
   int id;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + (blockIdx.y) * ((gridDim.x) * (blockDim.x));
-  if(id < size){
+  if (id < size) {
     displ[id - (0)] = displ[id - (0)] + (deltat) * (veloc[id - (0)]) + (deltatsqover2) * (accel[id - (0)]);
     veloc[id - (0)] = veloc[id - (0)] + (deltatover2) * (accel[id - (0)]);
     accel[id - (0)] = 0.0f;

--- a/src/gpu/kernels.gen/update_disp_veloc_kernel_cl.c
+++ b/src/gpu/kernels.gen/update_disp_veloc_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -98,7 +98,7 @@ inline void atomicAdd(volatile __global float *source, const float val) {\n\
 __kernel void update_disp_veloc_kernel(__global float * displ, __global float * veloc, __global float * accel, const int size, const float deltat, const float deltatsqover2, const float deltatover2){\n\
   int id;\n\
   id = get_global_id(0) + (get_group_id(1)) * (get_global_size(0));\n\
-  if(id < size){\n\
+  if (id < size) {\n\
     displ[id - (0)] = displ[id - (0)] + (deltat) * (veloc[id - (0)]) + (deltatsqover2) * (accel[id - (0)]);\n\
     veloc[id - (0)] = veloc[id - (0)] + (deltatover2) * (accel[id - (0)]);\n\
     accel[id - (0)] = 0.0f;\n\

--- a/src/gpu/kernels.gen/update_potential_kernel.cu
+++ b/src/gpu/kernels.gen/update_potential_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -87,7 +87,7 @@
 __global__ void update_potential_kernel(float * potential_acoustic, float * potential_dot_acoustic, float * potential_dot_dot_acoustic, const int size, const float deltat, const float deltatsqover2, const float deltatover2){
   int id;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + (blockIdx.y) * ((gridDim.x) * (blockDim.x));
-  if(id < size){
+  if (id < size) {
     potential_acoustic[id - (0)] = potential_acoustic[id - (0)] + (deltat) * (potential_dot_acoustic[id - (0)]) + (deltatsqover2) * (potential_dot_dot_acoustic[id - (0)]);
     potential_dot_acoustic[id - (0)] = potential_dot_acoustic[id - (0)] + (deltatover2) * (potential_dot_dot_acoustic[id - (0)]);
     potential_dot_dot_acoustic[id - (0)] = 0.0f;

--- a/src/gpu/kernels.gen/update_potential_kernel_cl.c
+++ b/src/gpu/kernels.gen/update_potential_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -98,7 +98,7 @@ inline void atomicAdd(volatile __global float *source, const float val) {\n\
 __kernel void update_potential_kernel(__global float * potential_acoustic, __global float * potential_dot_acoustic, __global float * potential_dot_dot_acoustic, const int size, const float deltat, const float deltatsqover2, const float deltatover2){\n\
   int id;\n\
   id = get_global_id(0) + (get_group_id(1)) * (get_global_size(0));\n\
-  if(id < size){\n\
+  if (id < size) {\n\
     potential_acoustic[id - (0)] = potential_acoustic[id - (0)] + (deltat) * (potential_dot_acoustic[id - (0)]) + (deltatsqover2) * (potential_dot_dot_acoustic[id - (0)]);\n\
     potential_dot_acoustic[id - (0)] = potential_dot_acoustic[id - (0)] + (deltatover2) * (potential_dot_dot_acoustic[id - (0)]);\n\
     potential_dot_dot_acoustic[id - (0)] = 0.0f;\n\

--- a/src/gpu/kernels.gen/update_veloc_acoustic_kernel.cu
+++ b/src/gpu/kernels.gen/update_veloc_acoustic_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -87,7 +87,7 @@
 __global__ void update_veloc_acoustic_kernel(float * veloc, const float * accel, const int size, const float deltatover2){
   int id;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + (blockIdx.y) * ((gridDim.x) * (blockDim.x));
-  if(id < size){
+  if (id < size) {
     veloc[id - (0)] = veloc[id - (0)] + (deltatover2) * (accel[id - (0)]);
   }
 }

--- a/src/gpu/kernels.gen/update_veloc_acoustic_kernel_cl.c
+++ b/src/gpu/kernels.gen/update_veloc_acoustic_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -98,7 +98,7 @@ inline void atomicAdd(volatile __global float *source, const float val) {\n\
 __kernel void update_veloc_acoustic_kernel(__global float * veloc, const __global float * accel, const int size, const float deltatover2){\n\
   int id;\n\
   id = get_global_id(0) + (get_group_id(1)) * (get_global_size(0));\n\
-  if(id < size){\n\
+  if (id < size) {\n\
     veloc[id - (0)] = veloc[id - (0)] + (deltatover2) * (accel[id - (0)]);\n\
   }\n\
 }\n\

--- a/src/gpu/kernels.gen/update_veloc_elastic_kernel.cu
+++ b/src/gpu/kernels.gen/update_veloc_elastic_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -87,7 +87,7 @@
 __global__ void update_veloc_elastic_kernel(float * veloc, const float * accel, const int size, const float deltatover2){
   int id;
   id = threadIdx.x + (blockIdx.x) * (blockDim.x) + (blockIdx.y) * ((gridDim.x) * (blockDim.x));
-  if(id < size){
+  if (id < size) {
     veloc[(id) * (3) - (0)] = veloc[(id) * (3) - (0)] + (deltatover2) * (accel[(id) * (3) - (0)]);
     veloc[(id) * (3) + 1 - (0)] = veloc[(id) * (3) + 1 - (0)] + (deltatover2) * (accel[(id) * (3) + 1 - (0)]);
     veloc[(id) * (3) + 2 - (0)] = veloc[(id) * (3) + 2 - (0)] + (deltatover2) * (accel[(id) * (3) + 2 - (0)]);

--- a/src/gpu/kernels.gen/update_veloc_elastic_kernel_cl.c
+++ b/src/gpu/kernels.gen/update_veloc_elastic_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -98,7 +98,7 @@ inline void atomicAdd(volatile __global float *source, const float val) {\n\
 __kernel void update_veloc_elastic_kernel(__global float * veloc, const __global float * accel, const int size, const float deltatover2){\n\
   int id;\n\
   id = get_global_id(0) + (get_group_id(1)) * (get_global_size(0));\n\
-  if(id < size){\n\
+  if (id < size) {\n\
     veloc[(id) * (3) - (0)] = veloc[(id) * (3) - (0)] + (deltatover2) * (accel[(id) * (3) - (0)]);\n\
     veloc[(id) * (3) + 1 - (0)] = veloc[(id) * (3) + 1 - (0)] + (deltatover2) * (accel[(id) * (3) + 1 - (0)]);\n\
     veloc[(id) * (3) + 2 - (0)] = veloc[(id) * (3) + 2 - (0)] + (deltatover2) * (accel[(id) * (3) + 2 - (0)]);\n\

--- a/src/gpu/kernels.gen/write_seismograms_transfer_from_device_kernel.cu
+++ b/src/gpu/kernels.gen/write_seismograms_transfer_from_device_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -92,7 +92,7 @@ __global__ void write_seismograms_transfer_from_device_kernel(const int * number
   int blockID;
   blockID = blockIdx.x + (blockIdx.y) * (gridDim.x);
   tx = threadIdx.x;
-  if(blockID < nrec_local){
+  if (blockID < nrec_local) {
     irec = number_receiver_global[blockID - (0)] - (1);
     ispec = ispec_selected_rec[irec - (0)] - (1);
     iglob = ibool[tx + (NGLL3) * (ispec) - (0)] - (1);

--- a/src/gpu/kernels.gen/write_seismograms_transfer_from_device_kernel_cl.c
+++ b/src/gpu/kernels.gen/write_seismograms_transfer_from_device_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -103,7 +103,7 @@ __kernel void write_seismograms_transfer_from_device_kernel(const __global int *
   int blockID;\n\
   blockID = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
   tx = get_local_id(0);\n\
-  if(blockID < nrec_local){\n\
+  if (blockID < nrec_local) {\n\
     irec = number_receiver_global[blockID - (0)] - (1);\n\
     ispec = ispec_selected_rec[irec - (0)] - (1);\n\
     iglob = ibool[tx + (NGLL3) * (ispec) - (0)] - (1);\n\

--- a/src/gpu/kernels.gen/write_seismograms_transfer_strain_from_device_kernel.cu
+++ b/src/gpu/kernels.gen/write_seismograms_transfer_strain_from_device_kernel.cu
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -92,7 +92,7 @@ __global__ void write_seismograms_transfer_strain_from_device_kernel(const int *
   int blockID;
   blockID = blockIdx.x + (blockIdx.y) * (gridDim.x);
   tx = threadIdx.x;
-  if(blockID < nrec_local){
+  if (blockID < nrec_local) {
     irec = number_receiver_global[blockID - (0)] - (1);
     ispec = ispec_selected_rec[irec - (0)] - (1);
     iglob = ibool[tx + (NGLL3) * (ispec) - (0)] - (1);

--- a/src/gpu/kernels.gen/write_seismograms_transfer_strain_from_device_kernel_cl.c
+++ b/src/gpu/kernels.gen/write_seismograms_transfer_strain_from_device_kernel_cl.c
@@ -1,5 +1,5 @@
 //note: please do not modify this file manually!
-//      this file has been generated automatically by BOAST version 0.9992
+//      this file has been generated automatically by BOAST version 0.9995
 //      by: make boast_kernels
 
 /*
@@ -103,7 +103,7 @@ __kernel void write_seismograms_transfer_strain_from_device_kernel(const __globa
   int blockID;\n\
   blockID = get_group_id(0) + (get_group_id(1)) * (get_num_groups(0));\n\
   tx = get_local_id(0);\n\
-  if(blockID < nrec_local){\n\
+  if (blockID < nrec_local) {\n\
     irec = number_receiver_global[blockID - (0)] - (1);\n\
     ispec = ispec_selected_rec[irec - (0)] - (1);\n\
     iglob = ibool[tx + (NGLL3) * (ispec) - (0)] - (1);\n\


### PR DESCRIPTION
Again :)

Updated BOAST sources to support version 0.9995+.
Improvement include a new keyword to correctly differentiate between a declaration and the opening of a procedure/controle structure. There are now 4 keywords: print decl open close.
Generated C like language syntax is also closer to coding standards.

You will need to update BOAST in order to continue generating the kernels after this update.

I tested the kernels using the non regression data and found no evidence of a problem.

Brice Videau
