### PR TITLE
FIX openmp flag.guess for intel compilers > 17

### DIFF
--- a/flags.guess
+++ b/flags.guess
@@ -9,7 +9,7 @@
 # if you want to compile with OpenMP, add this to the flags listed below, depending on the compiler you use:
 #
 #   -fopenmp for GNU gfortran
-#   -openmp for Intel ifort
+#   -qopenmp for Intel ifort
 #   -mp for Portland pgfortran
 #   -qsmp=omp for IBM xlf
 

--- a/flags.guess
+++ b/flags.guess
@@ -103,8 +103,7 @@ case $my_FC in
         DEF_FFLAGS="-xHost -fpe0 -ftz -assume buffered_io -assume byterecl -align sequence -std08 -diag-disable 6477 -implicitnone -gen-interfaces -warn all" # -mcmodel=medium -shared-intel
         OPT_FFLAGS="-O3 -check nobounds"
         DEBUG_FFLAGS="-check all -debug -g -O0 -fp-stack-check -traceback -ftrapuv"
-        # option "-openmp" is soon deprecated and replaced by "-qopenmp" for versions > 17.x
-        OMP_FFLAGS="-openmp"
+        OMP_FFLAGS="-qopenmp"
         ;;
     gfortran|*/gfortran|f95|*/f95)
         #


### PR DESCRIPTION
The "-openmp" flag has been removed from intel compilers 18.0 and further. This makes the configure fail when using --enable-openmp.
the -qopenmp is valid since intel 15.0.0

$ ifort --version
ifort (IFORT) 15.0.0 20140723
Copyright (C) 1985-2014 Intel Corporation.  All rights reserved.

$ ifort --help | grep qopenmp
-qopenmp  enable the compiler to generate multi-threaded code based on the

