### PR TITLE
Add a check to avoid a crash when using the GPU version of specfem and when SAVE_FORWARD, ATTENUATION and PARTIAL_PHYS_DISPERSION_ONLY are enabled.

### DIFF
--- a/src/specfem3D/iterate_time.F90
+++ b/src/specfem3D/iterate_time.F90
@@ -322,7 +322,7 @@
       endif
 
       ! attenuation memory variables
-      if (ATTENUATION_VAL) then
+      if (ATTENUATION_VAL .and. .not. PARTIAL_PHYS_DISPERSION_ONLY_VAL) then
         call transfer_rmemory_cm_from_device(Mesh_pointer,R_xx_crust_mantle,R_yy_crust_mantle,R_xy_crust_mantle, &
                                              R_xz_crust_mantle,R_yz_crust_mantle)
         call transfer_rmemory_ic_from_device(Mesh_pointer,R_xx_inner_core,R_yy_inner_core,R_xy_inner_core, &


### PR DESCRIPTION
Add a check for partial physical dispersion only when transfering memory variables from gpu to cpu. Without it specfem crashes with error like "CUDA error !!!!! <invalid argument> !!!!! at CUDA call error code: # 33001 " which seems to be caused because R_xx_... don't exist (as stated in the note few lines later).