### PR TITLE
Module variable cleanup

### DIFF
--- a/src/meshfem3D/model_attenuation.f90
+++ b/src/meshfem3D/model_attenuation.f90
@@ -65,31 +65,11 @@
 ! standard routine to setup model
 
   use constants
+  use meshfem3D_models_par,only: model_attenuation_variables
 
   implicit none
 
-! model_attenuation_variables
-  type model_attenuation_variables
-    sequence
-    double precision min_period, max_period
-    double precision                          :: QT_c_source        ! Source Frequency
-    double precision, dimension(:), pointer   :: Qtau_s             ! tau_sigma
-    double precision, dimension(:), pointer   :: QrDisc             ! Discontinuities Defined
-    double precision, dimension(:), pointer   :: Qr                 ! Radius
-    double precision, dimension(:), pointer   :: Qmu                ! Shear Attenuation
-    double precision, dimension(:,:), pointer :: Qtau_e             ! tau_epsilon
-    double precision, dimension(:), pointer   :: Qomsb, Qomsb2      ! one_minus_sum_beta
-    double precision, dimension(:,:), pointer :: Qfc, Qfc2          ! factor_common
-    double precision, dimension(:), pointer   :: Qsf, Qsf2          ! scale_factor
-    integer, dimension(:), pointer            :: Qrmin              ! Max and Mins of idoubling
-    integer, dimension(:), pointer            :: Qrmax              ! Max and Mins of idoubling
-    integer, dimension(:), pointer            :: interval_Q                 ! Steps
-    integer                                   :: Qn                 ! Number of points
-    integer dummy_pad ! padding 4 bytes to align the structure
-  end type model_attenuation_variables
-
-  type (model_attenuation_variables) AM_V
-! model_attenuation_variables
+  type (model_attenuation_variables) :: AM_V
 
   integer :: MIN_ATTENUATION_PERIOD,MAX_ATTENUATION_PERIOD
   integer :: myrank
@@ -116,31 +96,11 @@
   subroutine read_attenuation_model(min_att_period, max_att_period, AM_V)
 
   use constants
+  use meshfem3D_models_par,only: model_attenuation_variables
 
   implicit none
 
-! model_attenuation_variables
-  type model_attenuation_variables
-    sequence
-    double precision min_period, max_period
-    double precision                          :: QT_c_source        ! Source Frequency
-    double precision, dimension(:), pointer   :: Qtau_s             ! tau_sigma
-    double precision, dimension(:), pointer   :: QrDisc             ! Discontinuities Defined
-    double precision, dimension(:), pointer   :: Qr                 ! Radius
-    double precision, dimension(:), pointer   :: Qmu                ! Shear Attenuation
-    double precision, dimension(:,:), pointer :: Qtau_e             ! tau_epsilon
-    double precision, dimension(:), pointer   :: Qomsb, Qomsb2      ! one_minus_sum_beta
-    double precision, dimension(:,:), pointer :: Qfc, Qfc2          ! factor_common
-    double precision, dimension(:), pointer   :: Qsf, Qsf2          ! scale_factor
-    integer, dimension(:), pointer            :: Qrmin              ! Max and Mins of idoubling
-    integer, dimension(:), pointer            :: Qrmax              ! Max and Mins of idoubling
-    integer, dimension(:), pointer            :: interval_Q                 ! Steps
-    integer                                   :: Qn                 ! Number of points
-    integer dummy_pad ! padding 4 bytes to align the structure
-  end type model_attenuation_variables
-
-  type (model_attenuation_variables) AM_V
-! model_attenuation_variables
+  type (model_attenuation_variables) :: AM_V
 
   integer :: min_att_period, max_att_period
 
@@ -167,6 +127,8 @@
                                     R670,R220,R80,AM_V,AM_S,AS_V,CRUSTAL)
 
   use constants
+  use meshfem3D_models_par,only: model_attenuation_variables,model_attenuation_storage_var
+  use meshfem3D_models_par,only: attenuation_simplex_variables
 
   use model_1dref_par, only: &
     NR_REF,Mref_V_radius_ref,Mref_V_Qmu_ref
@@ -182,57 +144,9 @@
 
   implicit none
 
-! model_attenuation_variables
-  type model_attenuation_variables
-    sequence
-    double precision min_period, max_period
-    double precision                          :: QT_c_source        ! Source Frequency
-    double precision, dimension(:), pointer   :: Qtau_s             ! tau_sigma
-    double precision, dimension(:), pointer   :: QrDisc             ! Discontinuities Defined
-    double precision, dimension(:), pointer   :: Qr                 ! Radius
-    double precision, dimension(:), pointer   :: Qmu                ! Shear Attenuation
-    double precision, dimension(:,:), pointer :: Qtau_e             ! tau_epsilon
-    double precision, dimension(:), pointer   :: Qomsb, Qomsb2      ! one_minus_sum_beta
-    double precision, dimension(:,:), pointer :: Qfc, Qfc2          ! factor_common
-    double precision, dimension(:), pointer   :: Qsf, Qsf2          ! scale_factor
-    integer, dimension(:), pointer            :: Qrmin              ! Max and Mins of idoubling
-    integer, dimension(:), pointer            :: Qrmax              ! Max and Mins of idoubling
-    integer, dimension(:), pointer            :: interval_Q                 ! Steps
-    integer                                   :: Qn                 ! Number of points
-    integer dummy_pad ! padding 4 bytes to align the structure
-  end type model_attenuation_variables
-
-  type (model_attenuation_variables) AM_V
-! model_attenuation_variables
-
-! model_attenuation_storage_var
-  type model_attenuation_storage_var
-    sequence
-    double precision, dimension(:,:), pointer :: tau_e_storage
-    double precision, dimension(:), pointer :: Qmu_storage
-    integer Q_resolution
-    integer Q_max
-  end type model_attenuation_storage_var
-
-  type (model_attenuation_storage_var) AM_S
-! model_attenuation_storage_var
-
-! attenuation_simplex_variables
-  type attenuation_simplex_variables
-    sequence
-    double precision Q  ! Q     = Desired Value of Attenuation or Q
-    double precision iQ ! iQ    = 1/Q
-    double precision, dimension(:), pointer ::  f
-    ! f = Frequencies at which to evaluate the solution
-    double precision, dimension(:), pointer :: tau_s
-    ! tau_s = Tau_sigma defined by the frequency range and
-    !             number of standard linear solids
-    integer nf          ! nf    = Number of Frequencies
-    integer nsls        ! nsls  = Number of Standard Linear Solids
-  end type attenuation_simplex_variables
-
-  type(attenuation_simplex_variables) AS_V
-! attenuation_simplex_variables
+  type (model_attenuation_variables) :: AM_V
+  type (model_attenuation_storage_var) :: AM_S
+  type (attenuation_simplex_variables) :: AS_V
 
   integer :: myrank,REFERENCE_1D_MODEL
   double precision :: RICB, RCMB, R670, R220, R80
@@ -337,60 +251,14 @@
 ! includes min_period, max_period, and N_SLS
 
   use constants
+  use meshfem3D_models_par,only: model_attenuation_variables,model_attenuation_storage_var
+  use meshfem3D_models_par,only: attenuation_simplex_variables
 
   implicit none
 
-! model_attenuation_variables
-  type model_attenuation_variables
-    sequence
-    double precision min_period, max_period
-    double precision                          :: QT_c_source        ! Source Frequency
-    double precision, dimension(:), pointer   :: Qtau_s             ! tau_sigma
-    double precision, dimension(:), pointer   :: QrDisc             ! Discontinuities Defined
-    double precision, dimension(:), pointer   :: Qr                 ! Radius
-    double precision, dimension(:), pointer   :: Qmu                ! Shear Attenuation
-    double precision, dimension(:,:), pointer :: Qtau_e             ! tau_epsilon
-    double precision, dimension(:), pointer   :: Qomsb, Qomsb2      ! one_minus_sum_beta
-    double precision, dimension(:,:), pointer :: Qfc, Qfc2          ! factor_common
-    double precision, dimension(:), pointer   :: Qsf, Qsf2          ! scale_factor
-    integer, dimension(:), pointer            :: Qrmin              ! Max and Mins of idoubling
-    integer, dimension(:), pointer            :: Qrmax              ! Max and Mins of idoubling
-    integer, dimension(:), pointer            :: interval_Q                 ! Steps
-    integer                                   :: Qn                 ! Number of points
-    integer dummy_pad ! padding 4 bytes to align the structure
-  end type model_attenuation_variables
-
-  type (model_attenuation_variables) AM_V
-! model_attenuation_variables
-
-! model_attenuation_storage_var
-  type model_attenuation_storage_var
-    sequence
-    double precision, dimension(:,:), pointer :: tau_e_storage
-    double precision, dimension(:), pointer :: Qmu_storage
-    integer Q_resolution
-    integer Q_max
-  end type model_attenuation_storage_var
-
-  type (model_attenuation_storage_var) AM_S
-! model_attenuation_storage_var
-
-! attenuation_simplex_variables
-  type attenuation_simplex_variables
-    sequence
-    double precision Q  ! Q     = Desired Value of Attenuation or Q
-    double precision iQ ! iQ    = 1/Q
-    double precision, dimension(:), pointer ::  f
-    ! f = Frequencies at which to evaluate the solution
-    double precision, dimension(:), pointer :: tau_s
-    ! tau_s = Tau_sigma defined by the frequency range and
-    !             number of standard linear solids
-    integer nf          ! nf    = Number of Frequencies
-    integer nsls        ! nsls  = Number of Standard Linear Solids
-  end type attenuation_simplex_variables
-
-  type(attenuation_simplex_variables) AS_V
-! attenuation_simplex_variables
+  type (model_attenuation_variables) :: AM_V
+  type (model_attenuation_storage_var) :: AM_S
+  type (attenuation_simplex_variables) :: AS_V
 
   double precision :: Qmu_in, T_c_source
   double precision, dimension(N_SLS) :: tau_s, tau_e
@@ -418,20 +286,11 @@
   subroutine model_attenuation_storage(Qmu, tau_e, rw, AM_S)
 
   use constants
+  use meshfem3D_models_par,only: model_attenuation_storage_var
 
   implicit none
 
-! model_attenuation_storage_var
-  type model_attenuation_storage_var
-    sequence
-    double precision, dimension(:,:), pointer :: tau_e_storage
-    double precision, dimension(:), pointer :: Qmu_storage
-    integer Q_resolution
-    integer Q_max
-  end type model_attenuation_storage_var
-
   type (model_attenuation_storage_var) AM_S
-! model_attenuation_storage_var
 
   double precision :: Qmu
   double precision, dimension(N_SLS) :: tau_e
@@ -561,25 +420,11 @@
   subroutine attenuation_invert_by_simplex(t2, t1, n, Q_real, omega_not, tau_s, tau_e, AS_V)
 
   use constants
+  use meshfem3D_models_par,only: attenuation_simplex_variables
 
   implicit none
 
-! attenuation_simplex_variables
-  type attenuation_simplex_variables
-    sequence
-    double precision Q  ! Q     = Desired Value of Attenuation or Q
-    double precision iQ ! iQ    = 1/Q
-    double precision, dimension(:), pointer ::  f
-    ! f = Frequencies at which to evaluate the solution
-    double precision, dimension(:), pointer :: tau_s
-    ! tau_s = Tau_sigma defined by the frequency range and
-    !             number of standard linear solids
-    integer nf          ! nf    = Number of Frequencies
-    integer nsls        ! nsls  = Number of Standard Linear Solids
-  end type attenuation_simplex_variables
-
-  type(attenuation_simplex_variables) AS_V
-! attenuation_simplex_variables
+  type (attenuation_simplex_variables) :: AS_V
 
   ! Input / Output
   integer myrank
@@ -664,24 +509,11 @@
 
   subroutine attenuation_simplex_finish(AS_V)
 
+  use meshfem3D_models_par,only: attenuation_simplex_variables
+
   implicit none
 
-! attenuation_simplex_variables
-  type attenuation_simplex_variables
-    sequence
-    double precision Q  ! Q     = Desired Value of Attenuation or Q
-    double precision iQ ! iQ    = 1/Q
-    double precision, dimension(:), pointer ::  f
-    ! f = Frequencies at which to evaluate the solution
-    double precision, dimension(:), pointer :: tau_s
-    ! tau_s = Tau_sigma defined by the frequency range and
-    !             number of standard linear solids
-    integer nf          ! nf    = Number of Frequencies
-    integer nsls        ! nsls  = Number of Standard Linear Solids
-  end type attenuation_simplex_variables
-
-  type(attenuation_simplex_variables) AS_V
-! attenuation_simplex_variables
+  type (attenuation_simplex_variables) :: AS_V
 
   deallocate(AS_V%f)
   deallocate(AS_V%tau_s)
@@ -692,24 +524,11 @@ end subroutine attenuation_simplex_finish
 !   - See module for explanation
 subroutine attenuation_simplex_setup(nf_in,nsls_in,f_in,Q_in,tau_s_in,AS_V)
 
+  use meshfem3D_models_par,only: attenuation_simplex_variables
+
   implicit none
 
-! attenuation_simplex_variables
-  type attenuation_simplex_variables
-    sequence
-    double precision Q  ! Q     = Desired Value of Attenuation or Q
-    double precision iQ ! iQ    = 1/Q
-    double precision, dimension(:), pointer ::  f
-    ! f = Frequencies at which to evaluate the solution
-    double precision, dimension(:), pointer :: tau_s
-    ! tau_s = Tau_sigma defined by the frequency range and
-    !             number of standard linear solids
-    integer nf          ! nf    = Number of Frequencies
-    integer nsls        ! nsls  = Number of Standard Linear Solids
-  end type attenuation_simplex_variables
-
-  type(attenuation_simplex_variables) AS_V
-! attenuation_simplex_variables
+  type (attenuation_simplex_variables) :: AS_V
 
   integer nf_in, nsls_in
   double precision Q_in
@@ -815,24 +634,11 @@ subroutine attenuation_simplex_setup(nf_in,nsls_in,f_in,Q_in,tau_s_in,AS_V)
 !
   double precision function attenuation_eval(Xin,AS_V)
 
+  use meshfem3D_models_par,only: attenuation_simplex_variables
+
   implicit none
 
-! attenuation_simplex_variables
-  type attenuation_simplex_variables
-    sequence
-    double precision Q  ! Q     = Desired Value of Attenuation or Q
-    double precision iQ ! iQ    = 1/Q
-    double precision, dimension(:), pointer ::  f
-    ! f = Frequencies at which to evaluate the solution
-    double precision, dimension(:), pointer :: tau_s
-    ! tau_s = Tau_sigma defined by the frequency range and
-    !             number of standard linear solids
-    integer nf          ! nf    = Number of Frequencies
-    integer nsls        ! nsls  = Number of Standard Linear Solids
-  end type attenuation_simplex_variables
-
-  type(attenuation_simplex_variables) AS_V
-! attenuation_simplex_variables
+  type (attenuation_simplex_variables) :: AS_V
 
    ! Input
   double precision, dimension(AS_V%nsls) :: Xin
@@ -893,24 +699,11 @@ subroutine attenuation_simplex_setup(nf_in,nsls_in,f_in,Q_in,tau_s_in,AS_V)
 !     See Matlab fminsearch
   subroutine fminsearch(funk, x, n, itercount, tolf, prnt, err, AS_V)
 
+  use meshfem3D_models_par,only: attenuation_simplex_variables
+
   implicit none
 
-! attenuation_simplex_variables
-  type attenuation_simplex_variables
-    sequence
-    double precision Q  ! Q     = Desired Value of Attenuation or Q
-    double precision iQ ! iQ    = 1/Q
-    double precision, dimension(:), pointer ::  f
-    ! f = Frequencies at which to evaluate the solution
-    double precision, dimension(:), pointer :: tau_s
-    ! tau_s = Tau_sigma defined by the frequency range and
-    !             number of standard linear solids
-    integer nf          ! nf    = Number of Frequencies
-    integer nsls        ! nsls  = Number of Standard Linear Solids
-  end type attenuation_simplex_variables
-
-  type(attenuation_simplex_variables) AS_V
-! attenuation_simplex_variables
+  type (attenuation_simplex_variables) :: AS_V
 
   ! Input
   double precision, external :: funk

--- a/src/meshfem3D/model_gll.f90
+++ b/src/meshfem3D/model_gll.f90
@@ -38,24 +38,12 @@
 ! standard routine to setup model
 
   use constants
-  use meshfem3D_models_par,only: TRANSVERSE_ISOTROPY
+  use meshfem3D_models_par,only: TRANSVERSE_ISOTROPY,model_gll_variables
   use meshfem3D_par, only: ADIOS_FOR_MODELS
 
   implicit none
 
   ! GLL model_variables
-  type model_gll_variables
-    sequence
-    ! tomographic iteration model on GLL points
-    double precision :: scale_velocity,scale_density
-    ! isotropic model
-    real(kind=CUSTOM_REAL),dimension(:,:,:,:),pointer :: vs_new,vp_new,rho_new
-    ! transverse isotropic model
-    real(kind=CUSTOM_REAL),dimension(:,:,:,:),pointer :: vsv_new,vpv_new, &
-      vsh_new,vph_new,eta_new
-    logical :: MODEL_GLL
-    logical,dimension(3) :: dummy_pad ! padding 3 bytes to align the structure
-  end type model_gll_variables
   type (model_gll_variables) MGLL_V
 
   integer, dimension(MAX_NUM_REGIONS) :: NSPEC
@@ -222,23 +210,11 @@
   subroutine read_gll_model(myrank,MGLL_V,NSPEC)
 
   use constants
-  use meshfem3D_models_par,only: TRANSVERSE_ISOTROPY
+  use meshfem3D_models_par,only: TRANSVERSE_ISOTROPY,model_gll_variables
 
   implicit none
 
   ! GLL model_variables
-  type model_gll_variables
-    sequence
-    ! tomographic iteration model on GLL points
-    double precision :: scale_velocity,scale_density
-    ! isotropic model
-    real(kind=CUSTOM_REAL),dimension(:,:,:,:),pointer :: vs_new,vp_new,rho_new
-    ! transverse isotropic model
-    real(kind=CUSTOM_REAL),dimension(:,:,:,:),pointer :: vsv_new,vpv_new, &
-      vsh_new,vph_new,eta_new
-    logical :: MODEL_GLL
-    logical,dimension(3) :: dummy_pad ! padding 3 bytes to align the structure
-  end type model_gll_variables
   type (model_gll_variables) MGLL_V
 
   integer, dimension(MAX_NUM_REGIONS) :: NSPEC

--- a/src/meshfem3D/model_gll_adios.F90
+++ b/src/meshfem3D/model_gll_adios.F90
@@ -38,23 +38,11 @@ subroutine read_gll_model_adios(myrank,MGLL_V,NSPEC)
   use constants
   use adios_read_mod
   use adios_helpers_mod
-  use meshfem3D_models_par,only: TRANSVERSE_ISOTROPY
+  use meshfem3D_models_par,only: TRANSVERSE_ISOTROPY,model_gll_variables
 
   implicit none
 
   ! GLL model_variables
-  type model_gll_variables
-    sequence
-    ! tomographic iteration model on GLL points
-    double precision :: scale_velocity,scale_density
-    ! isotropic model
-    real(kind=CUSTOM_REAL),dimension(:,:,:,:),pointer :: vs_new,vp_new,rho_new
-    ! transverse isotropic model
-    real(kind=CUSTOM_REAL),dimension(:,:,:,:),pointer :: vsv_new,vpv_new, &
-      vsh_new,vph_new,eta_new
-    logical :: MODEL_GLL
-    logical,dimension(3) :: dummy_pad ! padding 3 bytes to align the structure
-  end type model_gll_variables
   type (model_gll_variables) MGLL_V
 
   integer, dimension(MAX_NUM_REGIONS) :: NSPEC

--- a/src/specfem3D/check_stability.f90
+++ b/src/specfem3D/check_stability.f90
@@ -38,7 +38,7 @@
   use specfem_par,only: &
     GPU_MODE,Mesh_pointer, &
     COMPUTE_AND_STORE_STRAIN, &
-    SIMULATION_TYPE,time_start,DT,t0, &
+    SIMULATION_TYPE,scale_displ,time_start,DT,t0, &
     NSTEP,it,it_begin,it_end,NUMBER_OF_RUNS,NUMBER_OF_THIS_RUN, &
     myrank,UNDO_ATTENUATION
 
@@ -81,8 +81,6 @@
   integer :: year,mon,day,hr,minutes,timestamp,julian_day_number,day_of_week, &
              timestamp_remote,year_remote,mon_remote,day_remote,hr_remote,minutes_remote,day_of_week_remote
   integer, external :: idaywk
-
-  double precision,parameter :: scale_displ = R_EARTH
 
   ! compute maximum of norm of displacement in each slice
   if (.not. GPU_MODE) then
@@ -362,7 +360,7 @@
 
   use specfem_par,only: &
     GPU_MODE,Mesh_pointer, &
-    SIMULATION_TYPE,time_start,DT,t0, &
+    SIMULATION_TYPE,scale_displ,time_start,DT,t0, &
     NSTEP,it,it_begin,it_end,NUMBER_OF_RUNS,NUMBER_OF_THIS_RUN, &
     myrank
 
@@ -383,8 +381,6 @@
 
   integer :: it_run,nstep_run
   logical :: SHOW_SEPARATE_RUN_INFORMATION
-
-  double precision,parameter :: scale_displ = R_EARTH
 
   ! checks if anything to do
   if (SIMULATION_TYPE /= 3 ) return

--- a/src/specfem3D/compute_arrays_source.f90
+++ b/src/specfem3D/compute_arrays_source.f90
@@ -118,7 +118,7 @@
 
   use constants,only: CUSTOM_REAL,SIZE_REAL,NDIM,NGLLX,NGLLY,NGLLZ,IIN_ADJ,R_EARTH,MAX_STRING_LEN
   use write_seismograms_mod, only: band_instrument_code
-  use specfem_par, only: NUMBER_OF_SIMULTANEOUS_RUNS, mygroup
+  use specfem_par, only: NUMBER_OF_SIMULTANEOUS_RUNS, mygroup, scale_displ_inv
 
   implicit none
 
@@ -145,8 +145,6 @@
   double precision, dimension(NGLLZ) :: zigll
 
   double precision, dimension(NDIM,NDIM) :: nu
-
-  double precision,parameter :: scale_displ_inv = 1.d0/R_EARTH
 
   double precision :: hxir(NGLLX), hpxir(NGLLX), hetar(NGLLY), hpetar(NGLLY), &
         hgammar(NGLLZ), hpgammar(NGLLZ)

--- a/src/specfem3D/compute_seismograms.F90
+++ b/src/specfem3D/compute_seismograms.F90
@@ -119,7 +119,7 @@
     hxir_store,hpxir_store,hetar_store,hpetar_store,hgammar_store,hpgammar_store, &
     tshift_cmt,hdur_gaussian, &
     DT,t0,deltat,it, &
-    scale_displ, &
+    scale_displ,scale_t, &
     hprime_xx,hprime_yy,hprime_zz, &
     ispec_selected_source,number_receiver_global
 
@@ -153,7 +153,6 @@
   double precision :: eps_trace,dxx,dyy,dxy,dxz,dyz
   double precision :: eps_loc(NDIM,NDIM), eps_loc_new(NDIM,NDIM)
   double precision :: stf
-  double precision :: scale_t
 
   real(kind=CUSTOM_REAL) :: displ_s(NDIM,NGLLX,NGLLY,NGLLZ)
   real(kind=CUSTOM_REAL) :: eps_s(NDIM,NDIM), eps_m_s, &
@@ -287,8 +286,6 @@
 
     moment_der(:,:,irec_local) = moment_der(:,:,irec_local) + eps_s(:,:) * stf_deltat
     sloc_der(:,irec_local) = sloc_der(:,irec_local) + eps_m_l_s(:) * stf_deltat
-
-    scale_t = ONE/dsqrt(PI*GRAV*RHOAV)
 
     Kp_deltat= -1.0d0/sqrt(PI)/hdur_gaussian(irec)*exp(-((dble(NSTEP-it)*DT-t0-tshift_cmt(irec))/hdur_gaussian(irec))**2) &
                        * deltat * scale_t

--- a/src/specfem3D/noise_tomography.f90
+++ b/src/specfem3D/noise_tomography.f90
@@ -401,7 +401,6 @@
   real(kind=CUSTOM_REAL), dimension(NDIM,NSTEP) :: noise_src_u
   double precision, dimension(NDIM) :: nu_master       ! component direction chosen at the master receiver
   double precision :: xi_noise, eta_noise, gamma_noise ! master receiver location
-  !double precision,parameter :: scale_displ_inv = 1.d0/R_EARTH ! non-dimensional scaling
   double precision, dimension(NGLLX) :: hxir, hpxir
   double precision, dimension(NGLLY) :: hetar, hpetar
   double precision, dimension(NGLLZ) :: hgammar, hpgammar
@@ -1004,7 +1003,7 @@
   real(kind=CUSTOM_REAL) :: scale_kl
 
   ! scaling factor for kernel units [ s / km^3 ]
-  scale_kl = scale_t/scale_displ * 1.d9
+  scale_kl = scale_t * scale_displ_inv * 1.d9
 
   sigma_kl_crust_mantle(:,:,:,:) = sigma_kl_crust_mantle(:,:,:,:) * scale_kl
 

--- a/src/specfem3D/prepare_timerun.f90
+++ b/src/specfem3D/prepare_timerun.f90
@@ -682,6 +682,7 @@
   scale_t_inv = dsqrt(PI*GRAV*RHOAV)
 
   scale_displ = R_EARTH
+  scale_displ_inv = ONE / scale_displ
 
   scale_veloc = scale_displ * scale_t_inv
 

--- a/src/specfem3D/save_kernels.F90
+++ b/src/specfem3D/save_kernels.F90
@@ -129,12 +129,12 @@
   !                  with the intent to dimensionalize kernel values to [ s km^(-3) ]
   !
   ! kernel unit [ s / km^3 ]
-  scale_kl = scale_t/scale_displ * 1.d9
+  scale_kl = scale_t * scale_displ_inv * 1.d9
   ! For anisotropic kernels
   ! final unit : [s km^(-3) GPa^(-1)]
   scale_kl_ani = scale_t**3 / (RHOAV*R_EARTH**3) * 1.d18
   ! final unit : [s km^(-3) (kg/m^3)^(-1)]
-  scale_kl_rho = scale_t / scale_displ / RHOAV * 1.d9
+  scale_kl_rho = scale_t * scale_displ_inv / RHOAV * 1.d9
 
   ! allocates temporary arrays
   if (SAVE_TRANSVERSE_KL_ONLY) then
@@ -557,7 +557,7 @@
   real(kind=CUSTOM_REAL) :: rhol,kappal,rho_kl,alpha_kl
   integer :: ispec,i,j,k
 
-  scale_kl = scale_t / scale_displ * 1.d9
+  scale_kl = scale_t * scale_displ_inv * 1.d9
 
   ! outer_core
   do ispec = 1, NSPEC_OUTER_CORE
@@ -621,7 +621,7 @@
   integer :: ispec,i,j,k
 
   ! scaling to units
-  scale_kl = scale_t / scale_displ * 1.d9
+  scale_kl = scale_t * scale_displ_inv * 1.d9
 
   ! inner_core
   do ispec = 1, NSPEC_INNER_CORE
@@ -679,7 +679,7 @@
   real(kind=CUSTOM_REAL):: scale_kl
 
   ! kernel unit [ s / km^3 ]
-  scale_kl = scale_t/scale_displ * 1.d9
+  scale_kl = scale_t * scale_displ_inv * 1.d9
 
   ! scale the boundary kernels properly: *scale_kl gives s/km^3 and 1.d3 gives
   ! the relative boundary kernels (for every 1 km) in s/km^2
@@ -806,7 +806,7 @@
   real(kind=CUSTOM_REAL) :: scale_kl
 
   ! scaling factors
-  scale_kl = scale_t/scale_displ * 1.d9
+  scale_kl = scale_t * scale_displ_inv * 1.d9
 
   ! scales approximate Hessian
   hess_kl_crust_mantle(:,:,:,:) = 2._CUSTOM_REAL * hess_kl_crust_mantle(:,:,:,:) * scale_kl

--- a/src/specfem3D/save_regular_kernels.f90
+++ b/src/specfem3D/save_regular_kernels.f90
@@ -63,12 +63,12 @@
   real(kind=CUSTOM_REAL) :: alphav_sq,alphah_sq,betav_sq,betah_sq,bulk_sq
 
   ! scaling factors
-  scale_kl = scale_t/scale_displ * 1.d9
+  scale_kl = scale_t * scale_displ_inv * 1.d9
   ! For anisotropic kernels
   ! final unit : [s km^(-3) GPa^(-1)]
   scale_kl_ani = scale_t**3 / (RHOAV*R_EARTH**3) * 1.d18
   ! final unit : [s km^(-3) (kg/m^3)^(-1)]
-  scale_kl_rho = scale_t / scale_displ / RHOAV * 1.d9
+  scale_kl_rho = scale_t * scale_displ_inv / RHOAV * 1.d9
 
   ! allocates temporary arrays
   allocate(rho_kl_crust_mantle_reg(npoints_slice), &

--- a/src/specfem3D/specfem3D_par.F90
+++ b/src/specfem3D/specfem3D_par.F90
@@ -292,7 +292,7 @@ module specfem_par
   integer :: it
 
   ! non-dimensionalization
-  double precision :: scale_t,scale_t_inv,scale_displ,scale_veloc
+  double precision :: scale_t,scale_t_inv,scale_displ,scale_displ_inv,scale_veloc
 
   ! time scheme parameters
   real(kind=CUSTOM_REAL) :: deltat,deltatover2,deltatsqover2

--- a/src/specfem3D/write_movie_volume.f90
+++ b/src/specfem3D/write_movie_volume.f90
@@ -789,6 +789,7 @@
 ! outputs norm of displacement: MOVIE_VOLUME_TYPE == 7
 
   use constants_solver
+  use specfem_par, only: scale_displ
 
   implicit none
 
@@ -808,14 +809,10 @@
   integer :: ispec,iglob,i,j,k,ier
   character(len=MAX_STRING_LEN) outputname
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: tmp_data
-  real(kind=CUSTOM_REAL) :: scale_displ
 
   logical,parameter :: OUTPUT_CRUST_MANTLE = .true.
   logical,parameter :: OUTPUT_OUTER_CORE = .true.
   logical,parameter :: OUTPUT_INNER_CORE = .true.
-
-  ! dimensionalized scaling
-  scale_displ = R_EARTH
 
   ! outputs norm of displacement
   if (OUTPUT_CRUST_MANTLE) then
@@ -911,6 +908,7 @@
 ! outputs norm of velocity: MOVIE_VOLUME_TYPE == 8
 
   use constants_solver
+  use specfem_par, only: scale_veloc
 
   implicit none
 
@@ -930,15 +928,10 @@
   integer :: ispec,iglob,i,j,k,ier
   character(len=MAX_STRING_LEN) outputname
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: tmp_data
-  real(kind=CUSTOM_REAL) :: scale_displ,scale_veloc
 
   logical,parameter :: OUTPUT_CRUST_MANTLE = .true.
   logical,parameter :: OUTPUT_OUTER_CORE = .true.
   logical,parameter :: OUTPUT_INNER_CORE = .true.
-
-  ! dimensionalized scaling
-  scale_displ = R_EARTH
-  scale_veloc = scale_displ * sqrt(PI*GRAV*RHOAV)
 
   ! outputs norm of velocity
   if (OUTPUT_CRUST_MANTLE) then
@@ -1033,6 +1026,7 @@
 ! outputs norm of acceleration: MOVIE_VOLUME_TYPE == 1
 
   use constants_solver
+  use specfem_par, only: scale_t_inv,scale_veloc
 
   implicit none
 
@@ -1052,16 +1046,14 @@
   integer :: ispec,iglob,i,j,k,ier
   character(len=MAX_STRING_LEN) outputname
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: tmp_data
-  real(kind=CUSTOM_REAL) :: scale_displ,scale_veloc,scale_accel
+  real(kind=CUSTOM_REAL) :: scale_accel
 
   logical,parameter :: OUTPUT_CRUST_MANTLE = .true.
   logical,parameter :: OUTPUT_OUTER_CORE = .true.
   logical,parameter :: OUTPUT_INNER_CORE = .true.
 
   ! dimensionalized scaling
-  scale_displ = R_EARTH
-  scale_veloc = scale_displ * sqrt(PI*GRAV*RHOAV)
-  scale_accel = scale_veloc * dsqrt(PI*GRAV*RHOAV)
+  scale_accel = scale_veloc * scale_t_inv
 
   ! outputs norm of acceleration
   if (OUTPUT_CRUST_MANTLE) then


### PR DESCRIPTION
Remove a few duplicated types and variables that exist in the shared modules and don't need to be re-created everywhere.