### PR TITLE
IMPROVE CI to run test global example with openmp enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ env:
     # run example 2 (global)
     - TEST="--enable-vectorization" TESTCOV=0 TESTMAKE=2
 
+    # run example 2 (global with openmp)
+    - TEST="--enable-vectorization --enable-openmp" TESTCOV=0 TESTMAKE=2
+
     # run example with debug bounds checking (regional)
     - TEST="--enable-debug" TESTCOV=0 TESTMAKE=3
 


### PR DESCRIPTION
This PR allow Travis CI to test for OpenMP build on global simulation.

It's currently failing ([travisCI link](https://travis-ci.org/MisterFruits/specfem3d_globe/jobs/225087142)), but @danielpeter is preparing a fix (this PR could also be integrated directly to the fix patch)