### PR TITLE
Whitespace issue in generated XML strings for asdf files

### DIFF
--- a/src/specfem3D/write_output_ASDF.f90
+++ b/src/specfem3D/write_output_ASDF.f90
@@ -690,14 +690,14 @@
                   ' xmlns:q="http://quakeml.org/xmlns/quakeml/1.2">'//&
                   '<eventParameters publicID="smi:local/'//trim(event_name_SAC)//'#eventPrm">'//&
                   '<event publicID="smi:local/'//trim(event_name_SAC)//'#eventID">'//&
-                  '<preferredOriginID > smi:local/'//trim(event_name_SAC)//'/origin#cmtorigin < /preferredOriginID>'//&
-                  '<preferredMagnitudeID > smi:local/'//trim(event_name_SAC)//'/magnitude#moment_mag < /preferredMagnitudeID>'//&
-                  '<preferredFocalMechanismID > smi:local/'//trim(event_name_SAC)//'/focal_mechanism < /preferredFocalMechanismID>'//&
-                  '<type > earthquake < /type>'//&
-                  '<typeCertainty > known < /typeCertainty>'//&
+                  '<preferredOriginID>smi:local/'//trim(event_name_SAC)//'/origin#cmtorigin</preferredOriginID>'//&
+                  '<preferredMagnitudeID>smi:local/'//trim(event_name_SAC)//'/magnitude#moment_mag</preferredMagnitudeID>'//&
+                  '<preferredFocalMechanismID>smi:local/'//trim(event_name_SAC)//'/focal_mechanism</preferredFocalMechanismID>'//&
+                  '<type>earthquake</type>'//&
+                  '<typeCertainty>known</typeCertainty>'//&
                   '<description>'//&
                   '<text>'//trim(event_name_SAC)//'</text>'//&
-                  '<type > earthquake name < /type>'//&
+                  '<type>earthquake name</type>'//&
                   '</description>'//&
                   '<origin publicID="smi:local/'//trim(event_name_SAC)//'/origin#reforigin">'//&
                   '<time>'//&
@@ -712,9 +712,9 @@
                   '<depth>'//&
                   '<value>'//trim(pde_depth_str)//'</value>'//&
                   '</depth>'//&
-                  '<type > hypocenter < /type>'//&
+                  '<type>hypocenter</type>'//&
                   '<comment id="smi:local/'//trim(event_name_SAC)//'/comment#ref_origin">'//&
-                  '<text > Hypocenter catalog: PDE < /text>'//&
+                  '<text>Hypocenter catalog: PDE</text>'//&
                   '</comment>'//&
                   '</origin>'//&
                   '<origin publicID="smi:local/'//trim(event_name_SAC)//'/origin#cmtorigin">'//&
@@ -733,9 +733,9 @@
                   '</origin>'//&
                   '<focalMechanism publicID="smi:local/'//trim(event_name_SAC)//'/focal_mechanism">'//&
                   '<momentTensor publicID="smi:local/'//trim(event_name_SAC)//'/momenttensor">'//&
-                  '<derivedOriginID > smi:local/'//trim(event_name_SAC)//'/origin#cmtorigin'//&
+                  '<derivedOriginID>smi:local/'//trim(event_name_SAC)//'/origin#cmtorigin'//&
                   '</derivedOriginID>'//&
-                  '<momentMagnitudeID > smi:local/'//trim(event_name_SAC)//'/magnitude#moment_mag'//&
+                  '<momentMagnitudeID>smi:local/'//trim(event_name_SAC)//'/magnitude#moment_mag'//&
                   '</momentMagnitudeID>'//&
                   '<scalarMoment>'//&
                   '<value>'//trim(M0_str)//'</value>'//&
@@ -743,31 +743,31 @@
                   '<tensor>'//&
                   '<Mrr>'//&
                   '<value>'//trim(Mrr_str)//'</value>'//&
-                  '<uncertainty > 0 < /uncertainty>'//&
+                  '<uncertainty>0</uncertainty>'//&
                   '</Mrr>'//&
                   '<Mtt>'//&
                   '<value>'//trim(Mtt_str)//'</value>'//&
-                  '<uncertainty > 0 < /uncertainty>'//&
+                  '<uncertainty>0</uncertainty>'//&
                   '</Mtt>'//&
                   '<Mpp>'//&
                   '<value>'//trim(Mpp_str)//'</value>'//&
-                  '<uncertainty > 0 < /uncertainty>'//&
+                  '<uncertainty>0</uncertainty>'//&
                   '</Mpp>'//&
                   '<Mrt>'//&
                   '<value>'//trim(Mrt_str)//'</value>'//&
-                  '<uncertainty > 0 < /uncertainty>'//&
+                  '<uncertainty>0</uncertainty>'//&
                   '</Mrt>'//&
                   '<Mrp>'//&
                   '<value>'//trim(Mrp_str)//'</value>'//&
-                  '<uncertainty > 0 < /uncertainty>'//&
+                  '<uncertainty>0</uncertainty>'//&
                   '</Mrp>'//&
                   '<Mtp>'//&
                   '<value>'//trim(Mtp_str)//'</value>'//&
-                  '<uncertainty > 0 < /uncertainty>'//&
+                  '<uncertainty>0</uncertainty>'//&
                   '</Mtp>'//&
                   '</tensor>'//&
                   '<sourceTimeFunction>'//&
-                  '<type > triangle < /type>'//&
+                  '<type>triangle</type>'//&
                   '<duration>'//trim(hdur_str)//'</duration>'//&
                   '</sourceTimeFunction>'//&
                   '</momentTensor>'//&
@@ -776,19 +776,19 @@
                   '<mag>'//&
                   '<value>'//trim(Mw_str)//'</value>'//&
                   '</mag>'//&
-                  '<type > Mwc < /type>'//&
+                  '<type>Mwc</type>'//&
                   '</magnitude>'//&
                   '<magnitude publicID="smi:local/'//trim(event_name_SAC)//'/magnitude#mb">'//&
                   '<mag>'//&
                   '<value>'//trim(mb_str)//'</value>'//&
                   '</mag>'//&
-                  '<type > mb < /type>'//&
+                  '<type>mb</type>'//&
                   '</magnitude>'//&
                   '<magnitude publicID="smi:local/'//trim(event_name_SAC)//'/magnitude#MS">'//&
                   '<mag>'//&
                   '<value>'//trim(ms_str)//'</value>'//&
                   '</mag>'//&
-                  '<type > MS < /type>'//&
+                  '<type>MS</type>'//&
                   '</magnitude>'//&
                   '</event>'//&
                   '</eventParameters>'//&
@@ -948,29 +948,29 @@
   len_station_ele = len(trim(station_ele))
 
   stationxmlstring = '<FDSNStationXML schemaVersion="1.0" xmlns="http://www.fdsn.org/xml/station/1">'//&
-                     '<Source > SPECFEM3D_GLOBE < /Source>'//&
-                     '<Module > SPECFEM3D_GLOBE/asdf-library < /Module>'//&
-                     '<ModuleURI > http://seismic-data.org < /ModuleURI>'//&
+                     '<Source>SPECFEM3D_GLOBE</Source>'//&
+                     '<Module>SPECFEM3D_GLOBE/asdf-library</Module>'//&
+                     '<ModuleURI>http://seismic-data.org</ModuleURI>'//&
                      '<Created>'//trim(start_time_string)//'</Created>'//&
                      '<Network code="'//trim(network_name(1:len(network_name)))//'"'//&
-                     ' > < Station code="'//trim(station_name(1:len(station_name)))//'">'//&
+                     '><Station code="'//trim(station_name(1:len(station_name)))//'">'//&
                      '<Latitude unit="DEGREES">'//trim(station_lat(1:len_station_lat))//'</Latitude>'//&
                      '<Longitude unit="DEGREES">'//trim(station_lon(1:len_station_lon))//'</Longitude>'//&
                      '<Elevation>'//trim(station_ele(1:len_station_ele))//'</Elevation>'//&
                      '<Site>'//&
-                     '<Name > N/A < /Name>'//&
+                     '<Name>N/A</Name>'//&
                      '</Site>'//&
                      '<CreationDate>'//trim(start_time_string)//'</CreationDate>'//&
-                     '<TotalNumberChannels > 3 < /TotalNumberChannels>'//&
-                     '<SelectedNumberChannels > 3 < /SelectedNumberChannels>'//&
+                     '<TotalNumberChannels>3</TotalNumberChannels>'//&
+                     '<SelectedNumberChannels>3</SelectedNumberChannels>'//&
                      '<Channel locationCode="S3" code="MXN"'//&
                      ' startDate="'//trim(start_time_string)//'">'//&
                      '<Latitude unit="DEGREES">'//trim(station_lat(1:len_station_lat))//'</Latitude>'//&
                      '<Longitude unit="DEGREES">'//trim(station_lon(1:len_station_lon))//'</Longitude>'//&
                      '<Elevation>'//trim(station_ele(1:len_station_ele))//'</Elevation>'//&
                      '<Depth>'//trim(station_depth(1:len_station_depth))//'</Depth>'//&
-                     '<Azimuth > 0.0 < /Azimuth>'//&
-                     '<Dip > 0.0 < /Dip>'//&
+                     '<Azimuth>0.0</Azimuth>'//&
+                     '<Dip>0.0</Dip>'//&
                      '</Channel>'//&
                      '<Channel locationCode="S3" code="MXE"'//&
                      ' startDate="'//trim(start_time_string)//'">'//&
@@ -978,8 +978,8 @@
                      '<Longitude unit="DEGREES">'//trim(station_lon(1:len_station_lon))//'</Longitude>'//&
                      '<Elevation>'//trim(station_ele(1:len_station_ele))//'</Elevation>'//&
                      '<Depth>'//trim(station_depth(1:len_station_depth))//'</Depth>'//&
-                     '<Azimuth > 90.0 < /Azimuth>'//&
-                     '<Dip > 0.0 < /Dip>'//&
+                     '<Azimuth>90.0</Azimuth>'//&
+                     '<Dip>0.0</Dip>'//&
                      '</Channel>'//&
                      '<Channel locationCode="S3" code="MXZ"'//&
                      ' startDate="'//trim(start_time_string)//'">'//&
@@ -987,8 +987,8 @@
                      '<Longitude unit="DEGREES">'//trim(station_lon(1:len_station_lon))//'</Longitude>'//&
                      '<Elevation>'//trim(station_ele(1:len_station_ele))//'</Elevation>'//&
                      '<Depth>'//trim(station_depth(1:len_station_depth))//'</Depth>'//&
-                     '<Azimuth > 0.0 < /Azimuth>'//&
-                     '<Dip > 90.0 < /Dip>'//&
+                     '<Azimuth>0.0</Azimuth>'//&
+                     '<Dip>90.0</Dip>'//&
                      '</Channel>'//&
                      '</Station>'//&
                      '</Network>'//&


### PR DESCRIPTION
Hi,

This pull request aims to fix the issues generated by the whitespace in XML strings (write_output_ASDF.f90) which were added in the last update.

Additional whitespace was causing 3 main problems:
 - XML specification does not allow for names to start with a space.
 - Strict interpretation of QuakeML standard was causing problems with the attribute values with spaces.
 - Adding extra space characters was changing the total length of StationXML which was causing truncation in the output.