### PR TITLE
Switch xlf to -qstrict.

### DIFF
--- a/flags.guess
+++ b/flags.guess
@@ -195,7 +195,7 @@ case $my_FC in
         # On IBM BlueGene at IDRIS (France) use:
         # -qtune=auto -qarch=450d -qsave     instead of -qtune=auto -qarch=auto
         DEF_FFLAGS="-qassert=contig -qhot -q64 -qtune=auto -qarch=auto -qcache=auto -qfree=f90 -qsuffix=f=f90 -qhalt=w -qlanglvl=2003std -g -qsuppress=1518-234 -qsuppress=1518-317 -qsuppress=1518-318 -qsuppress=1500-036"
-        OPT_FFLAGS="-O4 -qnostrict -Q -Wl,-relax"
+        OPT_FFLAGS="-O4 -qstrict -Q -Wl,-relax"
         # Options -qreport -qsource -qlist create a *.lst file containing detailed information about vectorization.
         DEBUG_FFLAGS="-g -O0 -C -qddim -qfullpath -qflttrap=overflow:zerodivide:invalid:enable -qfloat=nans -qinitauto=7FBFFFFF"
         ;;


### PR DESCRIPTION
This change prevents some minor differences of results between xlf and
other compilers. There is a small decrease in performance, but generally
it can be overshadowed by other problems like slow I/O.
