### PR TITLE
Added option for monochromatic source time function

### DIFF
--- a/src/specfem3D/comp_source_time_function.f90
+++ b/src/specfem3D/comp_source_time_function.f90
@@ -70,6 +70,24 @@
 !
 
 
+  double precision function comp_source_time_function_mono(t,f0)
+
+  use constants, only: PI
+
+  implicit none
+
+  double precision,intent(in) :: t,f0
+
+  comp_source_time_function_mono = sin(2.d0 * PI * f0 * t)
+
+  ! monochromatic source time function
+
+  end function comp_source_time_function_mono
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
   double precision function comp_source_time_function_rickr(t,f0)
 
   use constants, only: PI

--- a/src/specfem3D/compute_add_sources.f90
+++ b/src/specfem3D/compute_add_sources.f90
@@ -481,6 +481,7 @@
   double precision, external :: comp_source_time_function
   double precision, external :: comp_source_time_function_rickr
   double precision, external :: comp_source_time_function_gauss
+  double precision, external :: comp_source_time_function_mono
 
   ! note: calling comp_source_time_function() includes the handling for external source time functions
 
@@ -499,6 +500,10 @@
     case (2)
       ! Heaviside (step) source time function
       stf = comp_source_time_function(time_source_dble,hdur_Gaussian(isource))
+    case (3)
+      ! Monochromatic source time function
+      f0 = 1.d0 / hdur(isource) ! using hdur as a PERIOD just to avoid changing FORCESOLUTION file format
+      stf = comp_source_time_function_mono(time_source_dble,f0)
     case default
       stop 'unsupported force_stf value!'
     end select

--- a/src/specfem3D/get_force.f90
+++ b/src/specfem3D/get_force.f90
@@ -167,6 +167,13 @@
       ! null half-duration indicates a Heaviside
       ! replace with very short error function
       if (hdur(isource) < 5. * DT ) hdur(isource) = 5. * DT
+    case (3)
+      ! Monochromatic source time function
+      ! half-duration is the period
+      ! (see constants.h: TINYVAL = 1.d-9 )
+      if (hdur(isource) < TINYVAL ) then
+        stop 'Error set force period, make sure all forces have a non-zero period'
+      endif
     case default
       stop 'unsupported force_stf value!'
     end select

--- a/src/specfem3D/locate_sources.f90
+++ b/src/specfem3D/locate_sources.f90
@@ -754,6 +754,15 @@
               ! Heaviside
               write(IMAIN,*) '    using (quasi) Heaviside source time function'
               write(IMAIN,*) '             half duration: ',hdur(isource),' seconds'
+            case (3)
+              ! Monochromatic
+              write(IMAIN,*) '    using monochromatic source time function'
+              ! prints frequency content for point forces
+              f0 = hdur(isource)
+              write(IMAIN,*)
+              write(IMAIN,*) '    using a source of period ',f0
+              write(IMAIN,*)
+              write(IMAIN,*) '    half duration in period: ',hdur(isource),' seconds'
             case default
               stop 'unsupported force_stf value!'
             end select

--- a/src/specfem3D/setup_sources_receivers.f90
+++ b/src/specfem3D/setup_sources_receivers.f90
@@ -248,6 +248,9 @@
       case (2)
         ! Heaviside
         t0 = min(t0,1.5d0 * (tshift_src(isource) - hdur(isource)))
+      case (3)
+        ! Monochromatic
+        t0 = 0.d0
       case default
         stop 'unsupported force_stf value!'
       end select


### PR DESCRIPTION
Full waveform inversion with source encoding requires running a monochromatic source for a very long time. In this case, using a step source time function and convolving later could have stability issues.