### PR TITLE
Fixed a small bug with CEM compilation.

### DIFF
--- a/src/meshfem3D/get_model.F90
+++ b/src/meshfem3D/get_model.F90
@@ -157,7 +157,7 @@
                               c11,c12,c13,c14,c15,c16,c22,c23,c24,c25,c26,&
                               c33,c34,c35,c36,c44,c45,c46,c55,c56,c66 &
 #if defined (CEM)
-                              ,ispec,i,j,k
+                              ,ispec,i,j,k &
 #endif
                               )
 

--- a/src/meshfem3D/meshfem3D_models.F90
+++ b/src/meshfem3D/meshfem3D_models.F90
@@ -351,7 +351,7 @@
                               c11,c12,c13,c14,c15,c16,c22,c23,c24,c25,c26,&
                               c33,c34,c35,c36,c44,c45,c46,c55,c56,c66 &
 #if defined (CEM)
-                              ,ispec,i,j,k
+                              ,ispec,i,j,k &
 #endif
                               )
 


### PR DESCRIPTION
Just added an ampersand in the 'ifdef CEM' argument passing for get3Dmntl_val, ./configure with --with-cem was failing.
