### PR TITLE
Increase iterations for xi and eta to 5.

### DIFF
--- a/setup/constants.h.in
+++ b/setup/constants.h.in
@@ -715,8 +715,9 @@
 ! number of lines per source in CMTSOLUTION file
   integer, parameter :: NLINES_PER_CMTSOLUTION_SOURCE = 13
 
-! number of iterations to solve the non linear system for xi and eta
-  integer, parameter :: NUM_ITER = 4
+! number of iterations to solve the non linear system for xi and eta; this value
+! should be the minimum required to produce consistent results between compilers
+  integer, parameter :: NUM_ITER = 5
 
 ! number of hours per day for rotation rate of the Earth
   double precision, parameter :: HOURS_PER_DAY = 24.d0


### PR DESCRIPTION
This should produce consistent results when comparing ifort, gfortran and xlf.

Should fix #202.
