### PR TITLE
ADIOS2

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -262,6 +262,22 @@ MPILIBS += @ADIOS_LIBS@
 
 #######################################
 ####
+#### ADIOS2
+#### with configure: ./configure --with-adios2 ADIOS2_CONFIG=..
+####
+#######################################
+
+@COND_ADIOS2_TRUE@ADIOS2 = yes
+@COND_ADIOS2_FALSE@ADIOS2 = no
+
+@COND_ADIOS2_TRUE@ADIOS2_DEF = $(FC_DEFINE)HAVE_ADIOS2
+@COND_ADIOS2_FALSE@ADIOS2_DEF =
+
+@COND_ADIOS2_TRUE@FCFLAGS += @ADIOS2_FCFLAGS@ $(FC_DEFINE)HAVE_ADIOS2
+@COND_ADIOS2_TRUE@MPILIBS += @ADIOS2_LIBS@
+
+#######################################
+####
 #### ASDF
 #### with configure: ./configure --with-asdf ASDF_LIBS=..
 ####
@@ -362,6 +378,13 @@ DEFAULT += 	\
 	$(EMPTY_MACRO)
 endif
 
+#ifeq ($(ADIOS2), yes)
+#DEFAULT += 	\
+#	xcombine_vol_data_adios2 \
+#	xcombine_vol_data_vtk_adios2 \
+#	$(EMPTY_MACRO)
+#endif
+
 all: default aux movies postprocess tomography
 
 default: $(DEFAULT)
@@ -427,6 +450,10 @@ ifeq ($(ADIOS), yes)
 	@echo "    xcombine_vol_data_adios"
 	@echo "    xcombine_vol_data_vtk_adios"
 endif
+ifeq ($(ADIOS2), yes)
+	@echo "    xcombine_vol_data_adios2"
+	@echo "    xcombine_vol_data_vtk_adios2"
+endif
 	@echo "    xcombine_surf_data"
 	@echo "    xcombine_AVS_DX"
 	@echo "    xconvolve_source_timefunction"
@@ -447,6 +474,9 @@ endif
 	@echo "    xsmooth_sem"
 ifeq ($(ADIOS), yes)
 	@echo "    xconvert_model_file_adios"
+endif
+ifeq ($(ADIOS2), yes)
+	@echo "    xconvert_model_file_adios2"
 endif
 	@echo ""
 	@echo "- tomography tools: [make tomography]"

--- a/configure
+++ b/configure
@@ -635,6 +635,7 @@ MPI_INC
 VTK_LIBS
 VTK_LDFLAGS
 VTK_INCLUDES
+VTK_MAJOR
 OMP_FCFLAGS
 BLAS_LIBS
 LIBXSMM_LIBS
@@ -656,6 +657,9 @@ CUDA_FLAGS
 NVCC
 CONFIGURE_FLAGS
 ASDF_LIBS
+ADIOS2_LIBS
+ADIOS2_FCFLAGS
+ADIOS2_CONFIG
 ADIOS_LIBS
 ADIOS_FCFLAGS
 ADIOS_CONFIG
@@ -692,6 +696,8 @@ COND_CEM_FALSE
 COND_CEM_TRUE
 COND_ASDF_FALSE
 COND_ASDF_TRUE
+COND_ADIOS2_FALSE
+COND_ADIOS2_TRUE
 COND_ADIOS_FALSE
 COND_ADIOS_TRUE
 COND_VTK_FALSE
@@ -751,6 +757,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -783,6 +790,7 @@ with_xsmm
 enable_openmp
 enable_vtk
 with_adios
+with_adios2
 with_asdf
 with_cem
 with_vtk
@@ -805,6 +813,7 @@ FLAGS_CHECK
 LOCAL_PATH_IS_ALSO_GLOBAL
 CPP
 ADIOS_CONFIG
+ADIOS2_CONFIG
 ASDF_LIBS
 NVCC
 CUDA_FLAGS
@@ -863,6 +872,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1115,6 +1125,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1252,7 +1271,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1405,6 +1424,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1455,6 +1475,7 @@ Optional Packages:
   --with-xsmm             build LIBXSMM (see:https://github.com/hfp/libxsmm)
                           enabled version [default=no]
   --with-adios            build ADIOS enabled version [default=no]
+  --with-adios2           build ADIOS enabled version [default=no]
   --with-asdf             build ASDF enabled version [default=no]
   --with-cem              build CEM enabled version [default=no]
   --with-vtk              The prefix where VTK is installed [default=/usr]
@@ -1480,6 +1501,9 @@ Some influential environment variables:
               same path [default=true]
   CPP         C preprocessor
   ADIOS_CONFIG
+              Path to adios_config program that indicates how to compile with
+              it.
+  ADIOS2_CONFIG
               Path to adios_config program that indicates how to compile with
               it.
   ASDF_LIBS   ASDF libraries for linking programs
@@ -2983,6 +3007,27 @@ fi
 else
   COND_ADIOS_TRUE='#'
   COND_ADIOS_FALSE=
+fi
+
+
+###
+### ADIOS2
+###
+
+
+# Check whether --with-adios2 was given.
+if test "${with_adios2+set}" = set; then :
+  withval=$with_adios2; want_adios2="$withval"
+else
+  want_adios2=no
+fi
+
+ if test x"$want_adios2" != xno; then
+  COND_ADIOS2_TRUE=
+  COND_ADIOS2_FALSE='#'
+else
+  COND_ADIOS2_TRUE='#'
+  COND_ADIOS2_FALSE=
 fi
 
 
@@ -6457,6 +6502,147 @@ ac_compiler_gnu=$ac_cv_fc_compiler_gnu
 fi
 
 ###
+### ADIOS2
+###
+
+if test x"$want_adios2" != xno; then :
+
+    $as_echo "## ------ ##
+## ADIOS2 ##
+## ------ ##"
+
+
+  # Extract the first word of "adios2-config", so it can be a program name with args.
+set dummy adios2-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_ADIOS2_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $ADIOS2_CONFIG in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_ADIOS2_CONFIG="$ADIOS2_CONFIG" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_ADIOS2_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  ;;
+esac
+fi
+ADIOS2_CONFIG=$ac_cv_path_ADIOS2_CONFIG
+if test -n "$ADIOS2_CONFIG"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ADIOS2_CONFIG" >&5
+$as_echo "$ADIOS2_CONFIG" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+
+  if test "x$ADIOS2_CONFIG" = "x"; then
+    as_fn_error $? "adios2-config program not found; try setting ADIOS2_CONFIG to point to it" "$LINENO" 5
+  fi
+
+  ac_ext=${ac_fc_srcext-f}
+ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
+ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+
+  FC_save="$FC"
+  FCFLAGS_save="$FCFLAGS"
+  LIBS_save="$LIBS"
+  FC="$MPIFC"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ADIOS2 modules" >&5
+$as_echo_n "checking for ADIOS2 modules... " >&6; }
+  ADIOS2_FCFLAGS=`$ADIOS2_CONFIG --fortran-flags`
+  FCFLAGS="$ADIOS2_FCFLAGS $FCFLAGS"
+  cat > conftest.$ac_ext <<_ACEOF
+
+          program main
+
+    use adios2
+    type(adios2_adios) :: adios
+
+      end
+
+_ACEOF
+if ac_fn_fc_try_compile "$LINENO"; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    as_fn_error $? "ADIOS2 modules not found; is ADIOS2 built with Fortran support for this compiler?" "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ADIOS2 libraries" >&5
+$as_echo_n "checking for ADIOS2 libraries... " >&6; }
+  FCFLAGS="$ADIOS2_FCFLAGS $FCFLAGS_save"
+  ADIOS2_LIBS=`$ADIOS2_CONFIG --fortran-libs`
+  LIBS="$ADIOS2_LIBS $LIBS"
+  cat > conftest.$ac_ext <<_ACEOF
+
+          program main
+
+        use adios2
+        type(adios2_adios) :: adios
+        type(adios2_io)    :: io
+        integer            :: ierr
+        call adios2_declare_io(io, adios, "testIO", ierr)
+
+      end
+
+_ACEOF
+if ac_fn_fc_try_link "$LINENO"; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    as_fn_error $? "ADIOS2 libraries not found." "$LINENO" 5
+
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+
+  FC="$FC_save"
+  FCFLAGS="$FCFLAGS_save"
+  LIBS="$LIBS_save"
+  ac_ext=${ac_fc_srcext-f}
+ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
+ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_fc_compiler_gnu
+
+
+
+
+
+
+fi
+
+###
 ### ASDF
 ###
 
@@ -7081,15 +7267,21 @@ fi
     if test x$with_vtk != "xno"; then
         VTK_PREFIX="$with_vtk"
 
-        as_ac_File=`$as_echo "ac_cv_file_$VTK_PREFIX/include/vtk$vtk_suffix/vtkCommonInstantiator.h" | $as_tr_sh`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $VTK_PREFIX/include/vtk$vtk_suffix/vtkCommonInstantiator.h" >&5
-$as_echo_n "checking for $VTK_PREFIX/include/vtk$vtk_suffix/vtkCommonInstantiator.h... " >&6; }
+        # note: for VTK version 7.0 the file vtkCommonInstantiator.h no longer exists,
+        #       but has been renamed to vtkInstantiator.h instead
+        #AC_CHECK_FILE([$VTK_PREFIX/include/vtk$vtk_suffix/vtkCommonInstantiator.h],
+        #              [vtkFound="OK"])
+
+        # checks for common file: vtkVersion.h
+        as_ac_File=`$as_echo "ac_cv_file_$VTK_PREFIX/include/vtk$vtk_suffix/vtkVersion.h" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $VTK_PREFIX/include/vtk$vtk_suffix/vtkVersion.h" >&5
+$as_echo_n "checking for $VTK_PREFIX/include/vtk$vtk_suffix/vtkVersion.h... " >&6; }
 if eval \${$as_ac_File+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   test "$cross_compiling" = yes &&
   as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
-if test -r "$VTK_PREFIX/include/vtk$vtk_suffix/vtkCommonInstantiator.h"; then
+if test -r "$VTK_PREFIX/include/vtk$vtk_suffix/vtkVersion.h"; then
   eval "$as_ac_File=yes"
 else
   eval "$as_ac_File=no"
@@ -7101,6 +7293,7 @@ $as_echo "$ac_res" >&6; }
 if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
   vtkFound="OK"
 fi
+
 
         { $as_echo "$as_me:${as_lineno-$LINENO}: checking if VTK is installed in $VTK_PREFIX" >&5
 $as_echo_n "checking if VTK is installed in $VTK_PREFIX... " >&6; }
@@ -7116,9 +7309,6 @@ $as_echo "no" >&6; }
                         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-                        VTK_INCLUDES="-I$VTK_PREFIX/include/vtk$vtk_suffix"
-            VTK_LDFLAGS="-L$VTK_PREFIX/lib/vtk$vtk_suffix -L$VTK_PREFIX/lib64/vtk$vtk_suffix"
-
                         ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -7130,18 +7320,1273 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
             OLD_LDFLAGS=$LDFLAGS
             OLD_LIBS=$LIBS
 
+
+                        VTK_INCLUDES="-I$VTK_PREFIX/include/vtk$vtk_suffix"
+
+            # note: versions 6+ change library names
+            maj=`echo $vtk_version | sed 's/\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1/'`
+            VTK_MAJOR=$maj
+            { $as_echo "$as_me:${as_lineno-$LINENO}: VTK version $vtk_version - major version number is $VTK_MAJOR" >&5
+$as_echo "$as_me: VTK version $vtk_version - major version number is $VTK_MAJOR" >&6;}
+            VTK_LDFLAGS=""
+            if test -d "$VTK_PREFIX/lib/vtk$vtk_suffix" ; then VTK_LDFLAGS+="-L$VTK_PREFIX/lib/vtk$vtk_suffix "; fi
+            if test -d "$VTK_PREFIX/lib64/vtk$vtk_suffix" ; then VTK_LDFLAGS+="-L$VTK_PREFIX/lib64/vtk$vtk_suffix "; fi
+            if test "${VTK_MAJOR}" -gt "5" ; then
+              # for vtk versions 6+
+              if test -d "$VTK_PREFIX/lib" ; then VTK_LDFLAGS+="-L$VTK_PREFIX/lib "; fi
+            fi
+
                                     CFLAGS="$VTK_CFLAGS $CFLAGS"
             CXXFLAGS="$VTK_CXXFLAGS $CXXFLAGS"
             LDFLAGS="$VTK_LDFLAGS $LDFLAGS"
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking with linker flags $LDFLAGS" >&5
+$as_echo "$as_me: checking with linker flags $LDFLAGS" >&6;}
 
-                                                VTK_SUPPORT_LIBS="-lvtktiff -lvtkpng -lvtkjpeg -lvtkzlib -lvtkexpat -lvfw32 -lgdi32"
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for strcmp in -lvtkIO" >&5
-$as_echo_n "checking for strcmp in -lvtkIO... " >&6; }
-if ${ac_cv_lib_vtkIO_strcmp+:} false; then :
+            # tests common vtkIO library
+            if test "${VTK_MAJOR}" -gt "5" ; then
+              # for vtk versions 6+
+              lib_vtkIO=vtkIOCore$vtk_suffix
+            else
+              # for vtk versions <= 5
+              lib_vtkIO=vtkIO
+            fi
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking VTK library file: -l$lib_vtkIO" >&5
+$as_echo "$as_me: checking VTK library file: -l$lib_vtkIO" >&6;}
+            found_vtk_lib=no
+            as_ac_Lib=`$as_echo "ac_cv_lib_$lib_vtkIO''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -l$lib_vtkIO" >&5
+$as_echo_n "checking for main in -l$lib_vtkIO... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lvtkIO $VTK_SUPPORT_LIBS $LIBS"
+LIBS="-l$lib_vtkIO  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  found_vtk_lib=yes
+else
+  if test "x$VTK_LIBS" != "x" ; then
+                LIBS="$LIBS -L$VTK_LIBS"
+                { $as_echo "$as_me:${as_lineno-$LINENO}:   ... with LIBS: $LIBS" >&5
+$as_echo "$as_me:   ... with LIBS: $LIBS" >&6;}
+                as_ac_Lib=`$as_echo "ac_cv_lib_$lib_vtkIO''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -l$lib_vtkIO" >&5
+$as_echo_n "checking for main in -l$lib_vtkIO... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-l$lib_vtkIO  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  found_vtk_lib=yes
+else
+   if test "${VTK_MAJOR}" -gt "5" ; then
+                    # checks name without suffix
+                    vtk_suffix=""
+                    lib_vtkIO=vtkIOCore$vtk_suffix
+                    as_ac_Lib=`$as_echo "ac_cv_lib_$lib_vtkIO''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -l$lib_vtkIO" >&5
+$as_echo_n "checking for main in -l$lib_vtkIO... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-l$lib_vtkIO  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  found_vtk_lib=yes
+fi
+
+                  fi
+
+fi
+
+               fi
+
+fi
+
+            if test "$found_vtk_lib" != "yes"; then
+              # abort in case not found
+              as_fn_error $? "could not find VTK libraries" "$LINENO" 5
+            fi
+
+            # additional libraries
+            if test "${VTK_MAJOR}" -gt "5" ; then
+              # for vtk versions 6+
+              VTK_SUPPORT_LIBS="-lvtktiff$vtk_suffix -lvtkpng$vtk_suffix -lvtkjpeg$vtk_suffix -lvtkzlib$vtk_suffix -lvtkexpat$vtk_suffix -lvfw32 -lgdi32"
+            else
+              # for vtk versions <= 5
+              VTK_SUPPORT_LIBS="-lvtktiff -lvtkpng -lvtkjpeg -lvtkzlib -lvtkexpat -lvfw32 -lgdi32"
+            fi
+            if test "${VTK_MAJOR}" -gt "5" ; then
+              # version 6+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkIOXML$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkIOXML$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkIOXML$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkIOXML$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkIOXML$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkIOXML$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkIOImage$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkIOImage$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkIOImage$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkIOImage$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkIOImage$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkIOImage$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkDICOMParser$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkDICOMParser$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkDICOMParser$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkDICOMParser$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkDICOMParser$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkDICOMParser$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkRenderingCore$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkRenderingCore$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkRenderingCore$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkRenderingCore$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkRenderingCore$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkRenderingCore$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkRenderingLabel$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkRenderingLabel$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkRenderingLabel$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkRenderingLabel$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkRenderingLabel$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkRenderingLabel$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkRenderingAnnotation$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkRenderingAnnotation$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkRenderingAnnotation$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkRenderingAnnotation$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkRenderingAnnotation$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkRenderingAnnotation$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkFiltersCore$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkFiltersCore$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkFiltersCore$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkFiltersCore$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkFiltersCore$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkFiltersCore$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkFiltersGeneric$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkFiltersGeneric$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkFiltersGeneric$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkFiltersGeneric$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkFiltersGeneric$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkFiltersGeneric$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkCommonCore$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkCommonCore$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkCommonCore$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkCommonCore$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkCommonCore$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkCommonCore$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkInteractionStyle$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkInteractionStyle$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkInteractionStyle$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkInteractionStyle$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkInteractionStyle$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkInteractionStyle$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkzlib$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkzlib$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkzlib$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkzlib$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkzlib$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkzlib$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtkexpat$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkexpat$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtkexpat$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkexpat$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtkexpat$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtkexpat$vtk_suffix $LIBS"
+
+fi
+
+              as_ac_Lib=`$as_echo "ac_cv_lib_vtksys$vtk_suffix''_main" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtksys$vtk_suffix" >&5
+$as_echo_n "checking for main in -lvtksys$vtk_suffix... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtksys$vtk_suffix  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  eval "$as_ac_Lib=yes"
+else
+  eval "$as_ac_Lib=no"
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_LIBvtksys$vtk_suffix" | $as_tr_cpp` 1
+_ACEOF
+
+  LIBS="-lvtksys$vtk_suffix $LIBS"
+
+fi
+
+            else
+              # version <= 5
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkDICOMParser" >&5
+$as_echo_n "checking for main in -lvtkDICOMParser... " >&6; }
+if ${ac_cv_lib_vtkDICOMParser_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkDICOMParser  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtkDICOMParser_main=yes
+else
+  ac_cv_lib_vtkDICOMParser_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkDICOMParser_main" >&5
+$as_echo "$ac_cv_lib_vtkDICOMParser_main" >&6; }
+if test "x$ac_cv_lib_vtkDICOMParser_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKDICOMPARSER 1
+_ACEOF
+
+  LIBS="-lvtkDICOMParser $LIBS"
+
+fi
+
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkRendering" >&5
+$as_echo_n "checking for main in -lvtkRendering... " >&6; }
+if ${ac_cv_lib_vtkRendering_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkRendering  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtkRendering_main=yes
+else
+  ac_cv_lib_vtkRendering_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkRendering_main" >&5
+$as_echo "$ac_cv_lib_vtkRendering_main" >&6; }
+if test "x$ac_cv_lib_vtkRendering_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKRENDERING 1
+_ACEOF
+
+  LIBS="-lvtkRendering $LIBS"
+
+fi
+
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkGraphics" >&5
+$as_echo_n "checking for main in -lvtkGraphics... " >&6; }
+if ${ac_cv_lib_vtkGraphics_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkGraphics  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtkGraphics_main=yes
+else
+  ac_cv_lib_vtkGraphics_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkGraphics_main" >&5
+$as_echo "$ac_cv_lib_vtkGraphics_main" >&6; }
+if test "x$ac_cv_lib_vtkGraphics_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKGRAPHICS 1
+_ACEOF
+
+  LIBS="-lvtkGraphics $LIBS"
+
+fi
+
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkFiltering" >&5
+$as_echo_n "checking for main in -lvtkFiltering... " >&6; }
+if ${ac_cv_lib_vtkFiltering_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkFiltering  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtkFiltering_main=yes
+else
+  ac_cv_lib_vtkFiltering_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkFiltering_main" >&5
+$as_echo "$ac_cv_lib_vtkFiltering_main" >&6; }
+if test "x$ac_cv_lib_vtkFiltering_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKFILTERING 1
+_ACEOF
+
+  LIBS="-lvtkFiltering $LIBS"
+
+fi
+
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkGenericFiltering" >&5
+$as_echo_n "checking for main in -lvtkGenericFiltering... " >&6; }
+if ${ac_cv_lib_vtkGenericFiltering_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkGenericFiltering  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtkGenericFiltering_main=yes
+else
+  ac_cv_lib_vtkGenericFiltering_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkGenericFiltering_main" >&5
+$as_echo "$ac_cv_lib_vtkGenericFiltering_main" >&6; }
+if test "x$ac_cv_lib_vtkGenericFiltering_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKGENERICFILTERING 1
+_ACEOF
+
+  LIBS="-lvtkGenericFiltering $LIBS"
+
+fi
+
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkCommon" >&5
+$as_echo_n "checking for main in -lvtkCommon... " >&6; }
+if ${ac_cv_lib_vtkCommon_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkCommon  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtkCommon_main=yes
+else
+  ac_cv_lib_vtkCommon_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkCommon_main" >&5
+$as_echo "$ac_cv_lib_vtkCommon_main" >&6; }
+if test "x$ac_cv_lib_vtkCommon_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKCOMMON 1
+_ACEOF
+
+  LIBS="-lvtkCommon $LIBS"
+
+fi
+
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkzlib" >&5
+$as_echo_n "checking for main in -lvtkzlib... " >&6; }
+if ${ac_cv_lib_vtkzlib_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkzlib  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtkzlib_main=yes
+else
+  ac_cv_lib_vtkzlib_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkzlib_main" >&5
+$as_echo "$ac_cv_lib_vtkzlib_main" >&6; }
+if test "x$ac_cv_lib_vtkzlib_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKZLIB 1
+_ACEOF
+
+  LIBS="-lvtkzlib $LIBS"
+
+fi
+
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtkexpat" >&5
+$as_echo_n "checking for main in -lvtkexpat... " >&6; }
+if ${ac_cv_lib_vtkexpat_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtkexpat  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtkexpat_main=yes
+else
+  ac_cv_lib_vtkexpat_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkexpat_main" >&5
+$as_echo "$ac_cv_lib_vtkexpat_main" >&6; }
+if test "x$ac_cv_lib_vtkexpat_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKEXPAT 1
+_ACEOF
+
+  LIBS="-lvtkexpat $LIBS"
+
+fi
+
+              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lvtksys" >&5
+$as_echo_n "checking for main in -lvtksys... " >&6; }
+if ${ac_cv_lib_vtksys_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lvtksys  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+#ifdef FC_DUMMY_MAIN
+#ifndef FC_DUMMY_MAIN_EQ_F77
+#  ifdef __cplusplus
+     extern "C"
+#  endif
+   int FC_DUMMY_MAIN() { return 1; }
+#endif
+#endif
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_vtksys_main=yes
+else
+  ac_cv_lib_vtksys_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtksys_main" >&5
+$as_echo "$ac_cv_lib_vtksys_main" >&6; }
+if test "x$ac_cv_lib_vtksys_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBVTKSYS 1
+_ACEOF
+
+  LIBS="-lvtksys $LIBS"
+
+fi
+
+            fi
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking VTK library features in $lib_vtkIO" >&5
+$as_echo "$as_me: checking VTK library features in $lib_vtkIO" >&6;}
+            as_ac_Lib=`$as_echo "ac_cv_lib_$lib_vtkIO''_strcmp" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for strcmp in -l$lib_vtkIO" >&5
+$as_echo_n "checking for strcmp in -l$lib_vtkIO... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-l$lib_vtkIO $VTK_SUPPORT_LIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7169,33 +8614,42 @@ return strcmp ();
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_vtkIO_strcmp=yes
+  eval "$as_ac_Lib=yes"
 else
-  ac_cv_lib_vtkIO_strcmp=no
+  eval "$as_ac_Lib=no"
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkIO_strcmp" >&5
-$as_echo "$ac_cv_lib_vtkIO_strcmp" >&6; }
-if test "x$ac_cv_lib_vtkIO_strcmp" = xyes; then :
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBVTKIO 1
+#define `$as_echo "HAVE_LIB$lib_vtkIO" | $as_tr_cpp` 1
 _ACEOF
 
-  LIBS="-lvtkIO $LIBS"
+  LIBS="-l$lib_vtkIO $LIBS"
 
 else
 
-                VTK_SUPPORT_LIBS="-lvtktiff -lvtkpng -lvtkjpeg -lvtkzlib -lvtkexpat"
-                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for abort in -lvtkIO" >&5
-$as_echo_n "checking for abort in -lvtkIO... " >&6; }
-if ${ac_cv_lib_vtkIO_abort+:} false; then :
+                # version check
+                if test "${VTK_MAJOR}" -gt "5" ; then
+                  # version 6+
+                  VTK_SUPPORT_LIBS="-lvtktiff$vtk_suffix -lvtkpng$vtk_suffix -lvtkjpeg$vtk_suffix -lvtkzlib$vtk_suffix -lvtkexpat$vtk_suffix"
+                else
+                  # version <= 5
+                  VTK_SUPPORT_LIBS="-lvtktiff -lvtkpng -lvtkjpeg -lvtkzlib -lvtkexpat"
+                fi
+                as_ac_Lib=`$as_echo "ac_cv_lib_$lib_vtkIO''_abort" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for abort in -l$lib_vtkIO" >&5
+$as_echo_n "checking for abort in -l$lib_vtkIO... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lvtkIO $VTK_SUPPORT_LIBS $LIBS"
+LIBS="-l$lib_vtkIO $VTK_SUPPORT_LIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7223,33 +8677,35 @@ return abort ();
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_vtkIO_abort=yes
+  eval "$as_ac_Lib=yes"
 else
-  ac_cv_lib_vtkIO_abort=no
+  eval "$as_ac_Lib=no"
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkIO_abort" >&5
-$as_echo "$ac_cv_lib_vtkIO_abort" >&6; }
-if test "x$ac_cv_lib_vtkIO_abort" = xyes; then :
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBVTKIO 1
+#define `$as_echo "HAVE_LIB$lib_vtkIO" | $as_tr_cpp` 1
 _ACEOF
 
-  LIBS="-lvtkIO $LIBS"
+  LIBS="-l$lib_vtkIO $LIBS"
 
 else
 
                     VTK_SUPPORT_LIBS="-ltiff -lpng -ljpeg -lz -lexpat"
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for exit in -lvtkIO" >&5
-$as_echo_n "checking for exit in -lvtkIO... " >&6; }
-if ${ac_cv_lib_vtkIO_exit+:} false; then :
+                    as_ac_Lib=`$as_echo "ac_cv_lib_$lib_vtkIO''_exit" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for exit in -l$lib_vtkIO" >&5
+$as_echo_n "checking for exit in -l$lib_vtkIO... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lvtkIO $VTK_SUPPORT_LIBS $LIBS"
+LIBS="-l$lib_vtkIO $VTK_SUPPORT_LIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7277,33 +8733,35 @@ return exit ();
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_vtkIO_exit=yes
+  eval "$as_ac_Lib=yes"
 else
-  ac_cv_lib_vtkIO_exit=no
+  eval "$as_ac_Lib=no"
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkIO_exit" >&5
-$as_echo "$ac_cv_lib_vtkIO_exit" >&6; }
-if test "x$ac_cv_lib_vtkIO_exit" = xyes; then :
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBVTKIO 1
+#define `$as_echo "HAVE_LIB$lib_vtkIO" | $as_tr_cpp` 1
 _ACEOF
 
-  LIBS="-lvtkIO $LIBS"
+  LIBS="-l$lib_vtkIO $LIBS"
 
 else
 
                         VTK_SUPPORT_LIBS=""
-                        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for strstr in -lvtkIO" >&5
-$as_echo_n "checking for strstr in -lvtkIO... " >&6; }
-if ${ac_cv_lib_vtkIO_strstr+:} false; then :
+                        as_ac_Lib=`$as_echo "ac_cv_lib_$lib_vtkIO''_strstr" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for strstr in -l$lib_vtkIO" >&5
+$as_echo_n "checking for strstr in -l$lib_vtkIO... " >&6; }
+if eval \${$as_ac_Lib+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lvtkIO $VTK_SUPPORT_LIBS $LIBS"
+LIBS="-l$lib_vtkIO $VTK_SUPPORT_LIBS $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7331,22 +8789,23 @@ return strstr ();
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_vtkIO_strstr=yes
+  eval "$as_ac_Lib=yes"
 else
-  ac_cv_lib_vtkIO_strstr=no
+  eval "$as_ac_Lib=no"
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_vtkIO_strstr" >&5
-$as_echo "$ac_cv_lib_vtkIO_strstr" >&6; }
-if test "x$ac_cv_lib_vtkIO_strstr" = xyes; then :
+eval ac_res=\$$as_ac_Lib
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+if eval test \"x\$"$as_ac_Lib"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBVTKIO 1
+#define `$as_echo "HAVE_LIB$lib_vtkIO" | $as_tr_cpp` 1
 _ACEOF
 
-  LIBS="-lvtkIO $LIBS"
+  LIBS="-l$lib_vtkIO $LIBS"
 
 else
 
@@ -7363,7 +8822,12 @@ fi
 
 fi
 
-            VTK_LIBS="-lvtkIO -lvtkDICOMParser -lvtkFiltering -lvtkGenericFiltering -lvtkCommon $VTK_SUPPORT_LIBS -lvtksys"
+
+            if test "${VTK_MAJOR}" -gt "5" ; then
+              VTK_LIBS="-l$lib_vtkIO -lvtkIOXML$vtk_suffix -lvtkIOImage$vtk_suffix -lvtkDICOMParser$vtk_suffix -lvtkRenderingCore$vtk_suffix -lvtkRenderingLabel$vtk_suffix -lvtkRenderingAnnotation$vtk_suffix -lvtkFiltersCore$vtk_suffix -lvtkFiltersGeneric$vtk_suffix -lvtkCommonCore$vtk_suffix -lvtkInteractionStyle$vtk_suffix $VTK_SUPPORT_LIBS -lvtksys$vtk_suffix"
+            else
+              VTK_LIBS="-l$lib_vtkIO -lvtkDICOMParser -lvtkRendering -lvtkGraphics -lvtkFiltering -lvtkGenericFiltering -lvtkCommon $VTK_SUPPORT_LIBS -lvtksys"
+            fi
             LIBS="$VTK_LIBS $LIBS"
 
                         if test -n ""; then
@@ -7458,6 +8922,7 @@ $as_echo "#define HAVE_VTK /**/" >>confdefs.h
 
         fi          # if [[ -z "$vtkFound" ]];
     fi          # $with_vtk != "no"
+
 
 
 
@@ -8186,6 +9651,10 @@ Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${COND_ADIOS_TRUE}" && test -z "${COND_ADIOS_FALSE}"; then
   as_fn_error $? "conditional \"COND_ADIOS\" was never defined.
+Usually this means the macro was only invoked conditionally." "$LINENO" 5
+fi
+if test -z "${COND_ADIOS2_TRUE}" && test -z "${COND_ADIOS2_FALSE}"; then
+  as_fn_error $? "conditional \"COND_ADIOS2\" was never defined.
 Usually this means the macro was only invoked conditionally." "$LINENO" 5
 fi
 if test -z "${COND_ASDF_TRUE}" && test -z "${COND_ASDF_FALSE}"; then

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,17 @@ AC_ARG_WITH([adios],
 AM_CONDITIONAL([COND_ADIOS], [test x"$want_adios" != xno])
 
 ###
+### ADIOS2
+###
+
+AC_ARG_WITH([adios2],
+    [AC_HELP_STRING([--with-adios2],
+        [build ADIOS enabled version @<:@default=no@:>@])],
+    [want_adios2="$withval"],
+    [want_adios2=no])
+AM_CONDITIONAL([COND_ADIOS2], [test x"$want_adios2" != xno])
+
+###
 ### ASDF
 ###
 
@@ -279,6 +290,15 @@ AC_LANG_POP(C)
 AS_IF([test x"$want_adios" != xno], [
     AS_BOX([ADIOS])
     CIT_ADIOS_CONFIG
+])
+
+###
+### ADIOS2
+###
+
+AS_IF([test x"$want_adios2" != xno], [
+    AS_BOX([ADIOS2])
+    CIT_ADIOS2_CONFIG
 ])
 
 ###

--- a/setup/config.h.in
+++ b/setup/config.h.in
@@ -17,34 +17,59 @@
 /* Define if emmintrin.h */
 #undef HAVE_EMMINTRIN
 
-/* Define to 1 if you have the < inttypes.h > header file. */
+/* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
-/* Define to 1 if you have the `vtkIO' library (-lvtkIO). */
-#undef HAVE_LIBVTKIO
+/* Define to 1 if you have the `vtkCommon' library (-lvtkCommon). */
+#undef HAVE_LIBVTKCOMMON
 
-/* Define to 1 if you have the < memory.h > header file. */
+/* Define to 1 if you have the `vtkDICOMParser' library (-lvtkDICOMParser). */
+#undef HAVE_LIBVTKDICOMPARSER
+
+/* Define to 1 if you have the `vtkexpat' library (-lvtkexpat). */
+#undef HAVE_LIBVTKEXPAT
+
+/* Define to 1 if you have the `vtkFiltering' library (-lvtkFiltering). */
+#undef HAVE_LIBVTKFILTERING
+
+/* Define to 1 if you have the `vtkGenericFiltering' library
+   (-lvtkGenericFiltering). */
+#undef HAVE_LIBVTKGENERICFILTERING
+
+/* Define to 1 if you have the `vtkGraphics' library (-lvtkGraphics). */
+#undef HAVE_LIBVTKGRAPHICS
+
+/* Define to 1 if you have the `vtkRendering' library (-lvtkRendering). */
+#undef HAVE_LIBVTKRENDERING
+
+/* Define to 1 if you have the `vtksys' library (-lvtksys). */
+#undef HAVE_LIBVTKSYS
+
+/* Define to 1 if you have the `vtkzlib' library (-lvtkzlib). */
+#undef HAVE_LIBVTKZLIB
+
+/* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 
-/* Define to 1 if you have the < stdint.h > header file. */
+/* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
 
-/* Define to 1 if you have the < stdlib.h > header file. */
+/* Define to 1 if you have the <stdlib.h> header file. */
 #undef HAVE_STDLIB_H
 
-/* Define to 1 if you have the < strings.h > header file. */
+/* Define to 1 if you have the <strings.h> header file. */
 #undef HAVE_STRINGS_H
 
-/* Define to 1 if you have the < string.h > header file. */
+/* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
 
-/* Define to 1 if you have the < sys/stat.h > header file. */
+/* Define to 1 if you have the <sys/stat.h> header file. */
 #undef HAVE_SYS_STAT_H
 
-/* Define to 1 if you have the < sys/types.h > header file. */
+/* Define to 1 if you have the <sys/types.h> header file. */
 #undef HAVE_SYS_TYPES_H
 
-/* Define to 1 if you have the < unistd.h > header file. */
+/* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
 /* define if the VTK library is available */

--- a/setup/constants.h.in
+++ b/setup/constants.h.in
@@ -351,6 +351,16 @@
 
 !!-----------------------------------------------------------
 !!
+!! ADIOS2 Related values
+!!
+!!-----------------------------------------------------------
+
+  character(len=*), parameter :: ADIOS2_ENGINE_DEFAULT = "BP4"
+  character(len=*), parameter :: ADIOS2_ENGINE_PARAMS_DEFAULT = "SubStreams=64"
+  character(len=*), parameter :: ADIOS2_ENGINE_UNDO_ATT = "BP4"
+  character(len=*), parameter :: ADIOS2_ENGINE_PARAMS_UNDO_ATT = "SubStreams=64"
+!!-----------------------------------------------------------
+!!
 !! ASDF parameters
 !!
 !!-----------------------------------------------------------

--- a/src/shared/adios2_helpers_read_generated.f90
+++ b/src/shared/adios2_helpers_read_generated.f90
@@ -1,0 +1,697 @@
+# 1 "../source/src/shared/adios2_helpers_read_template.F90"
+# 1 "<built-in>"
+# 1 "<command-line>"
+# 1 "../source/src/shared/adios2_helpers_read_template.F90"
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+
+!===============================================================================
+!> Helpers to read data with ADIOS2
+!!
+!-------------------------------------------------------------------------------
+module adios2_helpers_read_mod
+
+  use adios2
+
+  implicit none
+
+  public :: check_adios2_err
+!
+!  public :: read_adios2_real_array
+!  public :: read_adios2_double_array
+!  public :: read_adios2_integer_array
+!  public :: read_adios2_long_array
+!  public :: read_adios2_logical_array
+!  public :: read_adios2_array
+
+  !! read_adios2_array(file, io, varname, ndims, start, count, data, src,func,step)
+  !!
+  !! Read (a selection of) variable data from a file
+  !! (set up a selection and schedule for reading in data)
+  !! Note: This function calls check_adios2_err which aborts the program on error
+  !! \param file adios2_engine object from adios2_open
+  !! \param io adios2_io object from adios2_declare_io
+  !! \param varname Name of the variable
+  !! \param ndims Number of dimensions of the variable
+  !! \param start Offsets in global array for reading
+  !! \param count Local sizes for reading
+  !! \param data Pre-allocated array to receive the data from file
+  !! \param src Sourcefile string (for error print)
+  !! \param func Calling Function string (for error print)
+  !! \param step (optional) step to read from a multi-step file
+
+
+  interface read_adios2
+    module procedure read_adios2_integer_1d
+    module procedure read_adios2_integer_2d
+    module procedure read_adios2_integer_3d
+    module procedure read_adios2_integer_4d
+    module procedure read_adios2_integer_5d
+
+    module procedure read_adios2_long_1d
+    module procedure read_adios2_long_2d
+    module procedure read_adios2_long_3d
+    module procedure read_adios2_long_4d
+    module procedure read_adios2_long_5d
+
+    module procedure read_adios2_real_1d
+    module procedure read_adios2_real_2d
+    module procedure read_adios2_real_3d
+    module procedure read_adios2_real_4d
+    module procedure read_adios2_real_5d
+
+    module procedure read_adios2_double_1d
+    module procedure read_adios2_double_2d
+    module procedure read_adios2_double_3d
+    module procedure read_adios2_double_4d
+    module procedure read_adios2_double_5d
+  end interface read_adios2
+
+contains
+
+
+!===============================================================================
+
+!> Check ADIOS return code, print a message and abort on error
+!! \param adios2_err The error code considered.
+subroutine check_adios2_err(myrank, adios2_err, sourcefile, func, msg)
+  implicit none
+  integer, intent(in) :: myrank, adios2_err
+  character(len=*), intent(in) :: sourcefile, func, msg
+
+  if (adios2_err /= adios2_error_none) then
+    print *, "process ", myrank, "has ADIOS2 error ",adios2_err,' in ', &
+    trim(sourcefile), ':', trim(func), ": ", trim(msg)
+    stop 'adios error'
+  endif
+end subroutine check_adios2_err
+
+
+!===============================================================================
+
+# 124 "../source/src/shared/adios2_helpers_read_template.F90"
+
+
+# 138 "../source/src/shared/adios2_helpers_read_template.F90"
+
+
+!# SUB(TYPENAME,TYPEDEF,NDIMS,DIMDEF) !subroutine read_adios2_TYPENAME_NDIMSd(file, io, varname, ndims, start, count, data, myrank, src, func, step)
+!CODE _ARGS
+!  TYPEDEF, dimension(DIMDEF), intent(out) :: data
+!CODE _BODY
+!end subroutine read_adios2_TYPENAME_NDIMSd
+
+
+
+
+
+
+! #  !define SUBROUTINETYPE(TYPENAME,TYPEDEF)
+! # #SUB(TYPENAME,TYPEDEF,1,:)
+! # #(TYPENAME,TYPEDEF,2,@@:,:@@)
+
+
+
+
+
+!! SUBROUTINETYPE(integer,integer(kind=4))
+
+!===============================================================================
+!> Read (a selection of) variable data from a file
+!! (set up a selection and schedule for reading in data)
+!! Note: This function calls check_adios2_err which aborts the program on error
+!! \param file adios2_engine object from adios2_open
+!! \param io adios2_io object from adios2_declare_io
+!! \param varname Name of the variable
+!! \param ndims Number of dimensions of the variable
+!! \param start Offsets in global array for reading
+!! \param count Local sizes for reading
+!! \param data Pre-allocated array to receive the data from file
+!! \param src Sourcefile string (for error print)
+!! \param func Calling Function string (for error print)
+subroutine read_adios2_real_1d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=4), dimension(:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_real_1d
+
+
+!===============================================================================
+subroutine read_adios2_real_2d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=4), dimension(:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_real_2d
+
+
+!===============================================================================
+subroutine read_adios2_real_3d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=4), dimension(:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_real_3d
+
+
+!===============================================================================
+subroutine read_adios2_real_4d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=4), dimension(:,:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_real_4d
+
+
+!===============================================================================
+subroutine read_adios2_real_5d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=4), dimension(:,:,:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_real_5d
+
+
+!===============================================================================
+subroutine read_adios2_double_1d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=8), dimension(:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_double_1d
+
+
+!===============================================================================
+subroutine read_adios2_double_2d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=8), dimension(:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_double_2d
+
+
+!===============================================================================
+subroutine read_adios2_double_3d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=8), dimension(:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_double_3d
+
+
+!===============================================================================
+subroutine read_adios2_double_4d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=8), dimension(:,:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_double_4d
+
+
+!===============================================================================
+subroutine read_adios2_double_5d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  real(kind=8), dimension(:,:,:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_double_5d
+
+
+!===============================================================================
+subroutine read_adios2_integer_1d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer, dimension(:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_integer_1d
+
+
+!===============================================================================
+subroutine read_adios2_integer_2d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer, dimension(:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_integer_2d
+
+
+!===============================================================================
+subroutine read_adios2_integer_3d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer, dimension(:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_integer_3d
+
+
+!===============================================================================
+subroutine read_adios2_integer_4d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer, dimension(:,:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_integer_4d
+
+
+!===============================================================================
+subroutine read_adios2_integer_5d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer, dimension(:,:,:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_integer_5d
+
+
+!===============================================================================
+subroutine read_adios2_long_1d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer(kind=8), dimension(:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_long_1d
+
+
+!===============================================================================
+subroutine read_adios2_long_2d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer(kind=8), dimension(:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_long_2d
+
+
+!===============================================================================
+subroutine read_adios2_long_3d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer(kind=8), dimension(:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_long_3d
+
+
+!===============================================================================
+subroutine read_adios2_long_4d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer(kind=8), dimension(:,:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_long_4d
+
+
+!===============================================================================
+subroutine read_adios2_long_5d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=*), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  integer, intent(in)               :: rank
+  character(len=*), intent(in)      :: src, func
+  integer(kind=8), intent(in), optional :: step
+  integer(kind=8), dimension(:,:,:,:,:), intent(out) :: data
+integer                 :: ier
+  type(adios2_variable)   :: var
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  if (present(step)) then
+      call adios2_set_step_selection(var, step, 1_8, ier)
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")
+  endif
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")
+end subroutine read_adios2_long_5d
+
+
+
+end module adios2_helpers_read_mod

--- a/src/shared/adios2_helpers_read_template.F90
+++ b/src/shared/adios2_helpers_read_template.F90
@@ -1,0 +1,327 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+
+!===============================================================================
+!> Helpers to read data with ADIOS2
+!!
+!-------------------------------------------------------------------------------
+module adios2_helpers_read_mod
+
+  use adios2
+
+  implicit none
+
+  public :: check_adios2_err
+!
+!  public :: read_adios2_real_array
+!  public :: read_adios2_double_array
+!  public :: read_adios2_integer_array
+!  public :: read_adios2_long_array
+!  public :: read_adios2_logical_array
+!  public :: read_adios2_array
+
+  !! read_adios2_array(file, io, varname, ndims, start, count, data, src,func,step)
+  !!
+  !! Read (a selection of) variable data from a file
+  !! (set up a selection and schedule for reading in data)
+  !! Note: This function calls check_adios2_err which aborts the program on error
+  !! \param file adios2_engine object from adios2_open
+  !! \param io adios2_io object from adios2_declare_io
+  !! \param varname Name of the variable
+  !! \param ndims Number of dimensions of the variable
+  !! \param start Offsets in global array for reading
+  !! \param count Local sizes for reading
+  !! \param data Pre-allocated array to receive the data from file
+  !! \param src Sourcefile string (for error print)
+  !! \param func Calling Function string (for error print)
+  !! \param step (optional) step to read from a multi-step file
+
+
+  interface read_adios2
+    module procedure read_adios2_integer_1d
+    module procedure read_adios2_integer_2d
+    module procedure read_adios2_integer_3d
+    module procedure read_adios2_integer_4d
+    module procedure read_adios2_integer_5d
+
+    module procedure read_adios2_long_1d
+    module procedure read_adios2_long_2d
+    module procedure read_adios2_long_3d
+    module procedure read_adios2_long_4d
+    module procedure read_adios2_long_5d
+
+    module procedure read_adios2_real_1d
+    module procedure read_adios2_real_2d
+    module procedure read_adios2_real_3d
+    module procedure read_adios2_real_4d
+    module procedure read_adios2_real_5d
+
+    module procedure read_adios2_double_1d
+    module procedure read_adios2_double_2d
+    module procedure read_adios2_double_3d
+    module procedure read_adios2_double_4d
+    module procedure read_adios2_double_5d
+  end interface read_adios2
+
+contains
+
+
+!===============================================================================
+
+!> Check ADIOS return code, print a message and abort on error
+!! \param adios2_err The error code considered.
+subroutine check_adios2_err(myrank, adios2_err, sourcefile, func, msg)
+  implicit none
+  integer, intent(in) :: myrank, adios2_err
+  character(len=*), intent(in) :: sourcefile, func, msg
+
+  if (adios2_err /= adios2_error_none) then
+    print *, "process ", myrank, "has ADIOS2 error ",adios2_err,' in ', &
+    trim(sourcefile), ':', trim(func), ": ", trim(msg)
+    stop 'adios error'
+  endif
+end subroutine check_adios2_err
+
+
+!===============================================================================
+
+#define CODE_ARGS \
+  use adios2                                                    _NL_\
+  implicit none                                                 _NL_\
+  type(adios2_engine), intent(in)   :: file                     _NL_\
+  type(adios2_io), intent(in)       :: io                       _NL_\
+  character(len=*), intent(in)      :: varname                  _NL_\
+  integer(kind=4), intent(in)       :: ndims                    _NL_\
+  integer(kind=8), dimension(1), intent(in) :: start, count     _NL_\
+  integer, intent(in)               :: rank                     _NL_\
+  character(len=*), intent(in)      :: src, func                _NL_\
+  integer(kind=8), intent(in), optional :: step
+
+
+#define CODE_BODY \
+  integer                 :: ier                                                               _NL_\
+  type(adios2_variable)   :: var                                                               _NL_\
+  call adios2_inquire_variable(var, io, varname, ier)                                          _NL_\
+  call check_adios2_err(rank, ier, src, func, "Inquire variable "//trim(varname))              _NL_\
+  call adios2_set_selection(var, ndims, start, count, ier)                                     _NL_\
+  if (present(step)) then                                                                      _NL_\
+      call adios2_set_step_selection(var, step, 1_8, ier)                                      _NL_\
+      call check_adios2_err(rank, ier, src, func, "Set step variable("//trim(varname)//")")    _NL_\
+  endif                                                                                        _NL_\
+  call adios2_get(file, var, data, adios2_mode_sync, ier)                                      _NL_\
+  call check_adios2_err(rank, ier, src, func, "Read variable("//trim(varname)//")")        
+
+
+!# SUB(TYPENAME,TYPEDEF,NDIMS,DIMDEF) \
+!subroutine read_adios2_##TYPENAME##_##NDIMS##d(file, io, varname, ndims, start, count, data, myrank, src, func, step)  _NL_\
+!##CODE _ARGS                                                                                     _NL_\
+!  TYPEDEF, dimension(DIMDEF), intent(out) :: data                                               _NL_\
+!##CODE _BODY                                                                                     _NL_\
+!end subroutine read_adios2_##TYPENAME##_##NDIMS##d
+
+! #  !define SUBROUTINETYPE(TYPENAME,TYPEDEF) _NL_\
+! # #SUB(TYPENAME,TYPEDEF,1,:)              _NL_\
+! # #(TYPENAME,TYPEDEF,2,@@:,:@@)          _NL_\
+
+
+!! SUBROUTINETYPE(integer,integer(kind=4))
+
+!===============================================================================
+!> Read (a selection of) variable data from a file
+!! (set up a selection and schedule for reading in data)
+!! Note: This function calls check_adios2_err which aborts the program on error
+!! \param file adios2_engine object from adios2_open
+!! \param io adios2_io object from adios2_declare_io
+!! \param varname Name of the variable
+!! \param ndims Number of dimensions of the variable
+!! \param start Offsets in global array for reading
+!! \param count Local sizes for reading
+!! \param data Pre-allocated array to receive the data from file
+!! \param src Sourcefile string (for error print)
+!! \param func Calling Function string (for error print)
+subroutine read_adios2_real_1d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=4), dimension(:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_real_1d
+
+
+!===============================================================================
+subroutine read_adios2_real_2d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=4), dimension(:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_real_2d
+
+
+!===============================================================================
+subroutine read_adios2_real_3d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=4), dimension(:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_real_3d
+
+
+!===============================================================================
+subroutine read_adios2_real_4d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=4), dimension(:,:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_real_4d
+
+
+!===============================================================================
+subroutine read_adios2_real_5d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=4), dimension(:,:,:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_real_5d
+
+
+!===============================================================================
+subroutine read_adios2_double_1d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=8), dimension(:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_double_1d
+
+
+!===============================================================================
+subroutine read_adios2_double_2d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=8), dimension(:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_double_2d
+
+
+!===============================================================================
+subroutine read_adios2_double_3d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=8), dimension(:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_double_3d
+
+
+!===============================================================================
+subroutine read_adios2_double_4d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=8), dimension(:,:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_double_4d
+
+
+!===============================================================================
+subroutine read_adios2_double_5d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  real(kind=8), dimension(:,:,:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_double_5d
+
+
+!===============================================================================
+subroutine read_adios2_integer_1d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer, dimension(:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_integer_1d
+
+
+!===============================================================================
+subroutine read_adios2_integer_2d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer, dimension(:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_integer_2d
+
+
+!===============================================================================
+subroutine read_adios2_integer_3d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer, dimension(:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_integer_3d
+
+
+!===============================================================================
+subroutine read_adios2_integer_4d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer, dimension(:,:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_integer_4d
+
+
+!===============================================================================
+subroutine read_adios2_integer_5d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer, dimension(:,:,:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_integer_5d
+
+
+!===============================================================================
+subroutine read_adios2_long_1d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer(kind=8), dimension(:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_long_1d
+
+
+!===============================================================================
+subroutine read_adios2_long_2d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer(kind=8), dimension(:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_long_2d
+
+
+!===============================================================================
+subroutine read_adios2_long_3d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer(kind=8), dimension(:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_long_3d
+
+
+!===============================================================================
+subroutine read_adios2_long_4d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer(kind=8), dimension(:,:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_long_4d
+
+
+!===============================================================================
+subroutine read_adios2_long_5d(file, io, varname, ndims, start, count, data, rank, src,func,step)
+CODE_ARGS
+  integer(kind=8), dimension(:,:,:,:,:), intent(out) :: data
+CODE_BODY
+end subroutine read_adios2_long_5d
+
+
+
+end module adios2_helpers_read_mod

--- a/src/shared/adios2_manager.F90
+++ b/src/shared/adios2_manager.F90
@@ -1,0 +1,235 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!> Tools to setup and cleanup ADIOS2,
+!> contains wrapper subroutines for common adios calls
+!
+! note: adios library calls use a format like "adios_do_something***()"
+!       our own wrapper functions thus will rather use something like "do_something_adios***()"
+!       to better distinguish between library functions and wrappers.
+
+module manager_adios2
+
+#ifdef HAVE_ADIOS2
+  use adios2, only: adios2_adios, adios2_engine
+#endif
+  implicit none
+
+  private
+
+  ! MPI copies of communicator and rank
+  integer,public :: comm_adios2
+  integer,public :: myrank_adios2
+  integer,public :: sizeprocs_adios2
+
+  ! initialized flag
+  logical :: is_adios2_initialized
+
+  ! ADIOS Real type based on CUSTOM_REAL
+  integer, public :: adios2_custom_real
+
+#ifdef HAVE_ADIOS2
+  ! adios2 handlers
+  type(adios2_adios), public:: adios2obj
+  ! File handlers that needs to be closed at exit
+  type(adios2_engine), public:: adios2_file_fwdatt
+#endif
+
+  ! debugging
+  logical,parameter :: DEBUG = .false.
+
+  ! public routines
+  public :: initialize_adios2
+  public :: finalize_adios2
+
+  ! only available with ADIOS2 compilation support
+  ! to clearly separate adios version and non-adios version of same tools
+#ifdef HAVE_ADIOS2xxx
+  public :: check_adios2_err
+  public :: read_adios2_global_real_1d_array
+  public :: read_adios2_global_double_1d_array
+  public :: read_adios2_global_integer_1d_array
+  public :: read_adios2_global_long_1d_array
+  public :: read_adios2_global_logical_1d_array
+  public :: read_adios2_global_string_1d_array
+  public :: read_adios2_global_1d_array
+#endif
+
+contains
+
+
+!-------------------------------------------------------------------------------
+!
+! public ADIOS2 wrapper routines (also available without adios compilation support)
+!
+!-------------------------------------------------------------------------------
+
+  subroutine initialize_adios2()
+
+!> Initialize ADIOS and setup the xml output file
+
+#ifdef HAVE_ADIOS2
+  use adios2, only: adios2_init, adios2_debug_mode_on, adios2_type_real4, adios2_type_real8
+#endif
+  use constants, only: CUSTOM_REAL, SIZE_REAL, SIZE_DOUBLE
+
+  implicit none
+
+  ! local parameters
+#ifdef HAVE_ADIOS2
+  integer :: ier
+#endif
+
+  ! initializes
+  is_adios2_initialized = .false.
+  call world_get_comm(comm_adios2)
+  call world_rank(myrank_adios2)
+  call world_size(sizeprocs_adios2)
+  adios2_custom_real = 0;
+
+
+#ifdef HAVE_ADIOS2
+
+  ! Create adios handler passing the communicator, debug mode and error flag
+  ! adios2 duplicates the communicator for its internal use
+  call adios2_init(adios2obj, comm_adios2, adios2_debug_mode_on, ier)
+
+  ! sets flag
+  is_adios2_initialized = .true.
+
+  if (CUSTOM_REAL == SIZE_REAL) then
+    adios2_custom_real = adios2_type_real4
+  else
+    adios2_custom_real = adios2_type_real8
+  endif
+
+#else
+
+  ! compilation without ADIOS support
+  if (myrank_adios2 == 0) then
+    print *, "Error: ADIOS2 enabled without ADIOS2 Support."
+    print *, "To enable ADIOS2 support, reconfigure with --with-adios2 flag."
+  endif
+  ! safety stop
+  call exit_MPI(myrank_adios2,"Error ADIOS2 manager: intitialize called without compilation support")
+
+#endif
+
+  end subroutine initialize_adios2
+
+!
+!-------------------------------------------------------------------------------
+!
+
+  subroutine finalize_adios2()
+
+!> Finalize ADIOS. Must be called once everything is written down.
+
+#ifdef HAVE_ADIOS2
+  use adios2, only: adios2_close, adios2_finalize
+#endif
+
+  implicit none
+
+  ! local parameters
+#ifdef HAVE_ADIOS2
+  integer :: ier
+#endif
+
+  ! synchronizes all first
+  call synchronize_all_comm(comm_adios2)
+
+#ifdef HAVE_ADIOS2
+  ! close files that are growing until the end of run
+  if (adios2_file_fwdatt%valid) then
+     call adios2_close(adios2_file_fwdatt, ier)
+  endif
+
+  ! finalize
+  call adios2_finalize(adios2obj, ier)
+  if (ier /= 0 ) stop 'Error cleaning up ADIOS2: calling adios2_finalize() routine failed'
+
+#else
+  ! safety stop
+  call exit_MPI(myrank_adios2,"Error ADIOS2 manager: finalize called without compilation support")
+#endif
+
+  end subroutine finalize_adios2
+
+
+!-------------------------------------------------------------------------------
+!
+! ADIOS wrapper routines (only available with adios compilation support)
+!
+!-------------------------------------------------------------------------------
+#ifdef HAVE_ADIOS2xxx
+
+
+
+subroutine read_var_adios2(file, io, varname, ndims, start, count, data, src, func )
+
+!> Read (a selection of) variable data from a file
+!! (set up a selection and schedule for reading in data)
+!! Note: This function calls check_adios2_err which aborts the program on error
+!! \param file adios2_engine object from adios2_open
+!! \param io adios2_io object from adios2_declare_io
+!! \param varname Name of the variable
+!! \param ndims Number of dimensions of the variable
+!! \param start Offsets in global array for reading
+!! \param count Local sizes for reading
+!! \param data Pre-allocated array to receive the data from file
+!! \param src Sourcefile string (for error print)
+!! \param func Calling Function string (for error print)
+
+
+  use adios2
+  implicit none
+  type(adios2_engine), intent(in)   :: file
+  type(adios2_io), intent(in)       :: io
+  character(len=:), intent(in)      :: varname
+  integer(kind=4), intent(in)       :: ndims
+  integer(kind=8), dimension(1), intent(in) :: start, count
+  (kind), dimension(:), intent(out) :: data
+  character(len=:), intent(in)      :: sourcefile, func, msg
+
+  integer                 :: ier
+  type(adios2_variable)   :: var
+
+  call adios2_inquire_variable(var, io, varname, ier)
+  call check_adios2_err(myrank_adios2, ier, src, unc, "Inquire variable "//trim(varname))
+  call adios2_set_selection(var, ndims, start, count, ier)
+  call adios2_get(file, var, data, adios2_mode_sync, ier)
+  call check_adios2_err(myrank_adios2, ier, src, unc, "adios2_get("//trim(varname)//")")
+
+end subroutine read_var_adios2
+
+
+
+#endif /* HAVE_ADIOS2 */
+end module manager_adios2
+
+

--- a/src/shared/read_parameter_file.F90
+++ b/src/shared/read_parameter_file.F90
@@ -273,6 +273,18 @@
   call read_value_logical(ADIOS_FOR_UNDO_ATTENUATION, 'ADIOS_FOR_UNDO_ATTENUATION', ier)
   if (ier /= 0) stop 'an error occurred while reading the parameter file: ADIOS_FOR_UNDO_ATTENUATION'
 
+#if !defined(HAVE_ADIOS2) && !defined(ADIOS_INPUT)
+    print *
+    print *,'**************'
+    print *,'**************'
+    print *,'ADIOS is enabled in parameter file but the code was not compiled with ADIOS'
+    print *,'See --with-adios2 and --with-adios configure options.'
+    print *,'**************'
+    print *,'**************'
+    print *
+    stop 'an error occurred while reading the parameter file: ADIOS is enabled but code not built with ADIOS'
+#endif
+
   ! ADIOS is very useful for very large simulations (say using 2000 MPI tasks or more)
   ! but slows down the code if used for simulations that are small or medium size, because of the overhead any library has.
   if (ADIOS_ENABLED .and. NCHUNKS * NPROC_XI_read * NPROC_ETA_read < 2000) then

--- a/src/shared/read_parameter_file.F90
+++ b/src/shared/read_parameter_file.F90
@@ -273,6 +273,7 @@
   call read_value_logical(ADIOS_FOR_UNDO_ATTENUATION, 'ADIOS_FOR_UNDO_ATTENUATION', ier)
   if (ier /= 0) stop 'an error occurred while reading the parameter file: ADIOS_FOR_UNDO_ATTENUATION'
 
+  if (ADIOS_ENABLED) then
 #if !defined(HAVE_ADIOS2) && !defined(ADIOS_INPUT)
     print *
     print *,'**************'
@@ -284,6 +285,7 @@
     print *
     stop 'an error occurred while reading the parameter file: ADIOS is enabled but code not built with ADIOS'
 #endif
+  endif
 
   ! ADIOS is very useful for very large simulations (say using 2000 MPI tasks or more)
   ! but slows down the code if used for simulations that are small or medium size, because of the overhead any library has.

--- a/src/specfem3D/finalize_simulation.F90
+++ b/src/specfem3D/finalize_simulation.F90
@@ -34,6 +34,7 @@
   use specfem_par_movie
 
   use manager_adios
+  use manager_adios2
 
 #ifdef XSMM
   use my_libxsmm
@@ -122,6 +123,9 @@
 
   ! adios finalizes
   if (ADIOS_ENABLED) then
+#ifdef HAVE_ADIOS2
+    call finalize_adios2()
+#endif
     call finalize_adios()
   endif
 

--- a/src/specfem3D/initialize_simulation.F90
+++ b/src/specfem3D/initialize_simulation.F90
@@ -30,6 +30,7 @@
   use specfem_par
   use specfem_par_movie
   use manager_adios
+  use manager_adios2
 
   implicit none
 
@@ -261,6 +262,9 @@
   endif
 
   if (ADIOS_ENABLED) then
+#ifdef HAVE_ADIOS2
+    call initialize_adios2()
+#endif
     call initialize_adios()
   endif
   !if (ADIOS_ENABLED) then

--- a/src/specfem3D/read_forward_arrays.F90
+++ b/src/specfem3D/read_forward_arrays.F90
@@ -71,7 +71,11 @@
     endif
 
     if (ADIOS_FOR_FORWARD_ARRAYS) then
+#ifdef HAVE_ADIOS2
+      call read_intermediate_forward_arrays_adios2()
+#else
       call read_intermediate_forward_arrays_adios()
+#endif
     else
       write(outputname,"('dump_all_arrays',i6.6)") myrank
       outputname = trim(LOCAL_TMP_PATH) // '/' // outputname(1:len_trim(outputname))
@@ -148,7 +152,11 @@
 
   ! reads in file data
   if (ADIOS_FOR_FORWARD_ARRAYS) then
+#ifdef HAVE_ADIOS2
+    call read_forward_arrays_adios2()
+#else
     call read_forward_arrays_adios()
+#endif
   else
     write(outputname,'(a,i6.6,a)') 'proc',myrank,'_save_forward_arrays.bin'
     outputname = trim(LOCAL_TMP_PATH) // '/' // outputname(1:len_trim(outputname))
@@ -272,7 +280,11 @@
   iteration_on_subset_tmp = NSUBSET_ITERATIONS - iteration_on_subset + 1
 
   if (ADIOS_FOR_UNDO_ATTENUATION) then
+#ifdef HAVE_ADIOS2
+    call read_forward_arrays_undoatt_adios2(iteration_on_subset_tmp)
+#else
     call read_forward_arrays_undoatt_adios(iteration_on_subset_tmp)
+#endif
   else
     ! reads in saved wavefield
     write(outputname,'(a,i6.6,a,i6.6,a)') 'proc',myrank,'_save_frame_at',iteration_on_subset_tmp,'.bin'

--- a/src/specfem3D/read_forward_arrays_adios2.F90
+++ b/src/specfem3D/read_forward_arrays_adios2.F90
@@ -1,0 +1,395 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!-------------------------------------------------------------------------------
+!> \file read_forward_arrays_adios.F90
+!! \brief Read saved forward arrays with the help of the ADIOS library.
+!-------------------------------------------------------------------------------
+
+!-------------------------------------------------------------------------------
+!> \brief Read forward arrays from an ADIOS file.
+!> \note read_intermediate_forward_arrays_adios2()
+!!       and read_forward_arrays_adios2() are not factorized, because
+!>       the latest read the bp file in "b_" prefixed arrays
+
+module forward_adios2_read
+  use adios2, only: adios2_engine, adios2_io, adios2_variable, adios2_attribute
+  use adios2_helpers_read_mod
+  type(adios2_io), public :: io_fwdatt
+  type(adios2_variable), public :: v_x
+  character(len=*), parameter :: src="read_forward_arrays_adios2"
+
+end module forward_adios2_read
+
+  subroutine read_intermediate_forward_arrays_adios2()
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_read
+
+  implicit none
+  ! Local parameters
+  character(len=MAX_STRING_LEN) :: file_name, io_name
+  character(len=*), parameter :: func="read_intermediate_forward_arrays_adios2()"
+  integer :: local_dim
+  ! ADIOS variables
+  type(adios2_io)         :: io
+  type(adios2_engine)     :: file
+  integer                 :: ier
+  integer(kind=8), dimension(1) :: start, count
+
+  file_name = trim(LOCAL_TMP_PATH) // "/dump_all_arrays_adios.bp"
+  io_name = "SPECFEM3D_GLOBE_FORWARD_ARRAYS"
+
+  ! Create the ADIOS IO group which will contain all variables and attributes
+  call adios2_declare_io(io, adios2obj, io_name, ier)
+  call check_adios2_err(myrank,ier,src,func, "Declare IO group")
+
+  ! Set engine and parameters
+  call adios2_set_engine(io, ADIOS2_ENGINE_DEFAULT, ier)
+
+  ! Open the handle to file containing all the ADIOS variables
+  call adios2_open(file, io, file_name, adios2_mode_read, ier)
+  call check_adios2_err(myrank,ier,src,func, "Open file "//file_name)
+
+  ! crust/mantle
+  local_dim = NDIM * NGLOB_CRUST_MANTLE
+  start(1) = local_dim*myrank; count(1) = local_dim
+
+  call read_adios2(file, io, "displ_crust_mantle", 1, start, count, displ_crust_mantle, myrank, src, func)
+  ! the above call is equivalent to:
+  ! call adios2_inquire_variable(v, io, "displ_crust_mantle", ier)
+  ! call check_adios2_err(myrank,ier,src,func, "Inquire variable displ_crust_mantle")
+  ! call adios2_set_selection(v, 1, start, count, ier)
+  ! call adios2_get(file, v, displ_crust_mantle, ier)
+  call read_adios2(file, io, "veloc_crust_mantle", 1, start, count, veloc_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "accel_crust_mantle", 1, start, count, accel_crust_mantle, myrank, src, func)
+
+  ! inner core
+  local_dim = NDIM * NGLOB_INNER_CORE
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "displ_inner_core", 1, start, count, displ_inner_core, myrank, src, func)
+  call read_adios2(file, io, "veloc_inner_core", 1, start, count, veloc_inner_core, myrank, src, func)
+  call read_adios2(file, io, "accel_inner_core", 1, start, count, accel_inner_core, myrank, src, func)
+
+  ! outer core
+  local_dim = NGLOB_OUTER_CORE
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "displ_outer_core", 1, start, count, displ_outer_core, myrank, src, func)
+  call read_adios2(file, io, "veloc_outer_core", 1, start, count, veloc_outer_core, myrank, src, func)
+  call read_adios2(file, io, "accel_outer_core", 1, start, count, accel_outer_core, myrank, src, func)
+
+  ! strains crust/mantle
+  local_dim = NGLLX * NGLLY * NGLLZ * NSPEC_CRUST_MANTLE_STR_OR_ATT
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "epsilondev_xx_crust_mantle", 1, start, count, epsilondev_xx_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_yy_crust_mantle", 1, start, count, epsilondev_yy_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_xy_crust_mantle", 1, start, count, epsilondev_xy_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_xz_crust_mantle", 1, start, count, epsilondev_xz_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_yz_crust_mantle", 1, start, count, epsilondev_yz_crust_mantle, myrank, src, func)
+
+  ! strains inner core
+  local_dim = NGLLX * NGLLY * NGLLZ * NSPEC_INNER_CORE_STR_OR_ATT
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "epsilondev_xx_inner_core", 1, start, count, epsilondev_xx_inner_core, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_yy_inner_core", 1, start, count, epsilondev_yy_inner_core, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_xy_inner_core", 1, start, count, epsilondev_xy_inner_core, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_xz_inner_core", 1, start, count, epsilondev_xz_inner_core, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_yz_inner_core", 1, start, count, epsilondev_yz_inner_core, myrank, src, func)
+
+  ! rotation
+  local_dim = NGLLX * NGLLY * NGLLZ * NSPEC_OUTER_CORE_ROTATION
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "A_array_rotation", 1, start, count, A_array_rotation, myrank, src, func)
+  call read_adios2(file, io, "B_array_rotation", 1, start, count, B_array_rotation, myrank, src, func)
+
+  ! attenuation memory variables crust/mantle
+  local_dim = N_SLS*NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE_ATTENUATION
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "R_xx_crust_mantle", 1, start, count, R_xx_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "R_yy_crust_mantle", 1, start, count, R_yy_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "R_xy_crust_mantle", 1, start, count, R_xy_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "R_xz_crust_mantle", 1, start, count, R_xz_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "R_yz_crust_mantle", 1, start, count, R_yz_crust_mantle, myrank, src, func)
+
+  ! attenuation memory variables inner core
+  local_dim = N_SLS*NGLLX*NGLLY*NGLLZ*NSPEC_INNER_CORE_ATTENUATION
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "R_xx_inner_core", 1, start, count, R_xx_inner_core, myrank, src, func)
+  call read_adios2(file, io, "R_yy_inner_core", 1, start, count, R_yy_inner_core, myrank, src, func)
+  call read_adios2(file, io, "R_xy_inner_core", 1, start, count, R_xy_inner_core, myrank, src, func)
+  call read_adios2(file, io, "R_xz_inner_core", 1, start, count, R_xz_inner_core, myrank, src, func)
+  call read_adios2(file, io, "R_yz_inner_core", 1, start, count, R_yz_inner_core, myrank, src, func)
+
+  ! closes adios file
+  call adios2_close(file, ier)
+  call check_adios2_err(myrank,ier,src,func, "Close file "//file_name)
+
+  end subroutine read_intermediate_forward_arrays_adios2
+
+!-------------------------------------------------------------------------------
+!> \brief Read forward arrays from an ADIOS file.
+!> \note read_intermediate_forward_arrays_adios2() and read_forward_arrays_adios2() are not factorized, because
+!>       the latest read the bp file in "b_" prefixed arrays
+
+  subroutine read_forward_arrays_adios2()
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_read
+
+  implicit none
+  ! Local parameters
+  character(len=MAX_STRING_LEN) :: file_name, io_name
+  character(len=*), parameter :: func="read_forward_arrays_adios2()"
+  integer :: local_dim
+  ! ADIOS variables
+  type(adios2_io)         :: io
+  type(adios2_engine)     :: file
+  integer                 :: ier
+  integer(kind=8), dimension(1) :: start, count
+
+  file_name = trim(LOCAL_TMP_PATH) // "/save_forward_arrays.bp"
+  io_name = "SPECFEM3D_GLOBE_FORWARD_ARRAYS"
+
+  ! Create the ADIOS IO group which will contain all variables and attributes
+  call adios2_declare_io(io, adios2obj, io_name, ier)
+  call check_adios2_err(myrank,ier,src,func, "Declare IO group")
+
+  ! Set engine and parameters
+  call adios2_set_engine(io, ADIOS2_ENGINE_DEFAULT, ier)
+
+  ! Open the handle to file containing all the ADIOS variables
+  call adios2_open(file, io, file_name, adios2_mode_read, ier)
+  call check_adios2_err(myrank,ier,src,func, "Open file "//file_name)
+
+  ! crust/mantle
+  local_dim = NDIM * NGLOB_CRUST_MANTLE
+  start(1) = local_dim*myrank; count(1) = local_dim
+
+  call read_adios2(file, io, "displ_crust_mantle", 1, start, count, displ_crust_mantle, myrank, src, func)
+  ! the above call is equivalent to:
+  ! call adios2_inquire_variable(v, io, "displ_crust_mantle", ier)
+  ! call check_adios2_err(myrank,ier,src,func, "Inquire variable displ_crust_mantle")
+  ! call adios2_set_selection(v, 1, start, count, ier)
+  ! call adios2_get(file, v, displ_crust_mantle, ier)
+  call read_adios2(file, io, "veloc_crust_mantle", 1, start, count, veloc_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "accel_crust_mantle", 1, start, count, accel_crust_mantle, myrank, src, func)
+
+  ! inner core
+  local_dim = NDIM * NGLOB_INNER_CORE
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "displ_inner_core", 1, start, count, displ_inner_core, myrank, src, func)
+  call read_adios2(file, io, "veloc_inner_core", 1, start, count, veloc_inner_core, myrank, src, func)
+  call read_adios2(file, io, "accel_inner_core", 1, start, count, accel_inner_core, myrank, src, func)
+
+  ! outer core
+  local_dim = NGLOB_OUTER_CORE
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "displ_outer_core", 1, start, count, displ_outer_core, myrank, src, func)
+  call read_adios2(file, io, "veloc_outer_core", 1, start, count, veloc_outer_core, myrank, src, func)
+  call read_adios2(file, io, "accel_outer_core", 1, start, count, accel_outer_core, myrank, src, func)
+
+  ! strains crust/mantle
+  local_dim = NGLLX * NGLLY * NGLLZ * NSPEC_CRUST_MANTLE_STR_OR_ATT
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "epsilondev_xx_crust_mantle", 1, start, count, epsilondev_xx_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_yy_crust_mantle", 1, start, count, epsilondev_yy_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_xy_crust_mantle", 1, start, count, epsilondev_xy_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_xz_crust_mantle", 1, start, count, epsilondev_xz_crust_mantle, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_yz_crust_mantle", 1, start, count, epsilondev_yz_crust_mantle, myrank, src, func)
+
+  ! strains inner core
+  local_dim = NGLLX * NGLLY * NGLLZ * NSPEC_INNER_CORE_STR_OR_ATT
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io, "epsilondev_xx_inner_core", 1, start, count, epsilondev_xx_inner_core, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_yy_inner_core", 1, start, count, epsilondev_yy_inner_core, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_xy_inner_core", 1, start, count, epsilondev_xy_inner_core, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_xz_inner_core", 1, start, count, epsilondev_xz_inner_core, myrank, src, func)
+  call read_adios2(file, io, "epsilondev_yz_inner_core", 1, start, count, epsilondev_yz_inner_core, myrank, src, func)
+
+  ! rotation
+  if (ROTATION_VAL) then
+     local_dim = NGLLX * NGLLY * NGLLZ * NSPEC_OUTER_CORE_ROTATION
+     start(1) = local_dim*myrank; count(1) = local_dim
+     call read_adios2(file, io, "A_array_rotation", 1, start, count, A_array_rotation, myrank, src, func)
+     call read_adios2(file, io, "B_array_rotation", 1, start, count, B_array_rotation, myrank, src, func)
+  endif
+
+
+  if (ATTENUATION_VAL) then
+     ! attenuation memory variables crust/mantle
+     local_dim = N_SLS*NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE_ATTENUATION
+     start(1) = local_dim*myrank; count(1) = local_dim
+     call read_adios2(file, io, "R_xx_crust_mantle", 1, start, count, R_xx_crust_mantle, myrank, src, func)
+     call read_adios2(file, io, "R_yy_crust_mantle", 1, start, count, R_yy_crust_mantle, myrank, src, func)
+     call read_adios2(file, io, "R_xy_crust_mantle", 1, start, count, R_xy_crust_mantle, myrank, src, func)
+     call read_adios2(file, io, "R_xz_crust_mantle", 1, start, count, R_xz_crust_mantle, myrank, src, func)
+     call read_adios2(file, io, "R_yz_crust_mantle", 1, start, count, R_yz_crust_mantle, myrank, src, func)
+
+     ! attenuation memory variables inner core
+     local_dim = N_SLS*NGLLX*NGLLY*NGLLZ*NSPEC_INNER_CORE_ATTENUATION
+     start(1) = local_dim*myrank; count(1) = local_dim
+     call read_adios2(file, io, "R_xx_inner_core", 1, start, count, R_xx_inner_core, myrank, src, func)
+     call read_adios2(file, io, "R_yy_inner_core", 1, start, count, R_yy_inner_core, myrank, src, func)
+     call read_adios2(file, io, "R_xy_inner_core", 1, start, count, R_xy_inner_core, myrank, src, func)
+     call read_adios2(file, io, "R_xz_inner_core", 1, start, count, R_xz_inner_core, myrank, src, func)
+     call read_adios2(file, io, "R_yz_inner_core", 1, start, count, R_yz_inner_core, myrank, src, func)
+  endif
+
+  ! closes adios file
+  call adios2_close(file, ier)
+  call check_adios2_err(myrank,ier,src,func, "Close file "//file_name)
+
+  end subroutine read_forward_arrays_adios2
+
+
+!-------------------------------------------------------------------------------
+!> \brief Read forward arrays for undo attenuation from an ADIOS file.
+
+  subroutine read_forward_arrays_undoatt_adios2(iteration_on_subset_tmp)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_read
+
+  implicit none
+  ! Arguments
+  integer, intent(in) :: iteration_on_subset_tmp
+  ! Local parameters
+  character(len=MAX_STRING_LEN) :: file_name, io_name
+  character(len=*), parameter :: func="read_forward_arrays_undoatt_adios2()"
+  integer :: local_dim
+  ! ADIOS variables
+  type(adios2_engine)     :: file
+  integer                 :: ier
+  integer(kind=8), dimension(1) :: start, count
+  ! shorten the name of iteration variable and make it integer*8
+  integer(kind=8) :: t
+
+  !! iterations here go down from N to 1
+  !! but ADIOS files has steps 0..N-1
+  t = iteration_on_subset_tmp - 1
+
+  file_name = trim(LOCAL_TMP_PATH) // "/save_forward_arrays.bp"
+  io_name = "SPECFEM3D_GLOBE_FORWARD_ARRAYS_UNDOATT"
+
+  if (.not.io_fwdatt%valid) then
+    ! Create the ADIOS IO group which will contain all variables and attributes
+    call adios2_declare_io(io_fwdatt, adios2obj, io_name, ier)
+    call check_adios2_err(myrank,ier,src,func, "Declare IO group")
+
+    ! Set engine and parameters
+    call adios2_set_engine(io_fwdatt, ADIOS2_ENGINE_DEFAULT, ier)
+  endif
+
+  if (.not.adios2_file_fwdatt%valid) then
+    ! Open the handle to file containing all the ADIOS variables
+    call adios2_open(adios2_file_fwdatt, io_fwdatt, file_name, adios2_mode_read, ier)
+    call check_adios2_err(myrank,ier,src,func, "Open file "//file_name)
+  endif
+
+  file = adios2_file_fwdatt
+  !
+  !call adios2_set_step_selection(variable, iteration_on_subset_tmp, 1, ier)
+  !
+  call check_adios2_err(myrank,ier,src,func, "Seeking step in "//file_name)
+
+  ! crust/mantle
+  local_dim = NDIM * NGLOB_CRUST_MANTLE
+  start(1) = local_dim*myrank; count(1) = local_dim
+
+  call read_adios2(file, io_fwdatt, "displ_crust_mantle", 1, start, count, displ_crust_mantle, myrank, src,func, t)
+  ! the above call is equivalent to:
+  ! call adios2_inquire_variable(v, io, "displ_crust_mantle", ier)
+  ! call check_adios2_err(myrank,ier,src,func, "Inquire variable displ_crust_mantle")
+  ! call adios2_set_selection(v, 1, start, count, ier)
+  ! call adios2_get(file, v, displ_crust_mantle, ier)
+  call read_adios2(file, io_fwdatt, "veloc_crust_mantle", 1, start, count, veloc_crust_mantle, myrank, src,func, t)
+  call read_adios2(file, io_fwdatt, "accel_crust_mantle", 1, start, count, accel_crust_mantle, myrank, src,func, t)
+
+  ! inner core
+  local_dim = NDIM * NGLOB_INNER_CORE
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io_fwdatt, "displ_inner_core", 1, start, count, displ_inner_core, myrank, src,func, t)
+  call read_adios2(file, io_fwdatt, "veloc_inner_core", 1, start, count, veloc_inner_core, myrank, src,func, t)
+  call read_adios2(file, io_fwdatt, "accel_inner_core", 1, start, count, accel_inner_core, myrank, src,func, t)
+
+  ! outer core
+  local_dim = NGLOB_OUTER_CORE
+  start(1) = local_dim*myrank; count(1) = local_dim
+  call read_adios2(file, io_fwdatt, "displ_outer_core", 1, start, count, displ_outer_core, myrank, src,func, t)
+  call read_adios2(file, io_fwdatt, "veloc_outer_core", 1, start, count, veloc_outer_core, myrank, src,func, t)
+  call read_adios2(file, io_fwdatt, "accel_outer_core", 1, start, count, accel_outer_core, myrank, src,func, t)
+
+  ! rotation
+  if (ROTATION_VAL) then
+     local_dim = NGLLX * NGLLY * NGLLZ * NSPEC_OUTER_CORE_ROTATION
+     start(1) = local_dim*myrank; count(1) = local_dim
+     call read_adios2(file, io_fwdatt, "A_array_rotation", 1, start, count, A_array_rotation, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "B_array_rotation", 1, start, count, B_array_rotation, myrank, src,func, t)
+  endif
+
+
+  if (ATTENUATION_VAL) then
+     ! attenuation memory variables crust/mantle
+     local_dim = N_SLS*NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE_ATTENUATION
+     start(1) = local_dim*myrank; count(1) = local_dim
+     call read_adios2(file, io_fwdatt, "R_xx_crust_mantle", 1, start, count, R_xx_crust_mantle, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "R_yy_crust_mantle", 1, start, count, R_yy_crust_mantle, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "R_xy_crust_mantle", 1, start, count, R_xy_crust_mantle, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "R_xz_crust_mantle", 1, start, count, R_xz_crust_mantle, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "R_yz_crust_mantle", 1, start, count, R_yz_crust_mantle, myrank, src,func, t)
+
+     ! attenuation memory variables inner core
+     local_dim = N_SLS*NGLLX*NGLLY*NGLLZ*NSPEC_INNER_CORE_ATTENUATION
+     start(1) = local_dim*myrank; count(1) = local_dim
+     call read_adios2(file, io_fwdatt, "R_xx_inner_core", 1, start, count, R_xx_inner_core, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "R_yy_inner_core", 1, start, count, R_yy_inner_core, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "R_xy_inner_core", 1, start, count, R_xy_inner_core, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "R_xz_inner_core", 1, start, count, R_xz_inner_core, myrank, src,func, t)
+     call read_adios2(file, io_fwdatt, "R_yz_inner_core", 1, start, count, R_yz_inner_core, myrank, src,func, t)
+  endif
+
+  ! Never close the file here. It will be closed in adios2_manager::finalize_adios2()
+
+  end subroutine read_forward_arrays_undoatt_adios2

--- a/src/specfem3D/rules.mk
+++ b/src/specfem3D/rules.mk
@@ -134,6 +134,7 @@ specfem3D_MODULES = \
 specfem3D_SHARED_OBJECTS = \
 	$O/shared_par.shared_module.o \
 	$O/adios_manager.shared_adios_module.o \
+	$O/adios2_manager.shared_adios2_module.o \
 	$O/auto_ner.shared.o \
 	$O/binary_c_io.cc.o \
 	$O/broadcast_computed_parameters.shared.o \
@@ -213,6 +214,34 @@ specfem3D_SHARED_OBJECTS += $(adios_specfem3D_SHARED_STUBS)
 endif
 
 ###
+### ADIOS2
+###
+
+adios2_specfem3D_OBJECTS = \
+	$O/read_forward_arrays_adios2.solverstatic_adios2.o \
+	$O/save_forward_arrays_adios2.solverstatic_adios2.o \
+	$O/save_kernels_adios2.solverstatic_adios2.o \
+	$(EMPTY_MACRO)
+#	$O/read_arrays_solver_adios2.solverstatic_adios2.o \
+#	$O/read_attenuation_adios2.solverstatic_adios2.o \
+#	$O/read_mesh_databases_adios2.solverstatic_adios2.o \
+
+adios2_specfem3D_SHARED_OBJECTS = \
+	$O/adios2_helpers_read.shared_adios2_module.o \
+	$(EMPTY_MACRO)
+
+adios2_specfem3D_SHARED_STUBS = \
+	$(EMPTY_MACRO)
+
+# conditional adios2 linking
+ifeq ($(ADIOS2),yes)
+specfem3D_OBJECTS += $(adios2_specfem3D_OBJECTS)
+specfem3D_SHARED_OBJECTS += $(adios2_specfem3D_SHARED_OBJECTS)
+else
+specfem3D_SHARED_OBJECTS += $(adios2_specfem3D_SHARED_STUBS)
+endif
+
+###
 ### ASDF
 ###
 
@@ -259,7 +288,7 @@ vtk_specfem3D_STUBS = \
 	$O/visual_vtk_stubs.visualc.o \
 	$(EMPTY_MACRO)
 
-# conditional adios linking
+# conditional vtk linking
 ifeq ($(VTK),yes)
 specfem3D_OBJECTS += $(vtk_specfem3D_OBJECTS)
 else
@@ -324,6 +353,7 @@ $O/locate_receivers.solverstatic.o: $O/write_seismograms.solverstatic.o
 $O/read_adjoint_sources.solverstatic.o: $O/write_seismograms.solverstatic.o
 
 $O/specfem3D_par.solverstatic_module.o: $O/adios_manager.shared_adios_module.o
+$O/specfem3D_par.solverstatic_module.o: $O/adios2_manager.shared_adios2_module.o
 
 # Version file
 $O/initialize_simulation.solverstatic.o: ${SETUP}/version.fh
@@ -354,6 +384,10 @@ $O/%.solverstatic_adios.o: $S/%.f90 ${OUTPUT}/values_from_mesher.h $O/shared_par
 $O/%.solverstatic_adios.o: $S/%.F90 ${OUTPUT}/values_from_mesher.h $O/shared_par.shared_module.o $O/specfem3D_par.solverstatic_module.o $O/adios_helpers.shared_adios.o
 	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -c -o $@ $<
 
+$O/%.solverstatic_adios2.o: $S/%.F90 ${OUTPUT}/values_from_mesher.h $O/shared_par.shared_module.o $O/specfem3D_par.solverstatic_module.o 
+	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -c -o $@ $<
+
+###
 ###
 ### no dependence on values from mesher here
 ###

--- a/src/specfem3D/save_forward_arrays.F90
+++ b/src/specfem3D/save_forward_arrays.F90
@@ -53,7 +53,11 @@
   ! save files to local disk or tape system if restart file
   if (NUMBER_OF_RUNS > 1 .and. NUMBER_OF_THIS_RUN < NUMBER_OF_RUNS) then
     if (ADIOS_FOR_FORWARD_ARRAYS) then
+#ifdef HAVE_ADIOS2
+      call save_intermediate_forward_arrays_adios2()
+#else
       call save_intermediate_forward_arrays_adios()
+#endif
     else
       write(outputname,"('dump_all_arrays',i6.6)") myrank
       open(unit=IOUT,file=trim(LOCAL_TMP_PATH)//'/'//trim(outputname), &
@@ -106,7 +110,11 @@
   ! save last frame of the forward simulation
   if (SIMULATION_TYPE == 1 .and. SAVE_FORWARD) then
     if (ADIOS_FOR_FORWARD_ARRAYS) then
+#ifdef HAVE_ADIOS2
+      call save_forward_arrays_adios2()
+#else
       call save_forward_arrays_adios()
+#endif
     else
       write(outputname,'(a,i6.6,a)') 'proc',myrank,'_save_forward_arrays.bin'
       outputname = trim(LOCAL_TMP_PATH)//'/'//trim(outputname)
@@ -203,7 +211,11 @@
   endif
 
   if (ADIOS_FOR_UNDO_ATTENUATION) then
+#ifdef HAVE_ADIOS2
+    call save_forward_arrays_undoatt_adios2()
+#else
     call save_forward_arrays_undoatt_adios()
+#endif
   else
     ! current subset iteration
     iteration_on_subset_tmp = iteration_on_subset

--- a/src/specfem3D/save_forward_arrays_adios2.F90
+++ b/src/specfem3D/save_forward_arrays_adios2.F90
@@ -1,0 +1,590 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+!-------------------------------------------------------------------------------
+!> \file save_forward_arrays_adios.F90
+!! \brief Save forward arrays with the help of the ADIOS library.
+!! \author MPBL
+!-------------------------------------------------------------------------------
+
+#include "config.fh"
+
+
+module forward_adios2_write
+  use adios2, only: adios2_engine, adios2_io, adios2_variable, adios2_attribute
+  type(adios2_engine), public :: file_fwd, file_fwdim
+  type(adios2_io), public :: io_fwd, io_fwdim, io_fwdatt
+
+  type(adios2_variable), public :: v_x
+
+end module forward_adios2_write
+!-------------------------------------------------------------------------------
+!> \brief Write intermediate forward arrays in an ADIOS file.
+!!
+!! This subroutine is only used when NUMBER_OF_RUNS > 1 and
+!! NUMBER_OF_THIS_RUN < NUMBER_OF_RUNS.
+
+  subroutine save_intermediate_forward_arrays_adios2()
+
+  use constants, only: MAX_STRING_LEN, ADIOS2_ENGINE_DEFAULT
+  use shared_parameters, only: LOCAL_TMP_PATH
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  ! Local parameters
+  character(len=MAX_STRING_LEN) :: outputname, ioname
+  integer :: ier
+
+  outputname = trim(LOCAL_TMP_PATH) // "/dump_all_arrays_adios.bp"
+  ioname = "SPECFEM3D_GLOBE_FORWARD_ARRAYS"
+
+  ! Create the ADIOS IO group which will contain all variables and attributes
+  call adios2_declare_io(io_fwdim, adios2obj, ioname, ier)
+  if (ier /= 0) then
+    print *,&
+    'Error declaring an ADIOS2 IO group for itermediate forward arrays output in save_intermediate_forward_arrays_adios2()'
+    stop 'Error declaring an ADIOS2 IO group: calling save_intermediate_forward_arrays_adios2() routine failed'
+  endif
+
+  ! Set engine and parameters
+  call adios2_set_engine(io_fwdim, ADIOS2_ENGINE_DEFAULT, ier)
+
+  ! Open the handle to file containing all the ADIOS variables
+  call adios2_open(file_fwdim, io_fwdim, outputname, adios2_mode_write, ier)
+  if (ier /= 0) then
+    print *,'Error opening ADIOS2 file for itermediate forward arrays in save_intermediate_forward_arrays_adios2()'
+    stop 'Error opening ADIOS2 file: calling save_intermediate_forward_arrays_adios2() routine failed'
+  endif
+
+  ! Define ADIOS variables
+  call define_common_forward_arrays_adios2(io_fwdim)
+  call define_epsilon_forward_arrays_adios2(io_fwdim)
+  call define_rotation_forward_arrays_adios2(io_fwdim)
+  call define_attenuation_forward_arrays_adios2(io_fwdim)
+
+  ! Issue the order to write the previously defined variable to the ADIOS file
+  call write_common_forward_arrays_adios2(file_fwdim)
+  call write_epsilon_forward_arrays_adios2(file_fwdim)
+  call write_rotation_forward_arrays_adios2(file_fwdim)
+  call write_attenuation_forward_arrays_adios2(file_fwdim)
+
+  ! Close ADIOS handler to the restart file.
+  call adios2_close(file_fwdim, ier)
+
+  end subroutine save_intermediate_forward_arrays_adios2
+
+!-------------------------------------------------------------------------------
+!> \brief Write selected forward arrays in an ADIOS file.
+!!
+!! This subroutine is only used for forward simulations when
+!! SAVE_FORWARD is set to .true. It dumps the same arrays than
+!! save_intermediate_forward_arrays_adios2() except than some arrays
+!! are only dumped if ROTATION and ATTENUATION are set to .true.
+
+  subroutine save_forward_arrays_adios2()
+
+  use constants, only: MAX_STRING_LEN, ADIOS2_ENGINE_DEFAULT
+  use constants_solver, only:  ATTENUATION_VAL, ROTATION_VAL
+  use shared_parameters, only: LOCAL_TMP_PATH
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  ! Local parameters
+  character(len=MAX_STRING_LEN) :: outputname, ioname
+  integer :: ier
+
+  outputname = trim(LOCAL_TMP_PATH) // "/save_forward_arrays.bp"
+  ioname = "SPECFEM3D_GLOBE_FORWARD_ARRAYS"
+
+  ! Create the ADIOS IO group which will contain all variables and attributes
+  call adios2_declare_io(io_fwd, adios2obj, ioname, ier)
+  if (ier /= 0) then
+    print *,'Error declaring an ADIOS2 IO group for forward arrays output in save_forward_arrays_adios2()'
+    stop 'Error declaring an ADIOS2 IO group: calling save_forward_arrays_adios2() routine failed'
+  endif
+
+  ! Set engine and parameters
+  call adios2_set_engine(io_fwd, ADIOS2_ENGINE_DEFAULT, ier)
+
+  ! Open the handle to file containing all the ADIOS variables
+  call adios2_open(file_fwd, io_fwd, outputname, adios2_mode_write, ier)
+  if (ier /= 0) then
+    print *,'Error opening ADIOS2 file for forward arrays in save_forward_arrays_adios2()'
+    stop 'Error opening ADIOS2 file: calling save_forward_arrays_adios2() routine failed'
+  endif
+
+  ! Define ADIOS variables
+  call define_common_forward_arrays_adios2(io_fwd)
+  call define_epsilon_forward_arrays_adios2(io_fwd)
+  if (ROTATION_VAL) then
+    call define_rotation_forward_arrays_adios2(io_fwd)
+  endif
+  if (ATTENUATION_VAL) then
+    call define_attenuation_forward_arrays_adios2(io_fwd)
+  endif
+
+  ! Issue the order to write the previously defined variable to the ADIOS file
+  call write_common_forward_arrays_adios2(file_fwd)
+
+  call write_epsilon_forward_arrays_adios2(file_fwd)
+
+  if (ROTATION_VAL) then
+      call write_rotation_forward_arrays_adios2(file_fwd)
+  endif
+
+  if (ATTENUATION_VAL) then
+    call write_attenuation_forward_arrays_adios2(file_fwd)
+  endif
+
+  ! Close ADIOS handler to the restart file.
+  call adios2_close(file_fwd, ier)
+
+  end subroutine save_forward_arrays_adios2
+
+!-------------------------------------------------------------------------------
+!> \brief Write selected forward arrays in an ADIOS file.
+!!
+!! This subroutine is only used for forward simulations when
+!! SAVE_FORWARD is set to .true. It dumps the same arrays than
+!! save_intermediate_forward_arrays_adios2() except than some arrays
+!! are only dumped if ROTATION and ATTENUATION are set to .true.
+
+  subroutine save_forward_arrays_undoatt_adios2()
+
+  use constants, only: MAX_STRING_LEN, ADIOS2_ENGINE_UNDO_ATT, ADIOS2_ENGINE_PARAMS_UNDO_ATT
+  use constants_solver, only:  ATTENUATION_VAL, ROTATION_VAL
+  use shared_parameters, only: LOCAL_PATH
+  use specfem_par, only: iteration_on_subset
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  ! Local parameters
+  character(len=MAX_STRING_LEN) :: outputname, ioname
+  integer :: ier
+  type(adios2_variable), save :: v_iter
+
+  ! current subset iteration
+  !write(outputname,'(a, a, i6.6, a)') trim(LOCAL_PATH), '/save_frame_at', iteration_on_subset,'.bp'
+  outputname = trim(LOCAL_PATH) // "/save_forward_arrays.bp"
+  ioname = "SPECFEM3D_GLOBE_FORWARD_ARRAYS_UNDOATT"
+
+  if (.not.io_fwdatt%valid) then
+     ! Create the ADIOS IO group which will contain all variables and attributes
+     call adios2_declare_io(io_fwdatt, adios2obj, ioname, ier)
+     if (ier /= 0) then
+       print *,'Error declaring an ADIOS2 IO group for forward arrays output in save_forward_arrays_undoatt_adios2()'
+       stop 'Error declaring an ADIOS2 IO group: calling save_forward_arrays_undoatt_adios2() routine failed'
+     endif
+
+     ! Set engine and parameters
+     call adios2_set_engine(io_fwdatt, ADIOS2_ENGINE_UNDO_ATT, ier)
+     ! Set parameters to ADIOS2_ENGINE_PARAMS_UNDO_ATT
+     call adios2_set_parameters(io_fwdatt, ADIOS2_ENGINE_PARAMS_UNDO_ATT, ier)
+
+     ! Define ADIOS variables
+     call adios2_define_variable(v_iter, io_fwdatt, "iteration", adios2_type_integer4, ier)
+     call define_common_forward_arrays_adios2(io_fwdatt)
+     if (ROTATION_VAL) then
+        call define_rotation_forward_arrays_adios2(io_fwdatt)
+     endif
+     if (ATTENUATION_VAL) then
+        call define_attenuation_forward_arrays_adios2(io_fwdatt)
+     endif
+  endif
+
+  if (.not.adios2_file_fwdatt%valid) then
+     ! Open the handle to file containing all the ADIOS variables
+     call adios2_open(adios2_file_fwdatt, io_fwdatt, outputname, adios2_mode_write, ier)
+     if (ier /= 0) then
+       print *,'Error opening ADIOS2 file for undoatt forward arrays in save_forward_arrays_undoatt_adios2()'
+       stop 'Error opening ADIOS2 file: calling save_forward_arrays_undoatt_adios2() routine failed'
+     endif
+  endif
+
+  call adios2_begin_step(adios2_file_fwdatt, ier)
+  ! Issue the order to write the previously defined variable to the ADIOS file
+  call adios2_put(adios2_file_fwdatt, v_iter, iteration_on_subset, ier)
+  call write_common_forward_arrays_adios2(adios2_file_fwdatt)
+
+  if (ROTATION_VAL) then
+    call write_rotation_forward_arrays_adios2(adios2_file_fwdatt)
+  endif
+
+  if (ATTENUATION_VAL) then
+    call write_attenuation_forward_arrays_adios2(adios2_file_fwdatt)
+  endif
+
+  ! end step to indicate output is completed. ADIOS2 can do I/O
+  call adios2_end_step(adios2_file_fwdatt, ier)
+  ! Never close the file here. It will be closed in adios2_manager::finalize_adios2()
+
+  end subroutine save_forward_arrays_undoatt_adios2
+
+
+!-------------------------------------------------------------------------------
+!> Define ADIOS forward arrays that are always dumped.
+!! \param io The adios group where the variables belongs
+!! \param group_size_inc The inout adios group size to increment
+!!                       with the size of the variable
+
+  subroutine define_common_forward_arrays_adios2(io)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  type(adios2_io), intent(in) :: io
+  type(adios2_variable) :: v
+
+  integer :: ier
+  integer(kind=8), dimension(1) :: gdim  ! Global shape of array
+  integer(kind=8), dimension(1) :: ldim  ! Local size of array
+  integer(kind=8), dimension(1) :: offs  ! Starting offset in global array
+
+  ! crust/mantle
+  ldim(1) = NDIM * NGLOB_CRUST_MANTLE
+  gdim = sizeprocs_adios2 * ldim;
+  offs = myrank_adios2 * ldim;
+  call adios2_define_variable(v, io, "displ_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "veloc_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "accel_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+  ! inner core
+  ldim(1) = NDIM * NGLOB_INNER_CORE
+  gdim = sizeprocs_adios2 * ldim;
+  offs = myrank_adios2 * ldim;
+  call adios2_define_variable(v, io, "displ_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "veloc_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "accel_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+  ! outer core
+  ldim(1) = NGLOB_OUTER_CORE
+  gdim = sizeprocs_adios2 * ldim;
+  offs = myrank_adios2 * ldim;
+  call adios2_define_variable(v, io, "displ_outer_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "veloc_outer_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "accel_outer_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+  end subroutine define_common_forward_arrays_adios2
+
+
+!-------------------------------------------------------------------------------
+!> Define ADIOS forward arrays that are always dumped
+!! except for undo attenuation.
+!! \param io The adios group where the variables belongs
+!! \param group_size_inc The inout adios group size to increment
+!!                       with the size of the variable
+
+  subroutine define_epsilon_forward_arrays_adios2(io)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  type(adios2_io), intent(in) :: io
+  type(adios2_variable) :: v
+
+  integer :: ier
+  integer(kind=8), dimension(1) :: gdim  ! Global shape of array
+  integer(kind=8), dimension(1) :: ldim  ! Local size of array
+  integer(kind=8), dimension(1) :: offs  ! Starting offset in global array
+
+  ! strains
+  ldim(1) = NGLLX * NGLLY * NGLLZ * NSPEC_CRUST_MANTLE_STR_OR_ATT
+  gdim = sizeprocs_adios2 * ldim;
+  offs = myrank_adios2 * ldim;
+  call adios2_define_variable(v, io, "epsilondev_xx_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "epsilondev_yy_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "epsilondev_xy_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "epsilondev_xz_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "epsilondev_yz_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+  ldim(1) = NGLLX * NGLLY * NGLLZ * NSPEC_INNER_CORE_STR_OR_ATT
+  gdim = sizeprocs_adios2 * ldim;
+  offs = myrank_adios2 * ldim;
+  call adios2_define_variable(v, io, "epsilondev_xx_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "epsilondev_yy_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "epsilondev_xy_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "epsilondev_xz_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "epsilondev_yz_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+  end subroutine define_epsilon_forward_arrays_adios2
+
+
+!-------------------------------------------------------------------------------
+!> Define ADIOS forward arrays that are dumped if ROTATION is true.
+!! \param io The adios group where the variables belongs
+!! \param group_size_inc The inout adios group size to increment
+!!                       with the size of the variable
+
+  subroutine define_rotation_forward_arrays_adios2(io)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  type(adios2_io), intent(in) :: io
+  type(adios2_variable) :: v
+
+  integer :: ier
+  integer(kind=8), dimension(1) :: gdim  ! Global shape of array
+  integer(kind=8), dimension(1) :: ldim  ! Local size of array
+  integer(kind=8), dimension(1) :: offs  ! Starting offset in global array
+
+  ldim(1) = NGLLX * NGLLY * NGLLZ * NSPEC_OUTER_CORE_ROTATION
+  gdim = sizeprocs_adios2 * ldim;
+  offs = myrank_adios2 * ldim;
+  call adios2_define_variable(v, io, "A_array_rotation", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "B_array_rotation", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+  end subroutine define_rotation_forward_arrays_adios2
+
+!-------------------------------------------------------------------------------
+!> Define ADIOS forward arrays that are dumped if ATTENUATION is true.
+!! \param io The adios group where the variables belongs
+!! \param group_size_inc The inout adios group size to increment
+!!                       with the size of the variable
+
+  subroutine define_attenuation_forward_arrays_adios2(io)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  type(adios2_io), intent(in) :: io
+  type(adios2_variable) :: v
+
+  integer :: ier
+  integer(kind=8), dimension(1) :: gdim  ! Global shape of array
+  integer(kind=8), dimension(1) :: ldim  ! Local size of array
+  integer(kind=8), dimension(1) :: offs  ! Starting offset in global array
+
+  ! attenuation memory variables
+  ! crust/mantle
+  ldim(1) = N_SLS*NGLLX*NGLLY*NGLLZ*NSPEC_CRUST_MANTLE_ATTENUATION
+  gdim = sizeprocs_adios2 * ldim;
+  offs = myrank_adios2 * ldim;
+
+  call adios2_define_variable(v, io, "R_xx_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "R_yy_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "R_xy_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "R_xz_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "R_yz_crust_mantle", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+  ! inner core
+  ldim(1) = N_SLS*NGLLX*NGLLY*NGLLZ*NSPEC_INNER_CORE_ATTENUATION
+  gdim = sizeprocs_adios2 * ldim;
+  offs = myrank_adios2 * ldim;
+  call adios2_define_variable(v, io, "R_xx_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "R_yy_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "R_xy_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "R_xz_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  call adios2_define_variable(v, io, "R_yz_inner_core", adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+  end subroutine define_attenuation_forward_arrays_adios2
+
+!-------------------------------------------------------------------------------
+!>  Schedule writes of ADIOS forward arrays that are always dumped.
+!! \param file The handle to the adios bp file
+!! \param group_size_inc The number of MPI processes involved in the writing
+
+  subroutine write_common_forward_arrays_adios2(file)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  type(adios2_engine), intent(in) :: file
+  integer :: ier
+
+  ! crust/mantle
+  call adios2_put(file, STRINGIFY_VAR(displ_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(veloc_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(accel_crust_mantle), ier)
+
+  ! inner core
+  call adios2_put(file, STRINGIFY_VAR(displ_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(veloc_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(accel_inner_core), ier)
+
+  ! outer core
+  call adios2_put(file, STRINGIFY_VAR(displ_outer_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(veloc_outer_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(accel_outer_core), ier)
+
+  end subroutine write_common_forward_arrays_adios2
+
+
+!-------------------------------------------------------------------------------
+!>  Schedule writes of ADIOS forward arrays that are always dumped.
+!! \param file The handle to the adios bp file
+!! \param group_size_inc The number of MPI processes involved in the writing
+
+  subroutine write_epsilon_forward_arrays_adios2(file)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  type(adios2_engine), intent(in) :: file
+  integer :: ier
+
+  ! strains
+  ! crust/mantle
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_xx_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_yy_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_xy_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_xz_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_yz_crust_mantle), ier)
+
+  ! inner core
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_xx_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_yy_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_xy_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_xz_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(epsilondev_yz_inner_core), ier)
+
+  end subroutine write_epsilon_forward_arrays_adios2
+
+
+!-------------------------------------------------------------------------------
+!>  Schedule writes of ADIOS forward arrays that are dumped if ROTATION is true.
+!! \param file The handle to the adios bp file
+
+  subroutine write_rotation_forward_arrays_adios2(file)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  type(adios2_engine), intent(in) :: file
+  integer :: ier
+  call adios2_put(file, STRINGIFY_VAR(A_array_rotation), ier)
+  call adios2_put(file, STRINGIFY_VAR(B_array_rotation), ier)
+
+  end subroutine write_rotation_forward_arrays_adios2
+
+!-------------------------------------------------------------------------------
+!>  Schedule writes of ADIOS forward arrays that are dumped if ATTENUATION
+!!  is true.
+!! \param file The handle to the adios bp file
+!! \param group_size_inc The number of MPI processes involved in the writing
+
+  subroutine write_attenuation_forward_arrays_adios2(file)
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+  use specfem_par_outercore
+
+  use adios2
+  use manager_adios2
+  use forward_adios2_write
+
+  implicit none
+
+  type(adios2_engine), intent(in) :: file
+  integer :: ier
+
+  ! attenuation memory variables
+  ! crust/mantle
+  call adios2_put(file, STRINGIFY_VAR(R_xx_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(R_yy_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(R_xy_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(R_xz_crust_mantle), ier)
+  call adios2_put(file, STRINGIFY_VAR(R_yz_crust_mantle), ier)
+
+  ! inner core
+  call adios2_put(file, STRINGIFY_VAR(R_xx_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(R_yy_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(R_xy_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(R_xz_inner_core), ier)
+  call adios2_put(file, STRINGIFY_VAR(R_yz_inner_core), ier)
+
+  end subroutine write_attenuation_forward_arrays_adios2
+

--- a/src/specfem3D/save_kernels.F90
+++ b/src/specfem3D/save_kernels.F90
@@ -49,8 +49,14 @@
 
   ! Open an handler to the ADIOS file in which kernel variables are written.
   if (ADIOS_FOR_KERNELS) then
-    if ((SIMULATION_TYPE == 3) .or. (SIMULATION_TYPE == 2 .and. nrec_local > 0)) &
+    if ((SIMULATION_TYPE == 3) .or. (SIMULATION_TYPE == 2 .and. nrec_local > 0)) then
+#ifdef HAVE_ADIOS2
+      call open_kernel_file_adios2()
+      call define_kernel_adios2_variables()
+#else
       call define_kernel_adios_variables()
+#endif
+    endif
   endif
 
   ! dump kernel arrays
@@ -92,8 +98,13 @@
 
   ! Write ADIOS defined variables to disk.
   if (ADIOS_FOR_KERNELS) then
-    if ((SIMULATION_TYPE == 3) .or. (SIMULATION_TYPE == 2 .and. nrec_local > 0)) &
+    if ((SIMULATION_TYPE == 3) .or. (SIMULATION_TYPE == 2 .and. nrec_local > 0)) then
+#ifdef HAVE_ADIOS2
+      call close_kernel_file_adios2()
+#else
       call close_file_adios()
+#endif
+    endif
   endif
 
   end subroutine save_kernels
@@ -537,11 +548,19 @@
 
   ! writes out kernels to files
   if (ADIOS_FOR_KERNELS) then
+#ifdef HAVE_ADIOS2
+    call write_kernels_cm_ani_adios2(alphav_kl_crust_mantle,alphah_kl_crust_mantle, &
+                                    betav_kl_crust_mantle,betah_kl_crust_mantle, &
+                                    eta_kl_crust_mantle, &
+                                    bulk_c_kl_crust_mantle,bulk_beta_kl_crust_mantle, &
+                                    bulk_betav_kl_crust_mantle,bulk_betah_kl_crust_mantle)
+#else
     call write_kernels_cm_ani_adios(alphav_kl_crust_mantle,alphah_kl_crust_mantle, &
                                     betav_kl_crust_mantle,betah_kl_crust_mantle, &
                                     eta_kl_crust_mantle, &
                                     bulk_c_kl_crust_mantle,bulk_beta_kl_crust_mantle, &
                                     bulk_betav_kl_crust_mantle,bulk_betah_kl_crust_mantle)
+#endif
   else
 
     call create_name_database(prname,myrank,IREGION_CRUST_MANTLE,LOCAL_TMP_PATH)
@@ -749,8 +768,13 @@
 
   ! writes out kernels to files
   if (ADIOS_FOR_KERNELS) then
+#ifdef HAVE_ADIOS2
+    call write_kernels_cm_iso_adios2(mu_kl_crust_mantle, kappa_kl_crust_mantle, rhonotprime_kl_crust_mantle, &
+                                    bulk_c_kl_crust_mantle,bulk_beta_kl_crust_mantle)
+#else
     call write_kernels_cm_iso_adios(mu_kl_crust_mantle, kappa_kl_crust_mantle, rhonotprime_kl_crust_mantle, &
                                     bulk_c_kl_crust_mantle,bulk_beta_kl_crust_mantle)
+#endif
   else
 
     call create_name_database(prname,myrank,IREGION_CRUST_MANTLE,LOCAL_TMP_PATH)
@@ -840,7 +864,11 @@
 
   ! writes out kernels to file
   if (ADIOS_FOR_KERNELS) then
+#ifdef HAVE_ADIOS2
+    call write_kernels_oc_adios2()
+#else
     call write_kernels_oc_adios()
+#endif
   else
     call create_name_database(prname,myrank,IREGION_OUTER_CORE,LOCAL_TMP_PATH)
 
@@ -908,7 +936,11 @@
 
   ! writes out kernels to file
   if (ADIOS_FOR_KERNELS) then
+#ifdef HAVE_ADIOS2
+    call write_kernels_ic_adios2()
+#else
     call write_kernels_ic_adios()
+#endif
   else
     call create_name_database(prname,myrank,IREGION_INNER_CORE,LOCAL_TMP_PATH)
 
@@ -953,7 +985,11 @@
 
   ! writes out kernels to file
   if (ADIOS_FOR_KERNELS) then
+#ifdef HAVE_ADIOS2
+    call write_kernels_boundary_kl_adios2()
+#else
     call write_kernels_boundary_kl_adios()
+#endif
   else
     call create_name_database(prname,myrank,IREGION_CRUST_MANTLE,LOCAL_TMP_PATH)
 
@@ -1034,7 +1070,11 @@
 
   ! writes out kernels to file
   if (ADIOS_FOR_KERNELS) then
+#ifdef HAVE_ADIOS2
+    call write_kernels_source_derivatives_adios2()
+#else
     call write_kernels_source_derivatives_adios()
+#endif
   else
     ! kernel file output
     do irec_local = 1, nrec_local
@@ -1091,7 +1131,11 @@
 
   ! writes out kernels to file
   if (ADIOS_FOR_KERNELS) then
+#ifdef HAVE_ADIOS2
+    call write_kernels_Hessian_adios2()
+#else
     call write_kernels_Hessian_adios()
+#endif
   else
     ! stores into file
     call create_name_database(prname,myrank,IREGION_CRUST_MANTLE,LOCAL_TMP_PATH)

--- a/src/specfem3D/save_kernels_adios2.F90
+++ b/src/specfem3D/save_kernels_adios2.F90
@@ -1,0 +1,600 @@
+!=====================================================================
+!
+!          S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!          --------------------------------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+!                 (there are currently many more authors!)
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+module kernel_adios2
+  use adios2, only: adios2_engine, adios2_io, adios2_variable, adios2_attribute
+  type(adios2_engine), public :: adios2_file_kernel
+  type(adios2_io), public :: adios2_io_kernel
+
+  type(adios2_variable), public :: v_alphav_kl_crust_mantle, v_alphah_kl_crust_mantle, v_betav_kl_crust_mantle, &
+                                   v_betah_kl_crust_mantle, v_eta_kl_crust_mantle, v_rho_kl_crust_mantle, &
+                                   v_bulk_c_kl_crust_mantle, v_bulk_betav_kl_crust_mantle, v_bulk_betah_kl_crust_mantle, &
+                                   v_alpha_kl_crust_mantle, v_cijkl_kl_crust_mantle, v_rhonotprime_kl_crust_mantle, &
+                                   v_kappa_kl_crust_mantle,  v_mu_kl_crust_mantle, &
+                                   v_beta_kl_crust_mantle,  v_sigma_kl_crust_mantle, v_bulk_beta_kl_crust_mantle, &
+                                   v_rho_kl_outer_core, v_alpha_kl_outer_core, v_beta_kl_outer_core, v_rho_kl_inner_core, &
+                                   v_alpha_kl_inner_core, v_beta_kl_inner_core, v_moho_kl, v_d400_kl, v_d670_kl, v_cmb_kl, &
+                                   v_icb_kl, v_hess_kl_crust_mantle, v_moment_der, v_sloc_der, v_stshift_der, v_shdur_der
+
+
+end module kernel_adios2
+
+
+!-------------------------------------------------------------------------------
+!> \file save_kernels_adios2.f90
+!! \brief Save kernels arrays to file with the help of the ADIOS2 library.
+!! \author MPBL
+!-------------------------------------------------------------------------------
+
+#include "config.fh"
+
+!==============================================================================
+!> Open ADIOS file for kernel output.
+  subroutine open_kernel_file_adios2()
+
+  use adios2
+  use manager_adios2, only: adios2obj
+  use kernel_adios2, only: adios2_file_kernel, adios2_io_kernel
+  use constants, only: MAX_STRING_LEN, ADIOS2_ENGINE_DEFAULT, ADIOS2_ENGINE_PARAMS_DEFAULT
+  use shared_parameters, only: OUTPUT_FILES
+
+
+  implicit none
+
+  ! local Variables
+  character(len=MAX_STRING_LEN) :: outputname, ioname
+  integer :: ier
+
+  outputname = trim(OUTPUT_FILES)//"/kernels.bp"
+  ioname = "SPECFEM3D_GLOBE_KERNELS"
+
+  ! Create the ADIOS IO group which will contain all variables and attributes
+  call adios2_declare_io(adios2_io_kernel, adios2obj, ioname, ier)
+  if (ier /= 0) then
+    print *,'Error declaring an ADIOS2 IO group for kernel output in open_kernel_file_adios2()'
+    stop 'Error declaring an ADIOS2 IO group: calling open_kernel_file_adios2() routine failed'
+  endif
+
+  ! Set engine and parameters
+  call adios2_set_engine(adios2_io_kernel, ADIOS2_ENGINE_DEFAULT, ier)
+  ! Set parameters to ADIOS2_ENGINE_PARAMS_UNDO_ATT
+  call adios2_set_parameters(adios2_io_kernel, ADIOS2_ENGINE_PARAMS_DEFAULT, ier)
+
+  ! Open the handle to file containing all the ADIOS variables
+  call adios2_open(adios2_file_kernel, adios2_io_kernel, outputname, adios2_mode_write, ier)
+  if (ier /= 0) then
+    print *,'Error opening ADIOS2 file for kernel output in open_kernel_file_adios2()'
+    stop 'Error opening ADIOS2 file: calling open_kernel_file_adios2() routine failed'
+  endif
+
+  end subroutine open_kernel_file_adios2
+
+!==============================================================================
+!> Open ADIOS file for kernel output.
+  subroutine close_kernel_file_adios2()
+
+  use adios2
+  use kernel_adios2, only: adios2_file_kernel
+
+  implicit none
+
+  integer :: ier
+
+  call adios2_close(adios2_file_kernel, ier)
+  if (ier /= 0) then
+    print *,'Error closing ADIOS2 file for kernel output in close_kernel_file_adios2()'
+    print *,'You need to check if the kernel file is produced correctly'
+  endif
+
+
+  end subroutine close_kernel_file_adios2
+
+
+!==============================================================================
+!> Define all the kernels that will be written to the ADIOS file.
+!!
+!! \note Everything is define in this single function, even the group size.
+!!       It is the reason why this function require only an handle on an ADIOS
+!!       file as an argument.
+  subroutine define_kernel_adios2_variables()
+
+  use specfem_par ! Just for dimensions. No need of arrays for now.
+  use specfem_par_crustmantle
+  use specfem_par_outercore
+  use specfem_par_innercore
+  use specfem_par_noise
+
+  use adios2
+  use manager_adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! local Variables
+  integer :: ier
+  integer(kind=8), dimension(1) :: gdim  ! Global shape of array
+  integer(kind=8), dimension(1) :: ldim  ! Local size of array
+  integer(kind=8), dimension(1) :: offs  ! Starting offset in global array
+
+  if (SIMULATION_TYPE == 3) then
+    ! crust mantle
+    if (ANISOTROPIC_KL) then
+
+      ! anisotropic kernels
+      ldim(1) = NGLLX * NGLLY * NGLLZ * NSPEC_CRUST_MANTLE_ADJOINT
+      gdim = sizeprocs_adios2 * ldim;
+      offs = myrank_adios2 * ldim;
+
+      ! outputs transverse isotropic kernels only
+      if (SAVE_TRANSVERSE_KL_ONLY) then
+        call adios2_define_variable(v_alphav_kl_crust_mantle, adios2_io_kernel, "alphav_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_alphah_kl_crust_mantle, adios2_io_kernel, "alphah_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_betav_kl_crust_mantle, adios2_io_kernel, "betav_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_betah_kl_crust_mantle, adios2_io_kernel, "betah_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_eta_kl_crust_mantle, adios2_io_kernel, "eta_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_rho_kl_crust_mantle, adios2_io_kernel, "rho_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_bulk_c_kl_crust_mantle, adios2_io_kernel, "bulk_c_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_bulk_betav_kl_crust_mantle, adios2_io_kernel, "bulk_betav_kl_crust_mantle",  &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_bulk_betah_kl_crust_mantle, adios2_io_kernel, "bulk_betah_kl_crust_mantle",  &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_alpha_kl_crust_mantle, adios2_io_kernel, "alpha_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_beta_kl_crust_mantle, adios2_io_kernel, "beta_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+        call adios2_define_variable(v_bulk_beta_kl_crust_mantle, adios2_io_kernel, "bulk_beta_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+      else
+
+        call adios2_define_variable(v_rho_kl_crust_mantle, adios2_io_kernel, "rho_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+        ldim(1) = 21 * NGLLX * NGLLY * NGLLZ * NSPEC_CRUST_MANTLE_ADJOINT
+        gdim = sizeprocs_adios2 * ldim;
+        offs = myrank_adios2 * ldim;
+
+        call adios2_define_variable(v_cijkl_kl_crust_mantle, adios2_io_kernel, "cijkl_kl_crust_mantle", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+
+      endif
+
+    else
+
+      ! isotropic kernels
+      ldim(1) = NGLLX * NGLLY * NGLLZ * NSPEC_CRUST_MANTLE_ADJOINT
+      gdim = sizeprocs_adios2 * ldim;
+      offs = myrank_adios2 * ldim;
+
+      call adios2_define_variable(v_rhonotprime_kl_crust_mantle, adios2_io_kernel, "rhonotprime_kl_crust_mantle",  &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+      call adios2_define_variable(v_kappa_kl_crust_mantle, adios2_io_kernel, "kappa_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+      call adios2_define_variable(v_mu_kl_crust_mantle, adios2_io_kernel, "mu_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+      call adios2_define_variable(v_rho_kl_crust_mantle, adios2_io_kernel, "rho_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+      call adios2_define_variable(v_alpha_kl_crust_mantle, adios2_io_kernel, "alpha_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+      call adios2_define_variable(v_beta_kl_crust_mantle, adios2_io_kernel, "beta_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+      call adios2_define_variable(v_bulk_c_kl_crust_mantle, adios2_io_kernel, "v_bulk_c_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+      call adios2_define_variable(v_bulk_beta_kl_crust_mantle, adios2_io_kernel, "bulk_beta_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+    endif
+
+    ! noise strength kernel
+    if (NOISE_TOMOGRAPHY == 3) then
+      ldim(1) = NGLLX * NGLLY * NGLLZ * NSPEC_CRUST_MANTLE_ADJOINT
+      gdim = sizeprocs_adios2 * ldim;
+      offs = myrank_adios2 * ldim;
+
+      call adios2_define_variable(v_sigma_kl_crust_mantle, adios2_io_kernel, "sigma_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+    endif
+
+    ! outer core
+    ldim(1) = NSPEC_OUTER_CORE * NGLLX * NGLLY * NGLLZ
+    gdim = sizeprocs_adios2 * ldim;
+    offs = myrank_adios2 * ldim;
+
+    call adios2_define_variable(v_rho_kl_outer_core, adios2_io_kernel, "rho_kl_outer_core", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+    call adios2_define_variable(v_alpha_kl_outer_core, adios2_io_kernel, "alpha_kl_outer_core", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+    if (deviatoric_outercore) then
+      call adios2_define_variable(v_beta_kl_outer_core, adios2_io_kernel, "beta_kl_outer_core", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+    endif
+
+    ! inner core
+    ldim(1) = NSPEC_INNER_CORE * NGLLX * NGLLY * NGLLZ
+    gdim = sizeprocs_adios2 * ldim;
+    offs = myrank_adios2 * ldim;
+    call adios2_define_variable(v_rho_kl_inner_core, adios2_io_kernel, "rho_kl_inner_core", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+    call adios2_define_variable(v_alpha_kl_inner_core, adios2_io_kernel, "alpha_kl_inner_core", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+    call adios2_define_variable(v_beta_kl_inner_core, adios2_io_kernel, "beta_kl_inner_core", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+    ! boundary kernel
+    if (SAVE_BOUNDARY_MESH) then
+      !call save_kernels_boundary_kl()
+      if (.not. SUPPRESS_CRUSTAL_MESH .and. HONOR_1D_SPHERICAL_MOHO) then
+        ldim(1) = NSPEC2D_MOHO * NGLLX * NGLLY * NDIM
+        gdim = sizeprocs_adios2 * ldim;
+        offs = myrank_adios2 * ldim;
+        call adios2_define_variable(v_moho_kl, adios2_io_kernel, "moho_kl", &
+                                    adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+      endif
+      ldim(1) = NSPEC2D_400 * NGLLX * NGLLY
+      gdim = sizeprocs_adios2 * ldim;
+      offs = myrank_adios2 * ldim;
+      call adios2_define_variable(v_d400_kl, adios2_io_kernel, "d400_kl", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+      ldim(1) = NSPEC2D_670 * NGLLX * NGLLY
+      gdim = sizeprocs_adios2 * ldim;
+      offs = myrank_adios2 * ldim;
+      call adios2_define_variable(v_d670_kl, adios2_io_kernel, "d670_kl", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+      ldim(1) = NSPEC2D_CMB * NGLLX * NGLLY
+      gdim = sizeprocs_adios2 * ldim;
+      offs = myrank_adios2 * ldim;
+      call adios2_define_variable(v_cmb_kl, adios2_io_kernel, "cmb_kl", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+      ldim(1) = NSPEC2D_ICB * NGLLX * NGLLY
+      gdim = sizeprocs_adios2 * ldim;
+      offs = myrank_adios2 * ldim;
+      call adios2_define_variable(v_icb_kl, adios2_io_kernel, "icb_kl", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+    endif
+
+    ! approximate Hessian
+    if (APPROXIMATE_HESS_KL) then
+      !call save_kernels_Hessian()
+      ldim(1) = NSPEC_CRUST_MANTLE_ADJOINT* NGLLX * NGLLY * NGLLZ
+      gdim = sizeprocs_adios2 * ldim;
+      offs = myrank_adios2 * ldim;
+      call adios2_define_variable(v_hess_kl_crust_mantle, adios2_io_kernel, "hess_kl_crust_mantle", &
+                                  adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+    endif
+  endif
+
+  ! save source derivatives for adjoint simulations
+  if (SIMULATION_TYPE == 2 .and. nrec_local > 0) then
+    ldim(1) = 3 * 3 * nrec_local
+    gdim = sizeprocs_adios2 * ldim;
+    offs = myrank_adios2 * ldim;
+    call adios2_define_variable(v_moment_der, adios2_io_kernel, "moment_der", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+    ldim(1) = 3 * nrec_local
+    gdim = sizeprocs_adios2 * ldim;
+    offs = myrank_adios2 * ldim;
+    call adios2_define_variable(v_sloc_der, adios2_io_kernel, "sloc_der", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+    ldim(1) = nrec_local
+    gdim = sizeprocs_adios2 * ldim;
+    offs = myrank_adios2 * ldim;
+    call adios2_define_variable(v_stshift_der, adios2_io_kernel, "stshift_der", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+
+    ldim(1) = nrec_local
+    gdim = sizeprocs_adios2 * ldim;
+    offs = myrank_adios2 * ldim;
+    call adios2_define_variable(v_shdur_der, adios2_io_kernel, "shdur_der", &
+                                adios2_custom_real, 1, gdim, offs, ldim, .true., ier)
+  endif
+
+  end subroutine define_kernel_adios2_variables
+
+
+!==============================================================================
+!> Schedule ADIOS writes for kernel variables related to the crust mantle.
+  subroutine write_kernels_cm_ani_adios2(alphav_kl_crust_mantle,alphah_kl_crust_mantle, &
+                                        betav_kl_crust_mantle,betah_kl_crust_mantle, &
+                                        eta_kl_crust_mantle, &
+                                        bulk_c_kl_crust_mantle,bulk_beta_kl_crust_mantle, &
+                                        bulk_betav_kl_crust_mantle,bulk_betah_kl_crust_mantle)
+
+  use specfem_par
+  use specfem_par_crustmantle
+
+  use adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! Parameters
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NSPEC_CRUST_MANTLE_ADJOINT) :: &
+      alphav_kl_crust_mantle,alphah_kl_crust_mantle, &
+      betav_kl_crust_mantle,betah_kl_crust_mantle, &
+      eta_kl_crust_mantle, &
+      bulk_c_kl_crust_mantle,bulk_beta_kl_crust_mantle, &
+      bulk_betav_kl_crust_mantle,bulk_betah_kl_crust_mantle
+
+  ! Variables
+  integer :: ier
+
+  ! checks if anything to do
+  if (.not. ANISOTROPIC_KL) return
+
+  ! For anisotropic kernels
+  ! outputs transverse isotropic kernels only
+  if (SAVE_TRANSVERSE_KL_ONLY) then
+    ! transverse isotropic kernels
+    ! (alpha_v, alpha_h, beta_v, beta_h, eta, rho ) parameterization
+    call adios2_put(adios2_file_kernel, v_alphav_kl_crust_mantle, alphav_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_alphah_kl_crust_mantle, alphah_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_betav_kl_crust_mantle, betav_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_betah_kl_crust_mantle, betah_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_eta_kl_crust_mantle, eta_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_rho_kl_crust_mantle, rho_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_bulk_c_kl_crust_mantle, bulk_c_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_bulk_betav_kl_crust_mantle, bulk_betav_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_bulk_betah_kl_crust_mantle, bulk_betah_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_alpha_kl_crust_mantle, alpha_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_beta_kl_crust_mantle, beta_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_bulk_beta_kl_crust_mantle, bulk_beta_kl_crust_mantle, adios2_mode_sync, ier)
+  else
+    ! note: the C_ij and density kernels are not for relative perturbations
+    !       (delta ln( m_i) = delta m_i / m_i),
+    !       but absolute perturbations (delta m_i = m_i - m_0)
+    ! Note: adios2_put() by default is in deferred mode which does not work if the array
+    ! disappears before adios2_end_step/adios2_close
+    ! For temporary arrays, we must use adios2_mode_sync as an extra argument
+    call adios2_put(adios2_file_kernel, v_rho_kl_crust_mantle, -rho_kl_crust_mantle, adios2_mode_sync, ier)
+    call adios2_put(adios2_file_kernel, v_cijkl_kl_crust_mantle, -cijkl_kl_crust_mantle, adios2_mode_sync, ier)
+  endif
+
+  end subroutine write_kernels_cm_ani_adios2
+
+!==============================================================================
+!> Schedule ADIOS writes for kernel variables related to the crust mantle.
+  subroutine write_kernels_cm_iso_adios2(mu_kl_crust_mantle, kappa_kl_crust_mantle, rhonotprime_kl_crust_mantle, &
+                                        bulk_c_kl_crust_mantle,bulk_beta_kl_crust_mantle)
+
+  use specfem_par
+  use specfem_par_crustmantle
+
+  use adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! Parameters
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLY,NGLLZ,NSPEC_CRUST_MANTLE_ADJOINT) :: &
+      mu_kl_crust_mantle, kappa_kl_crust_mantle, rhonotprime_kl_crust_mantle, &
+      bulk_c_kl_crust_mantle,bulk_beta_kl_crust_mantle
+
+  ! Variables
+  integer :: ier
+
+  ! checks if anything to do
+  if (ANISOTROPIC_KL) return
+
+  ! isotropic kernels
+  ! primary kernels: (rho,kappa,mu) parameterization
+  call adios2_put(adios2_file_kernel, v_rhonotprime_kl_crust_mantle, rhonotprime_kl_crust_mantle, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_kappa_kl_crust_mantle, kappa_kl_crust_mantle, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_mu_kl_crust_mantle, mu_kl_crust_mantle, adios2_mode_sync, ier)
+
+  ! (rho, alpha, beta ) parameterization
+  call adios2_put(adios2_file_kernel, v_rho_kl_crust_mantle, rho_kl_crust_mantle, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_alpha_kl_crust_mantle, alpha_kl_crust_mantle, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_beta_kl_crust_mantle, beta_kl_crust_mantle, adios2_mode_sync, ier)
+
+  ! (rho, bulk, beta ) parameterization, K_rho same as above
+  call adios2_put(adios2_file_kernel, v_bulk_c_kl_crust_mantle, bulk_c_kl_crust_mantle, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_bulk_beta_kl_crust_mantle, bulk_beta_kl_crust_mantle, adios2_mode_sync, ier)
+
+  end subroutine write_kernels_cm_iso_adios2
+
+
+!==============================================================================
+!> Schedule ADIOS writes for kernel variables related to the outer core.
+  subroutine write_kernels_oc_adios2()
+
+  use specfem_par
+  use specfem_par_outercore
+
+  use adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! Variables
+  integer :: ier
+
+  call adios2_put(adios2_file_kernel, v_rho_kl_outer_core, rho_kl_outer_core, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_alpha_kl_outer_core, alpha_kl_outer_core, adios2_mode_sync, ier)
+
+  !deviatoric kernel check
+  if (deviatoric_outercore) then
+    call adios2_put(adios2_file_kernel, v_beta_kl_outer_core, beta_kl_outer_core, adios2_mode_sync, ier)
+  endif
+
+  end subroutine write_kernels_oc_adios2
+
+
+!==============================================================================
+!> Schedule ADIOS writes for kernel variables related to the inner core.
+  subroutine write_kernels_ic_adios2()
+
+  use specfem_par
+  use specfem_par_innercore
+
+  use adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! Variables
+  integer :: ier
+
+  call adios2_put(adios2_file_kernel, v_rho_kl_inner_core, rho_kl_inner_core, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_alpha_kl_inner_core, alpha_kl_inner_core, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_beta_kl_inner_core, beta_kl_inner_core, adios2_mode_sync, ier)
+
+  end subroutine write_kernels_ic_adios2
+
+
+!==============================================================================
+!> Schedule ADIOS writes for kernel variables related to the boundaries.
+  subroutine write_kernels_boundary_kl_adios2()
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_innercore
+
+  use adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! Variables
+  integer :: ier
+
+  if (.not. SUPPRESS_CRUSTAL_MESH .and. HONOR_1D_SPHERICAL_MOHO) then
+    call adios2_put(adios2_file_kernel, v_moho_kl, moho_kl, adios2_mode_sync, ier)
+  endif
+
+  call adios2_put(adios2_file_kernel, v_d400_kl, d400_kl, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_d670_kl, d670_kl, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_cmb_kl, cmb_kl, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_icb_kl, icb_kl, adios2_mode_sync, ier)
+
+  end subroutine write_kernels_boundary_kl_adios2
+
+
+!==============================================================================
+!> Schedule writes for the source derivatives (moment tensors and source
+!! locations.
+!!
+!! \note Not to dump one value at a time (as in the non ADIOS version) data are
+!!       scaled and oriented but are not written in the same order than in the
+!!       non ADIOS version.
+!!       (see save_kernels_source_derivatives in save_kernels.f90)
+  subroutine write_kernels_source_derivatives_adios2()
+
+  use specfem_par
+
+  use adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! Variables
+  ! We do not want to change moment_der and sloc as it might introduce future
+  ! concerns if we want to use them after.
+  ! No use of modified moment_der values since it implies to allocate those
+  ! arrays in save_kernels() and to carry them along the way. It might be better
+  ! to transform these arrays in the post processing phase.
+  !real(kind=CUSTOM_REAL), dimension(3,3,nrec_local) :: moment_der_tmp
+  !real(kind=CUSTOM_REAL), dimension(3,nrec_local) :: sloc_der_tmp
+  integer :: ier
+
+  !moment_der_tmp(:, :, :) = moment_der(:, :, :) * 1e-7
+  !moment_der_tmp(1, 3, :) = -2 * moment_der(1, 3, :)
+  !moment_der_tmp(2, 3, :) =  2 * moment_der(2, 3, :)
+  !moment_der_tmp(1, 2, :) = -2 * moment_der(1, 2, :)
+  !moment_der_tmp(3, 1, :) = moment_der(1, 3, :)
+  !moment_der_tmp(3, 2, :) = moment_der(2, 3, :)
+  !moment_der_tmp(2, 1, :) = moment_der(1, 2, :)
+  !sloc_der_tmp(:, :) = - sloc_der(:, :)
+  !sloc_der_tmp(3, :) = - sloc_der(3, :)
+
+
+  ! Note: adios2_put() by default is in deferred mode which does not work if the array
+  ! disappears before adios2_end_step/adios2_close
+  ! For temporary arrays, use adios2_mode_sync as an extra argument
+
+  call adios2_put(adios2_file_kernel, v_moment_der, moment_der, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_sloc_der, sloc_der, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_stshift_der, stshift_der, adios2_mode_sync, ier)
+  call adios2_put(adios2_file_kernel, v_shdur_der, shdur_der, adios2_mode_sync, ier)
+
+  end subroutine write_kernels_source_derivatives_adios2
+
+
+!==============================================================================
+!> Schedule ADIOS writes for kernel variables related to the Hessian.
+  subroutine write_kernels_Hessian_adios2()
+
+  use specfem_par
+  use specfem_par_crustmantle
+
+  use adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! Variables
+  integer :: ier
+
+  ! stores into file
+  call adios2_put(adios2_file_kernel, v_hess_kl_crust_mantle, hess_kl_crust_mantle, adios2_mode_sync, ier)
+
+  end subroutine write_kernels_Hessian_adios2
+
+!==============================================================================
+!> Schedule ADIOS writes for kernel variables related to the noise strength kernel.
+  subroutine write_kernels_strength_noise_adios2()
+
+  use specfem_par
+  use specfem_par_crustmantle
+  use specfem_par_noise
+
+  use adios2
+  use kernel_adios2
+
+  implicit none
+
+  ! Variables
+  integer :: ier
+
+  ! stores into file
+  call adios2_put(adios2_file_kernel, v_sigma_kl_crust_mantle, sigma_kl_crust_mantle, adios2_mode_sync, ier)
+
+  end subroutine write_kernels_strength_noise_adios2


### PR DESCRIPTION
Use ADIOS2 in specfem3D application for reading and writing forward arrays and kernel files.
Save all attenuation frames into one big dataset save_forward_arrays.bp to keep the number of files in check.

This PR adds support for ADIOS2 while it still can use ADIOS1 for the those I/O sections that are not transformed yet. This PR focuses on the forward + adjoint simulation to write and read the attenuation frames and to write the end result kernel data.  Other tools are not touched yet. 

In the Par_file, there is no change, because both save_forward_arrays and save_kernel is calling ADIOS2 functions instead of ADIOS1 functions and uses the same flags. The long term goal is to eventually remove all ADIOS1 functions to clean up. 

There was a bug fix in ADIOS2 to make the kernel output work correctly, so specfem3D will work with the upcoming ADIOS2 2.4.0 release (Jun 30) but not with earlier releases. 