### PR TITLE
remove cl_khr_int64_base_atomics need in fp32

### DIFF
--- a/src/gpu/boast/HEADER.rb
+++ b/src/gpu/boast/HEADER.rb
@@ -82,6 +82,8 @@ module BOAST
     if BOAST::get_lang == CL then
       if BOAST::get_default_real_size == 8 or opts[:double] then
         BOAST::get_output.puts "#pragma OPENCL EXTENSION cl_khr_fp64: enable"
+      end
+      if BOAST::get_default_real_size == 8 then
         BOAST::get_output.puts "#pragma OPENCL EXTENSION cl_khr_int64_base_atomics: enable"
       end
       load "./atomicAdd_f.rb"


### PR DESCRIPTION
This should allow compiling kernels on an intel architecture as cl_khr_int64_base_atomics is not supported on those. This extension is not needed when using fp32 but only if the whole code goes fp64.

Regards,

Brice