### PR TITLE
now accepting GPU device names that are longer than 12 character

### DIFF
--- a/src/gpu/initialize_gpu.c
+++ b/src/gpu/initialize_gpu.c
@@ -935,7 +935,7 @@ void FC_FUNC_ (initialize_gpu_device,
 
   TRACE ("initialize_device");
 
-  const int STRING_LENGTH = 12; // GPU_PLATFORM and GPU_DEVICE string length (as defined in shared_par.f90 module)
+  const int STRING_LENGTH = 128; // GPU_PLATFORM and GPU_DEVICE string length (as defined in shared_par.f90 module)
 
   char *platform_filter;
   char *device_filter;

--- a/src/shared/broadcast_computed_parameters.f90
+++ b/src/shared/broadcast_computed_parameters.f90
@@ -122,8 +122,8 @@
   call bcast_all_ch(LOCAL_TMP_PATH,MAX_STRING_LEN)
   call bcast_all_ch(MODEL,MAX_STRING_LEN)
 
-  call bcast_all_ch(GPU_PLATFORM,12)
-  call bcast_all_ch(GPU_DEVICE,12)
+  call bcast_all_ch(GPU_PLATFORM,128)
+  call bcast_all_ch(GPU_DEVICE,128)
 
   call bcast_all_i(ner,MAX_NUMBER_OF_MESH_LAYERS)
   call bcast_all_i(ratio_sampling_array,MAX_NUMBER_OF_MESH_LAYERS)

--- a/src/shared/shared_par.f90
+++ b/src/shared/shared_par.f90
@@ -132,8 +132,8 @@
 
   ! GPU simulations
   integer :: GPU_RUNTIME
-  character(len=12) :: GPU_PLATFORM
-  character(len=12) :: GPU_DEVICE
+  character(len=128) :: GPU_PLATFORM
+  character(len=128) :: GPU_DEVICE
   logical :: GPU_MODE
 
   ! adios file output

--- a/src/specfem3D/initialize_simulation.f90
+++ b/src/specfem3D/initialize_simulation.f90
@@ -598,7 +598,7 @@
     endif
 
     ! initializes GPU and outputs info to files for all processes
-    call initialize_gpu_device(GPU_RUNTIME,GPU_PLATFORM,GPU_DEVICE,myrank,ngpu_devices)
+    call initialize_gpu_device(GPU_RUNTIME,GPU_PLATFORM,trim(GPU_DEVICE),myrank,ngpu_devices)
   endif
 
   ! collects min/max of local devices found for statistics


### PR DESCRIPTION
GPU device name had a string of 12 characters, that easily fit 'Tesla' or 'Kepler' or the like, but not 'GeForce GTX 1080'. With this request it does, with room to spare in case the industry comes up with longer names.