### PR TITLE
Updated to reflect BOAST >= v1.3.0 Procedure syntax.

### DIFF
--- a/src/gpu/boast/compute_acoustic_kernel.rb
+++ b/src/gpu/boast/compute_acoustic_kernel.rb
@@ -16,7 +16,7 @@ module BOAST
     ngll3        = Int("NGLL3",        :const => n_gll3)
     ngll3_padded = Int("NGLL3_PADDED", :const => n_gll3_padded)
 
-    p = Procedure(function_name, v, [],:local => true) {
+    p = Procedure(function_name, v, :local => true) {
       decl *templ    = [Real("temp1l"),    Real("temp2l"),    Real("temp3l")]
       decl *hp       = [Real("hp1"),       Real("hp2"),       Real("hp3")]
       decl *xil      = [Real("xixl"),      Real("xiyl"),      Real("xizl")]

--- a/src/gpu/boast/compute_element_att_memory_helper.rb
+++ b/src/gpu/boast/compute_element_att_memory_helper.rb
@@ -41,7 +41,7 @@ module BOAST
     ngll3_padded = Int("NGLL3_PADDED", :const => n_gll3_padded)
     nsls  = Int("N_SLS", :const => n_sls)
 
-    p = Procedure(function_name, v, [], :local => true) {
+    p = Procedure(function_name, v, :local => true) {
       decl offset = Int("offset")
       decl i_sls  = Int("i_sls")
       decl mul = Real("mul")

--- a/src/gpu/boast/compute_element_att_stress_helper.rb
+++ b/src/gpu/boast/compute_element_att_stress_helper.rb
@@ -25,7 +25,7 @@ module BOAST
     ngll3 = Int("NGLL3", :const => n_gll3)
     nsls  = Int("N_SLS", :const => n_sls)
 
-    p = Procedure(function_name, v, [], :local => true) {
+    p = Procedure(function_name, v, :local => true) {
       decl offset = Int("offset")
       decl i_sls  = Int("i_sls")
       decl r_xx_val = Real("R_xx_val")

--- a/src/gpu/boast/compute_element_gravity_helper.rb
+++ b/src/gpu/boast/compute_element_gravity_helper.rb
@@ -34,7 +34,7 @@ module BOAST
                                      Real("rho_s_H#{n}", :dir => :inout, :dim => [Dim()], :private => true )
     }
 
-    p = Procedure(function_name, v, [], :local => true) {
+    p = Procedure(function_name, v, :local => true) {
       decl radius = Real("radius"), theta = Real("theta"), phi = Real("phi")
       decl cos_theta = Real("cos_theta"), sin_theta = Real("sin_theta"), cos_phi = Real("cos_phi"), sin_phi = Real("sin_phi")
       decl cos_theta_sq = Real("cos_theta_sq"), sin_theta_sq = Real("sin_theta_sq"), cos_phi_sq = Real("cos_phi_sq"), sin_phi_sq = Real("sin_phi_sq")

--- a/src/gpu/boast/compute_element_strain_undoatt_helper.rb
+++ b/src/gpu/boast/compute_element_strain_undoatt_helper.rb
@@ -23,7 +23,7 @@ module BOAST
     v.push epsilon_trace_over_3  = Real("epsilon_trace_over_3",          :dir => :out, :dim => [Dim(1)], :register => true )
 
 
-    sub = Procedure(function_name, v, [], :local => true) {
+    sub = Procedure(function_name, v, :local => true) {
       decl tx = Int("tx")
       decl k = Int("K")
       decl j = Int("J")

--- a/src/gpu/boast/compute_strain_product_helper.rb
+++ b/src/gpu/boast/compute_strain_product_helper.rb
@@ -9,7 +9,7 @@ module BOAST
     b_eps_trace_over_3 = Real("b_eps_trace_over_3",:dir => :in)
     b_epsdev           = Real("b_epsdev",          :dir => :in, :dim => [Dim(5)], :register => true )
 
-    sub = Procedure(function_name, [prod, eps_trace_over_3, epsdev, b_eps_trace_over_3, b_epsdev], [], :local => true) {
+    sub = Procedure(function_name, [prod, eps_trace_over_3, epsdev, b_eps_trace_over_3, b_epsdev], :local => true) {
       decl eps   = Real("eps", :dim => [Dim(6)], :allocate => true )
       decl b_eps = Real("b_eps", :dim => [Dim(6)], :allocate => true )
       decl p = Int("p")

--- a/src/gpu/boast/inner_core_impl_kernel_forward.rb
+++ b/src/gpu/boast/inner_core_impl_kernel_forward.rb
@@ -59,7 +59,7 @@ module BOAST
     v.push sigma_xz = Real("sigma_xz", :dir => :out, :dim => [Dim()], :private => true )
     v.push sigma_yz = Real("sigma_yz", :dir => :out, :dim => [Dim()], :private => true )
 
-    p = Procedure( function_name, v, [], :local => true ) {
+    p = Procedure( function_name, v, :local => true ) {
       c = (0..5).collect { |indx1|
             (0..5).collect { |indx2|
               if (indx2 < indx1) then
@@ -132,7 +132,7 @@ module BOAST
     v.push sigma_xz               = Real("sigma_xz",           :dir => :out, :dim => [Dim()], :private => true )
     v.push sigma_yz               = Real("sigma_yz",           :dir => :out, :dim => [Dim()], :private => true )
 
-    p = Procedure( function_name, v, [], :local => true ) {
+    p = Procedure( function_name, v, :local => true ) {
       decl lambdal = Real("lambdal"), mul = Real("mul"), lambdalplus2mul = Real("lambdalplus2mul"), kappal = Real("kappal")
 
       print kappal === d_kappavstore[offset]
@@ -185,7 +185,7 @@ module BOAST
     v.push sigma_xz               = Real("sigma_xz",           :dir => :out, :dim => [Dim()], :private => true )
     v.push sigma_yz               = Real("sigma_yz",           :dir => :out, :dim => [Dim()], :private => true )
 
-    p = Procedure( function_name, v, [], :local => true ) {
+    p = Procedure( function_name, v, :local => true ) {
       decl kappavl = Real("kappavl"), muvl = Real("muvl"), kappahl = Real("kappahl"), muhl = Real("muhl")
       decl rhovpvsq = Real("rhovpvsq"), rhovphsq = Real("rhovphsq"), rhovsvsq = Real("rhovsvsq"), rhovshsq = Real("rhovshsq"), eta_aniso = Real("eta_aniso")
       decl costheta = Real("costheta"), sintheta = Real("sintheta"), cosphi = Real("cosphi"), sinphi = Real("sinphi")
@@ -601,21 +601,21 @@ module BOAST
       if get_lang == CL then
         get_output.puts "#ifdef #{use_textures_fields}"
           get_output.puts "#ifdef #{use_textures_constants}"
-            p = Procedure(function_name, v+textures_fields+textures_constants, constants, :qualifiers => qualifiers)
+            p = Procedure(function_name, v+textures_fields+textures_constants, :constants => constants, :qualifiers => qualifiers)
             open p
             set_indent_level(0)
           get_output.puts "#else"
-            p = Procedure(function_name, v+textures_fields, constants, :qualifiers => qualifiers)
+            p = Procedure(function_name, v+textures_fields, :constants => constants, :qualifiers => qualifiers)
             open p
             set_indent_level(0)
           get_output.puts "#endif"
         get_output.puts "#else"
           get_output.puts "#ifdef #{use_textures_constants}"
-            p = Procedure(function_name, v+textures_constants, constants, :qualifiers => qualifiers)
+            p = Procedure(function_name, v+textures_constants, :constants => constants, :qualifiers => qualifiers)
             open p
             set_indent_level(0)
           get_output.puts "#else"
-            p = Procedure(function_name, v, constants, :qualifiers => qualifiers)
+            p = Procedure(function_name, v, :constants => constants, :qualifiers => qualifiers)
             open p
           get_output.puts "#endif"
         get_output.puts "#endif"
@@ -629,7 +629,7 @@ module BOAST
           decl d_hprimewgll_xx_tex.sampler
         get_output.puts "#endif"
       else
-        p = Procedure(function_name, v, constants, :qualifiers => qualifiers)
+        p = Procedure(function_name, v, :constants => constants, :qualifiers => qualifiers)
         open p
       end
 

--- a/src/gpu/boast/outer_core_impl_kernel_forward.rb
+++ b/src/gpu/boast/outer_core_impl_kernel_forward.rb
@@ -16,7 +16,7 @@ module BOAST
 
     ngll3 = Int("NGLL3", :const => n_gll3)
 
-    p = Procedure(function_name, v, [], :local => true) {
+    p = Procedure(function_name, v, :local => true) {
       decl two_omega_deltat = Real("two_omega_deltat")
       decl cos_two_omega_t  = Real("cos_two_omega_t")
       decl sin_two_omega_t  = Real("sin_two_omega_t")
@@ -173,21 +173,21 @@ module BOAST
       if get_lang == CL then
         get_output.puts "#ifdef #{use_textures_fields}"
           get_output.puts "#ifdef #{use_textures_constants}"
-            p = Procedure(function_name, v+textures_fields+textures_constants, constants)
+            p = Procedure(function_name, v+textures_fields+textures_constants, :constants => constants)
             open p
             set_indent_level(0)
           get_output.puts "#else"
-            p = Procedure(function_name, v+textures_fields, constants)
+            p = Procedure(function_name, v+textures_fields, :constants => constants)
             open p
             set_indent_level(0)
           get_output.puts "#endif"
         get_output.puts "#else"
           get_output.puts "#ifdef #{use_textures_constants}"
-            p = Procedure(function_name, v+textures_constants, constants)
+            p = Procedure(function_name, v+textures_constants, :constants => constants)
             open p
             set_indent_level(0)
           get_output.puts "#else"
-            p = Procedure(function_name, v, constants)
+            p = Procedure(function_name, v, :constants => constants)
             open p
           get_output.puts "#endif"
         get_output.puts "#endif"
@@ -201,7 +201,7 @@ module BOAST
           decl d_hprimewgll_xx_oc_tex.sampler
         get_output.puts "#endif"
       else
-        p = Procedure(function_name, v, constants)
+        p = Procedure(function_name, v, :constants => constants)
         open p
       end
       decl bx = Int("bx")


### PR DESCRIPTION
Kernels don't have to be regenerated, output is identical to previous version.

Best regards,

Brice Videau