### PR TITLE
Apply changes for performance improvement of OpenMP execution

### DIFF
--- a/src/specfem3D/compute_forces_crust_mantle_Dev.F90
+++ b/src/specfem3D/compute_forces_crust_mantle_Dev.F90
@@ -329,6 +329,9 @@
 !DIR$ IVDEP
     do ijk = 1,NGLLCUBE
 #else
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+!$OMP CRITICAL
+#endif
     do k = 1,NGLLZ
       do j = 1,NGLLY
         do i = 1,NGLLX
@@ -360,6 +363,9 @@
         enddo
       enddo
     enddo
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+!$OMP END CRITICAL
+#endif
 #endif
     ! update memory variables based upon the Runge-Kutta scheme
     ! convention for attenuation

--- a/src/specfem3D/compute_forces_inner_core_Dev.F90
+++ b/src/specfem3D/compute_forces_inner_core_Dev.F90
@@ -688,6 +688,9 @@
 !DIR$ IVDEP
       do ijk = 1,NGLLCUBE
 #else
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+!$OMP CRITICAL
+#endif
       do k = 1,NGLLZ
         do j = 1,NGLLY
           do i = 1,NGLLX
@@ -718,6 +721,9 @@
           enddo
         enddo
       enddo
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+!$OMP END CRITICAL
+#endif
 #endif
 
       ! use Runge-Kutta scheme to march memory variables in time

--- a/src/specfem3D/compute_forces_outer_core_Dev.F90
+++ b/src/specfem3D/compute_forces_outer_core_Dev.F90
@@ -410,6 +410,9 @@
 !DIR$ IVDEP
     do ijk = 1,NGLLCUBE
 #else
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+!$OMP CRITICAL
+#endif
     do k = 1,NGLLZ
       do j = 1,NGLLY
         do i = 1,NGLLX
@@ -429,6 +432,9 @@
         enddo
       enddo
     enddo
+#ifndef USE_OPENMP_ATOMIC_INSTEAD_OF_CRITICAL
+!$OMP END CRITICAL
+#endif
 #endif
 
     ! update rotation term with Euler scheme

--- a/src/specfem3D/prepare_timerun.f90
+++ b/src/specfem3D/prepare_timerun.f90
@@ -3355,6 +3355,8 @@
 
   use specfem_par
   use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
   implicit none
 
   integer :: iphase
@@ -3382,6 +3384,38 @@
                       ibool_crust_mantle,phase_iglob_crust_mantle, &
                       ibool_inv_tbl_crust_mantle, ibool_inv_st_crust_mantle, &
                       num_globs_crust_mantle)
+
+  !---- inner core : outer elements (iphase=1)
+  iphase=1 
+  call make_inv_table(iphase,NGLOB_INNER_CORE,NSPEC_INNER_CORE, &
+                      nspec_outer_inner_core,phase_ispec_inner_inner_core, &
+                      ibool_inner_core,phase_iglob_inner_core, &
+                      ibool_inv_tbl_inner_core, ibool_inv_st_inner_core, &
+                      num_globs_inner_core)
+
+  !---- inner core : inner elements (iphase=2)
+  iphase=2
+  call make_inv_table(iphase,NGLOB_INNER_CORE,NSPEC_INNER_CORE, &
+                      nspec_inner_inner_core,phase_ispec_inner_inner_core, &
+                      ibool_inner_core,phase_iglob_inner_core, &
+                      ibool_inv_tbl_inner_core, ibool_inv_st_inner_core, &
+                      num_globs_inner_core)
+
+  !---- outer core : outer elements (iphase=1)
+  iphase=1 
+  call make_inv_table(iphase,NGLOB_OUTER_CORE,NSPEC_OUTER_CORE, &
+                      nspec_outer_outer_core,phase_ispec_inner_outer_core, &
+                      ibool_outer_core,phase_iglob_outer_core, &
+                      ibool_inv_tbl_outer_core, ibool_inv_st_outer_core, &
+                      num_globs_outer_core)
+
+  !---- outer core : inner elements (iphase=2)
+  iphase=2
+  call make_inv_table(iphase,NGLOB_OUTER_CORE,NSPEC_OUTER_CORE, &
+                      nspec_inner_outer_core,phase_ispec_inner_outer_core, &
+                      ibool_outer_core,phase_iglob_outer_core, &
+                      ibool_inv_tbl_outer_core, ibool_inv_st_outer_core, &
+                      num_globs_outer_core)
 
   ! user output
   if (myrank == 0) then

--- a/src/specfem3D/specfem3D_par.F90
+++ b/src/specfem3D/specfem3D_par.F90
@@ -334,8 +334,10 @@ module specfem_par_crustmantle
   ! mesh parameters
   integer, dimension(NGLLX,NGLLY,NGLLZ,NSPEC_CRUST_MANTLE) :: ibool_crust_mantle
 
-  integer, dimension(NGLOB_CRUST_MANTLE+1) :: ibool_inv_st_crust_mantle
-  integer, dimension(NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE) :: ibool_inv_tbl_crust_mantle
+  integer, dimension(NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE,2) :: ibool_inv_tbl_crust_mantle
+  integer, dimension(NGLOB_CRUST_MANTLE+1,2) :: ibool_inv_st_crust_mantle
+  integer, dimension(2) :: num_globs_crust_mantle
+  integer, dimension(NGLOB_CRUST_MANTLE,2) :: phase_iglob_crust_mantle
 
   real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NSPEC_CRUST_MANTLE) :: &
     xix_crust_mantle,xiy_crust_mantle,xiz_crust_mantle,&

--- a/src/specfem3D/specfem3D_par.F90
+++ b/src/specfem3D/specfem3D_par.F90
@@ -334,6 +334,9 @@ module specfem_par_crustmantle
   ! mesh parameters
   integer, dimension(NGLLX,NGLLY,NGLLZ,NSPEC_CRUST_MANTLE) :: ibool_crust_mantle
 
+  integer, dimension(NGLOB_CRUST_MANTLE+1) :: ibool_inv_st_crust_mantle
+  integer, dimension(NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE) :: ibool_inv_tbl_crust_mantle
+
   real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NSPEC_CRUST_MANTLE) :: &
     xix_crust_mantle,xiy_crust_mantle,xiz_crust_mantle,&
     etax_crust_mantle,etay_crust_mantle,etaz_crust_mantle, &

--- a/src/specfem3D/specfem3D_par.F90
+++ b/src/specfem3D/specfem3D_par.F90
@@ -520,6 +520,11 @@ module specfem_par_innercore
   ! mesh parameters
   integer, dimension(NGLLX,NGLLY,NGLLZ,NSPEC_INNER_CORE) :: ibool_inner_core
 
+  integer, dimension(NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE,2) :: ibool_inv_tbl_inner_core
+  integer, dimension(NGLOB_CRUST_MANTLE+1,2) :: ibool_inv_st_inner_core
+  integer, dimension(2) :: num_globs_inner_core
+  integer, dimension(NGLOB_CRUST_MANTLE,2) :: phase_iglob_inner_core
+
   real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NSPEC_INNER_CORE) :: &
     xix_inner_core,xiy_inner_core,xiz_inner_core,&
     etax_inner_core,etay_inner_core,etaz_inner_core, &
@@ -631,6 +636,11 @@ module specfem_par_outercore
   ! ----------------- outer core ---------------------
   ! mesh parameters
   integer, dimension(NGLLX,NGLLY,NGLLZ,NSPEC_OUTER_CORE) :: ibool_outer_core
+
+  integer, dimension(NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE,2) :: ibool_inv_tbl_outer_core
+  integer, dimension(NGLOB_CRUST_MANTLE+1,2) :: ibool_inv_st_outer_core
+  integer, dimension(2) :: num_globs_outer_core
+  integer, dimension(NGLOB_CRUST_MANTLE,2) :: phase_iglob_outer_core
 
   real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NSPEC_OUTER_CORE) :: &
     xix_outer_core,xiy_outer_core,xiz_outer_core,&

--- a/src/specfem3D/update_displacement_Newmark.f90
+++ b/src/specfem3D/update_displacement_Newmark.f90
@@ -406,12 +406,12 @@
   !   - inner core region
   !         needs both, acceleration update & velocity corrector terms
 
+  if (FORCE_VECTORIZATION_VAL) then
+
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP SHARED( NGLOB_CM, veloc_crust_mantle, deltatover2, &
 !$OMP accel_crust_mantle, NGLOB_IC, veloc_inner_core, accel_inner_core) &
 !$OMP PRIVATE(i)
-
-  if (FORCE_VECTORIZATION_VAL) then
 
     ! crust/mantle
 !$OMP DO SCHEDULE(GUIDED)
@@ -427,6 +427,8 @@
     enddo
 !$OMP enddo
 
+!$OMP END PARALLEL
+
   else
 
     ! crust/mantle
@@ -440,8 +442,6 @@
     enddo
 
   endif
-
-!$OMP END PARALLEL
 
   end subroutine update_veloc_elastic
 


### PR DESCRIPTION
Apply changes for performance improvement of OpenMP execution

Following are measured speedup values of 8 thread execution relative to 1 thread. 

Time stepping loop -> 6.81x 
compute_forces_outer_core -> 7.63x 
compute_forces_crust_mantle -> 7.80x 
compute_forces_inner_core -> 4.52x 

[Execution environment]
-regional_Greece_small
-SGI ICE X (Intel Xeon E5-2670, 8cores/CPU, 2CPUs/node)
-I used 2nodes, 4CPUs and 32cores.

![waveform regional_greece_small](https://cloud.githubusercontent.com/assets/13531065/11230793/74afe83e-8de5-11e5-999d-62344d7cf8ec.png)
