### PR TITLE
Change default compiler for regional_Greece_small

### DIFF
--- a/EXAMPLES/regional_Greece_small/run_this_example.sh
+++ b/EXAMPLES/regional_Greece_small/run_this_example.sh
@@ -32,9 +32,9 @@ rm -rf OUTPUT_FILES/*
 # using default configuration
 cd ../../
 # configures package with ifort compiler
-./configure F90=ifort MPIF90=/usr/local/openmpi-ifort/bin/mpif90 FLAGS_CHECK="-O3 -assume byterecl" > tmp.log
+#./configure F90=ifort MPIF90=/usr/local/openmpi-ifort/bin/mpif90 FLAGS_CHECK="-O3 -assume byterecl" > tmp.log
 # configures package with gfortran compiler
-#./configure F90=gfortran MPIF90=mpif90 FLAGS_CHECK="-O3"
+./configure F90=gfortran MPIF90=mpif90 FLAGS_CHECK="-O3"
 
 # compiles for a forward simulation
 cp $currentdir/DATA/Par_file DATA/Par_file


### PR DESCRIPTION
In the script run_this_example.sh, the code was configured with

./configure F90=ifort MPIF90=/usr/local/openmpi-ifort/bin/mpif90 \
 FLAGS_CHECK="-O3 -assume byterecl" > tmp.log

by default. This is a not a standard setting. And it causes some issues
with running the buildbot test.

This commit sets the default to the GNU compilers.
