### PR TITLE
Setup GLL points earlier in the solver.

### DIFF
--- a/src/specfem3D/specfem3D.F90
+++ b/src/specfem3D/specfem3D.F90
@@ -461,11 +461,11 @@
   ! initializes simulation parameters
   call initialize_simulation()
 
-  ! starts reading the databases
-  call read_mesh_databases()
-
   ! sets up reference element GLL points/weights/derivatives
   call setup_GLL_points()
+
+  ! starts reading the databases
+  call read_mesh_databases()
 
   ! reads topography & bathymetry & ellipticity
   call read_topography_bathymetry()


### PR DESCRIPTION
The GLL point setup is pretty independent, and is needed earlier if using a regular kernel grid.