### PR TITLE
global_slice_util: Automatically choose correct module flag

### DIFF
--- a/utils/Visualization/VTK_ParaView/global_slice_util/Makefile
+++ b/utils/Visualization/VTK_ParaView/global_slice_util/Makefile
@@ -1,6 +1,12 @@
 F90 = ifort
 F90_FLAGS = -O3
 
+ifeq ($(F90),ifort)
+MODULE_FLAG = -module
+else
+MODULE_FLAG = -J
+endif
+
 LIB =
 
 SUB_MOD = sub_slice_number
@@ -10,6 +16,8 @@ MOD_DIR = mod
 OBJ_DIR = obj
 BIN_DIR = ..
 
+DIRS = $(MOD_DIR) $(OBJ_DIR) $(BIN_DIR)
+
 SUB_MOD_OBJ = $(patsubst %,$(OBJ_DIR)/%.o,$(SUB_MOD))
 SRC_OBJ = $(patsubst %,$(OBJ_DIR)/%.o,$(SRC_ALL))
 
@@ -17,11 +25,14 @@ F90_OBJ = $(SUB_MOD_OBJ) $(SRC_OBJ)
 
 all : $(SRC_ALL)
 
+$(DIRS):
+	mkdir -p $(DIRS)
+
 $(SRC_ALL): % : %.f90 $(SUB_MOD_OBJ) constants.h
-	$(F90) -o $(BIN_DIR)/x$@ $(F90_FLAGS) $*.f90 -module $(MOD_DIR) $(SUB_MOD_OBJ) $(LIB)
+	$(F90) -o $(BIN_DIR)/x$@ $(F90_FLAGS) $*.f90 $(MODULE_FLAG) $(MOD_DIR) $(SUB_MOD_OBJ) $(LIB)
 
 $(SUB_MOD_OBJ): $(OBJ_DIR)/%.o : %.f90
-	$(F90) -c -o $(OBJ_DIR)/$*.o $*.f90 -module $(MOD_DIR)
+	$(F90) -c -o $(OBJ_DIR)/$*.o $*.f90 $(MODULE_FLAG) $(MOD_DIR)
 
 clean:
 	\rm -f $(MOD_DIR)/*.mod $(OBJ_DIR)/*.o *.o *.mod *~ garc_station.txt  xsection_translate.txt xglobal_slice_number xmake_az_stations xnormal_plane


### PR DESCRIPTION
Make `utils/Visualization/VTK_ParaView/global_slice_util/Makefile` slightly more portable and detect in a rudimentary way whether to use the Intelism `-module` for building Fortran modules, or the more common `-J`.