### PR TITLE
Add Laplacian smoothing, correction of ocean load and small fixes

### DIFF
--- a/src/specfem3D/prepare_oceans.f90
+++ b/src/specfem3D/prepare_oceans.f90
@@ -62,6 +62,7 @@
   updated_dof_ocean_load(:) = .false.
 
   ! Get valence of dof and assemble
+  allocate(valence(NGLOB_CRUST_MANTLE_OCEANS),stat=ier)
   if (ier /= 0) stop 'Error allocating arrays valence (ocean load)'
   valence(:) = 1.
   call assemble_MPI_scalar(NPROCTOT_VAL,NGLOB_CRUST_MANTLE, &

--- a/src/specfem3D/prepare_oceans.f90
+++ b/src/specfem3D/prepare_oceans.f90
@@ -45,6 +45,8 @@
   integer :: ipoin,ispec,ispec2D,i,j,k,iglob,ier
   ! flag to mask ocean-bottom degrees of freedom for ocean load
   logical, dimension(:), allocatable :: updated_dof_ocean_load
+  real, dimension(:), allocatable :: valence, normx, normy, normz
+  real :: norm=1.
 
   ! checks if anything to do
   if (.not. OCEANS_VAL) return
@@ -59,6 +61,26 @@
   if (ier /= 0) stop 'Error allocating arrays updated_dof_ocean_load'
   updated_dof_ocean_load(:) = .false.
 
+  ! Get valence of dof and assemble
+  if (ier /= 0) stop 'Error allocating arrays valence (ocean load)'
+  valence(:) = 1.
+  call assemble_MPI_scalar(NPROCTOT_VAL,NGLOB_CRUST_MANTLE, &
+                           valence, &
+                           num_interfaces_crust_mantle,max_nibool_interfaces_cm, &
+                           nibool_interfaces_crust_mantle,ibool_interfaces_crust_mantle, &
+                           my_neighbors_crust_mantle)
+  
+  ! For norms
+  allocate(normx(NGLOB_CRUST_MANTLE_OCEANS),stat=ier)
+  if (ier /= 0) stop 'Error allocating arrays normx (ocean load)'
+  normx(:) = 0.
+  allocate(normy(NGLOB_CRUST_MANTLE_OCEANS),stat=ier)
+  if (ier /= 0) stop 'Error allocating arrays normy (ocean load)'
+  normy(:) = 0.
+  allocate(normz(NGLOB_CRUST_MANTLE_OCEANS),stat=ier)
+  if (ier /= 0) stop 'Error allocating arrays normz (ocean load)'
+  normz(:) = 0.
+
   ! counts global points on surface to oceans
   ipoin = 0
   do ispec2D = 1,NSPEC_TOP
@@ -70,6 +92,10 @@
         iglob = ibool_crust_mantle(i,j,k,ispec)
         ! updates once
         if (.not. updated_dof_ocean_load(iglob)) then
+          ! Get normals
+          normx(iglob) = normal_top_crust_mantle(1,i,j,ispec2D) 
+          normy(iglob) = normal_top_crust_mantle(2,i,j,ispec2D)
+          normz(iglob) = normal_top_crust_mantle(3,i,j,ispec2D)
           ipoin = ipoin + 1
           updated_dof_ocean_load(iglob) = .true.
         endif
@@ -78,9 +104,28 @@
   enddo
   npoin_oceans = ipoin
 
+  ! Assemble normals
+  call assemble_MPI_scalar(NPROCTOT_VAL,NGLOB_CRUST_MANTLE, &
+                           normx, &
+                           num_interfaces_crust_mantle,max_nibool_interfaces_cm, &
+                           nibool_interfaces_crust_mantle,ibool_interfaces_crust_mantle, &
+                           my_neighbors_crust_mantle)
+  call assemble_MPI_scalar(NPROCTOT_VAL,NGLOB_CRUST_MANTLE, &
+                           normy, &
+                           num_interfaces_crust_mantle,max_nibool_interfaces_cm, &
+                           nibool_interfaces_crust_mantle,ibool_interfaces_crust_mantle, &
+                           my_neighbors_crust_mantle)
+  call assemble_MPI_scalar(NPROCTOT_VAL,NGLOB_CRUST_MANTLE, &
+                           normz, &
+                           num_interfaces_crust_mantle,max_nibool_interfaces_cm, &
+                           nibool_interfaces_crust_mantle,ibool_interfaces_crust_mantle, &
+                           my_neighbors_crust_mantle)
+
+
   ! user info
   if (myrank == 0) then
     write(IMAIN,*) "  number of global points on oceans = ",npoin_oceans
+    write(IMAIN,*) "  maximum valence of global points on oceans = ",maxval(valence)
     call flush_IMAIN()
   endif
 
@@ -110,7 +155,15 @@
           ! fills arrays
           ibool_ocean_load(ipoin) = iglob
           rmass_ocean_load_selected(ipoin) = rmass_ocean_load(iglob)
-          normal_ocean_load(:,ipoin) = normal_top_crust_mantle(:,i,j,ispec2D)
+          ! Make normal continuous
+          if (valence(iglob) > 1.) then
+             norm = sqrt(normx(iglob)**2 + normy(iglob)**2 + normz(iglob)**2)
+             normal_ocean_load(1,ipoin) = normx(iglob) / norm
+             normal_ocean_load(2,ipoin) = normy(iglob) / norm
+             normal_ocean_load(3,ipoin) = normz(iglob) / norm
+          else
+             normal_ocean_load(:,ipoin) = normal_top_crust_mantle(:,i,j,ispec2D)
+          end if
           ! masks this global point
           updated_dof_ocean_load(iglob) = .true.
         endif
@@ -121,6 +174,8 @@
   ! frees memory
   deallocate(updated_dof_ocean_load)
   deallocate(rmass_ocean_load)
+  deallocate(valence)
+  deallocate(normx,normy,normz)
 
   ! synchronizes processes
   call synchronize_all()

--- a/src/tomography/postprocess_sensitivity_kernels/interpolate_model.F90
+++ b/src/tomography/postprocess_sensitivity_kernels/interpolate_model.F90
@@ -1012,7 +1012,7 @@
 #ifdef USE_ADIOS_INSTEAD_OF_MESH
     ! single adios file for all old model arrays
     ! opens adios file with old model values
-    write(solver_file,'(a,a)') trim(dir_topo1)//'/model_gll.bp'
+    write(solver_file,'(a,a)') trim(input_model_dir)//'/model_gll.bp'
     call open_file_adios_read_and_init_method(myadios_val_file,myadios_val_group,solver_file)
 #endif
 

--- a/src/tomography/postprocess_sensitivity_kernels/laplacian_smoothing_sem.F90
+++ b/src/tomography/postprocess_sensitivity_kernels/laplacian_smoothing_sem.F90
@@ -1,0 +1,1051 @@
+#include "config.fh"
+
+program laplacian_smoothing_sem
+  
+  use constants, only: CUSTOM_REAL,NGLLX,NGLLY,NGLLZ,NDIM,IIN,IOUT, &
+       GAUSSALPHA,GAUSSBETA,MAX_STRING_LEN,R_EARTH_KM,myrank
+  
+  use postprocess_par, only: &
+       NCHUNKS_VAL,NPROC_XI_VAL,NPROC_ETA_VAL,NPROCTOT_VAL,NEX_XI_VAL,NEX_ETA_VAL, &
+       ANGULAR_WIDTH_XI_IN_DEGREES_VAL,ANGULAR_WIDTH_ETA_IN_DEGREES_VAL, &
+       NSPEC_CRUST_MANTLE,NGLOB_CRUST_MANTLE,MAX_KERNEL_NAMES,LOCAL_PATH
+  
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+  use adios_helpers_mod
+  use manager_adios
+#endif
+  
+  implicit none
+  
+  ! copy from static compilation (depends on Par_file values)
+  integer, parameter :: NPROC_XI  = NPROC_XI_VAL
+  integer, parameter :: NPROC_ETA = NPROC_ETA_VAL
+  integer, parameter :: NCHUNKS   = NCHUNKS_VAL
+  
+  !takes region 1 kernels
+  integer, parameter :: NSPEC_AB = NSPEC_CRUST_MANTLE
+  integer, parameter :: NGLOB_AB = NGLOB_CRUST_MANTLE
+  
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+  integer, parameter :: NARGS = 6
+  character(len=*), parameter :: reg_name = 'reg1/'
+#else
+  integer, parameter :: NARGS = 5
+  character(len=*), parameter :: reg_name = '_reg1_'
+#endif
+  
+  integer :: nspec, nglob, nker
+  integer :: iker, i, j, k, iel, i1, i2, ier, sizeprocs
+  
+  double precision    :: Lx, Ly, Lz, conv_crit
+  
+  
+  real(kind=CUSTOM_REAL), dimension(:),       allocatable :: m, s  
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: mo, so
+  
+  ! Mesh parameters
+  real(kind=CUSTOM_REAL), dimension(:),       allocatable :: xglob, yglob, zglob, valglob
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: dxsi_dx, deta_dx, dgam_dx
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: dxsi_dy, deta_dy, dgam_dy
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: dxsi_dz, deta_dz, dgam_dz
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: jacobian  
+
+  integer, dimension(:,:,:,:), allocatable :: ibool
+  integer, dimension(:),       allocatable :: idoubling, ispec_is_tiso, my_neighbors, &
+                                              nibool_interfaces, ibool_interfaces_tmp
+  integer, dimension(:,:),     allocatable :: ibool_interfaces
+
+  integer :: max_nibool_interfaces, num_interfaces
+  
+  double precision, dimension(NGLLX)             :: wx, xgll
+  double precision, dimension(NGLLY)             :: wy, ygll
+  double precision, dimension(NGLLZ)             :: wz, zgll
+
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLX)       :: dlagx,   dlagy,   dlagz
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLX)       :: dlagxwx, dlagywy, dlagzwz
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLX)       :: wxy,     wxz,     wyz
+  real(kind=CUSTOM_REAL), dimension(NGLLX,NGLLX,NGLLX) :: wxyz  
+  
+    
+  character(len=MAX_STRING_LEN),dimension(NARGS) :: arg
+  character(len=MAX_STRING_LEN),dimension(MAX_KERNEL_NAMES) :: kernel_names
+  character(len=MAX_STRING_LEN) :: kernel_names_comma_delimited
+  character(len=MAX_STRING_LEN) :: kernel_name, topo_dir
+  
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+  character(len=MAX_STRING_LEN) :: input_file, solver_file, solver_file_mpi, tmp_dir
+  character(len=MAX_STRING_LEN) :: varname, tmp_str
+#else
+  character(len=MAX_STRING_LEN) :: input_dir, output_dir
+  character(len=MAX_STRING_LEN) :: local_data_file
+#endif
+  
+  character(len=MAX_STRING_LEN) :: output_file
+  character(len=MAX_STRING_LEN) :: filename
+
+  ! tmp variable
+  character(len=MAX_STRING_LEN) :: region_name, file_name
+  integer :: iregion_code
+
+  real(kind=CUSTOM_REAL) :: dxsi_dxl, deta_dxl, dgam_dxl
+  real(kind=CUSTOM_REAL) :: dxsi_dyl, deta_dyl, dgam_dyl
+  real(kind=CUSTOM_REAL) :: dxsi_dzl, deta_dzl, dgam_dzl, jacobianl
+
+  real(kind=CUSTOM_REAL) :: norm_kerl, norm_ker
+  
+  ! timing
+  double precision, external :: wtime
+
+  ! ADIOS
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+  integer(kind=8) :: group_size_inc,local_dim
+  logical :: is_kernel
+#endif
+  
+  ! number of steps to reach 100 percent, i.e. 10 outputs info for every 10 percent
+  integer,parameter :: NSTEP_PERCENT_INFO = 10
+
+  double precision, external :: lagrange_deriv_GLL
+
+  ! initialize the MPI communicator and start the NPROCTOT MPI processes
+  call init_mpi()
+  call world_size(sizeprocs)
+  call world_rank(myrank)
+  
+  ! Parameters for convergence 
+  conv_crit    = 1e-5    ! convergence criterion
+  niter_cg_max = 1000    ! max number of iteration
+
+ ! check command line arguments
+  if (command_argument_count() /= NARGS) then
+     if (myrank == 0) then
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+        print *,'Usage: mpirun -np NPROC bin/xlaplacian_smoothing_sem_adios SIGMA_H SIGMA_V KERNEL_NAME INPUT_FILE SOLVER_FILE OUTPUT_FILE'
+        print *,'   with'
+        print *,'     SIGMA_H, SIGMA_V - horizontal and vertical smoothing lenghts'
+        print *,'     KERNEL_NAME      - comma-separated kernel names (e.g., alpha_kernel,beta_kernel)'
+        print *,'     INPUT_FILE       - ADIOS file with kernel values (e.g., kernels.bp)'
+        print *,'     SOLVER_FILE      - ADIOS file with mesh arrays (e.g., DATABASES_MPI/) containing solver_data.bp solver_data_mpi.bp'
+        print *,'     OUTPUT_FILE      - ADIOS file for smoothed output'
+        print *
+#else
+        print *, 'Usage: mpirun -np NPROC bin/xlaplacian_smoothing_sem SIGMA_H SIGMA_V KERNEL_NAME INPUT_DIR OUPUT_DIR'
+        print *,'   with'
+        print *,'     SIGMA_H, SIGMA_V - horizontal and vertical smoothing lenghts'
+        print *,'     KERNEL_NAME      - comma-separated kernel names (e.g., alpha_kernel,beta_kernel)'
+        print *,'     INPUT_DIR        - directory with kernel files (e.g., proc***_alpha_kernel.bin)'
+        print *,'     OUTPUT_DIR       - directory for smoothed output files'
+        print *
+#endif
+        stop ' Please check command line arguments'
+     endif
+  endif
+  call synchronize_all()
+  
+  ! check number of MPI processes
+  if (sizeprocs /= NPROCTOT_VAL) then
+     if (myrank == 0) then
+        print *
+        print *,'Expected number of MPI processes: ', NPROCTOT_VAL
+        print *,'Actual number of MPI processes: ', sizeprocs
+        print *
+     endif
+     call synchronize_all()
+     stop 'Error wrong number of MPI processes'
+  endif
+  call synchronize_all()
+  
+  if (myrank == 0) then
+     print *, 'Running XLAPLACIAN_SMOOTHING_SEM'
+     print *
+  endif
+  call synchronize_all()
+  
+  ! parse command line arguments
+  do i = 1, NARGS
+     call get_command_argument(i,arg(i))
+     if (i <= 5 .and. trim(arg(i)) == '') then
+        stop ' Please check command line arguments'
+     endif
+  enddo
+  read(arg(1),*) Lx
+  read(arg(2),*) Lz
+  kernel_names_comma_delimited = arg(3)
+  
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+  ! ADIOS arguments
+  input_file = arg(4)
+  tmp_dir     = arg(5)
+  write(solver_file, '(a,a)') trim(tmp_dir)//'solver_data.bp'
+  write(solver_file_mpi, '(a,a)') trim(tmp_dir)//'solver_data_mpi.bp'
+  output_file = arg(6)
+#else
+  input_dir = arg(4)
+  output_dir = arg(5)
+#endif
+  call synchronize_all()
+  
+  call parse_kernel_names(kernel_names_comma_delimited,kernel_names,nker)
+  if (nker > MAX_KERNEL_NAMES) stop 'number of kernel_names exceeds MAX_KERNEL_NAMES'
+  
+  if (myrank == 0) then
+     ! The machinery for reading multiple names from the command line is in
+     ! place,
+     ! but the smoothing routines themselves have not yet been modified to work
+     !  on multiple arrays.
+     if (myrank == 0) print *, 'Smoothing list: ', trim(kernel_names_comma_delimited),' - total: ',nker
+     if (myrank == 0) print *
+  endif
+  call synchronize_all()
+  
+  call read_parameter_file()
+  topo_dir = trim(LOCAL_PATH)//'/'
+  
+  ! checks if basin code or global code: global code uses nchunks /= 0
+  if (NCHUNKS == 0) stop 'Error nchunks'
+  if (sizeprocs /= NPROCTOT_VAL) call exit_mpi(myrank,'Error total number of slices')
+  
+  ! user output
+  if (myrank == 0) then
+     print *,"defaults:"
+     print *,"  NPROC_XI , NPROC_ETA        : ",NPROC_XI,NPROC_ETA
+     print *,"  NCHUNKS                     : ",NCHUNKS
+     print *
+     print *,"  smoothing sigma_h , sigma_v (km)                : ",Lx,Lz
+     print *
+     print *,"  data name      : ",trim(kernel_names_comma_delimited)
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+     ! ADIOS arguments
+     print *,"  input file     : ",trim(input_file)
+     print *,"  solver file    : ",trim(solver_file)
+     print *,"  output file    : ",trim(output_file)
+#else
+     print *,"  input dir      : ",trim(input_dir)
+     print *,"  output dir     : ",trim(output_dir)
+#endif
+     print *
+     print *,"number of elements per slice: ",NSPEC_AB
+     print *
+  endif
+  
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+  ! ADIOS
+  call synchronize_all()
+  ! initializes ADIOS
+  if (myrank == 0) then
+     print *, 'initializing ADIOS...'
+     print *, ' '
+  endif
+  call initialize_adios()
+#endif
+  
+  ! synchronizes
+  call synchronize_all()
+  Lx = Lx / real(R_EARTH_KM,kind=CUSTOM_REAL) ! scale
+  Lz = Lz / real(R_EARTH_KM,kind=CUSTOM_REAL) ! scale
+  Ly = Lx
+  
+  
+  ! 1. Read inputs and prepare mpi / gpu
+  if (.not.allocated(ibool))         allocate(ibool(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(valglob))       allocate(valglob(nglob_ab))
+  if (.not.allocated(dxsi_dx))       allocate(dxsi_dx(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(dxsi_dy))       allocate(dxsi_dy(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(dxsi_dz))       allocate(dxsi_dz(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(deta_dx))       allocate(deta_dx(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(deta_dy))       allocate(deta_dy(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(deta_dz))       allocate(deta_dz(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(dgam_dx))       allocate(dgam_dx(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(dgam_dy))       allocate(dgam_dy(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(dgam_dz))       allocate(dgam_dz(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(jacobian))      allocate(jacobian(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(xglob))         allocate(xglob(nglob_ab))
+  if (.not.allocated(yglob))         allocate(yglob(nglob_ab))
+  if (.not.allocated(zglob))         allocate(zglob(nglob_ab))
+  if (.not.allocated(idoubling))     allocate(idoubling(nspec_ab))
+  if (.not.allocated(ispec_is_tiso)) allocate(ispec_is_tiso(nspec_ab))
+
+  if (.not.allocated(m))  allocate(m(nglob_ab))
+  if (.not.allocated(s))  allocate(s(nglob_ab))
+  if (.not.allocated(mo)) allocate(mo(ngllx, nglly, ngllz, nspec_ab))
+  if (.not.allocated(so)) allocate(so(ngllx, nglly, ngllz, nspec_ab))
+  m(:) = 0
+  s(:) = 0
+
+  ! GLL points weights
+  call zwgljd(xgll,wx,NGLLX,GAUSSALPHA,GAUSSBETA)
+  call zwgljd(ygll,wy,NGLLY,GAUSSALPHA,GAUSSBETA)
+  call zwgljd(zgll,wz,NGLLZ,GAUSSALPHA,GAUSSBETA)
+  do k=1,NGLLZ
+     do j=1,NGLLY
+        do i=1,NGLLX
+           wxyz(i,j,k) = real(wx(i)*wy(j)*wz(k),kind=CUSTOM_REAL)
+        enddo
+     enddo
+  enddo
+  ! Get derivative matrices
+  do i1 = 1,NGLLX
+     do i2 = 1,NGLLX
+        dlagx(i2,i1)   = real(lagrange_deriv_GLL(i1-1,i2-1,xgll,NGLLX), kind=CUSTOM_REAL)
+        dlagy(i2,i1)   = real(lagrange_deriv_GLL(i1-1,i2-1,xgll,NGLLX), kind=CUSTOM_REAL)
+        dlagz(i2,i1)   = real(lagrange_deriv_GLL(i1-1,i2-1,xgll,NGLLX), kind=CUSTOM_REAL)
+        dlagxwx(i2,i1) = real(lagrange_deriv_GLL(i1-1,i2-1,xgll,NGLLX)*wx(i2), kind=CUSTOM_REAL)
+        dlagywy(i2,i1) = real(lagrange_deriv_GLL(i1-1,i2-1,xgll,NGLLX)*wy(i2), kind=CUSTOM_REAL)
+        dlagzwz(i2,i1) = real(lagrange_deriv_GLL(i1-1,i2-1,xgll,NGLLX)*wz(i2), kind=CUSTOM_REAL)
+        wxy(i1, i2)    = real(wx(i1)*wy(i2), kind=CUSTOM_REAL)
+        wyz(i1, i2)    = real(wy(i1)*wz(i2), kind=CUSTOM_REAL)
+        wxz(i1, i2)    = real(wx(i1)*wz(i2), kind=CUSTOM_REAL)       
+     enddo
+  enddo
+  
+  
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+ ! ADIOS
+  ! user output
+  if (myrank == 0) print *, 'reading in ADIOS solver file: ',trim(solver_file)
+  
+  ! opens file for reading
+  call init_adios_group(myadios_group, "MeshReader")
+  call open_file_adios_read_and_init_method(myadios_file, myadios_group, trim(solver_file))  
+  call read_adios_scalar(myadios_file, myadios_group, myrank, trim(reg_name)//"nspec", nspec)
+  call read_adios_scalar(myadios_file, myadios_group, myrank, trim(reg_name)//"nglob", nglob)  
+  if (nspec /= NSPEC_AB) call exit_mpi(myrank,'Error invalid nspec value in solver_data.bp')
+  if (nglob /= NGLOB_AB) call exit_mpi(myrank,'Error invalid nglob value in solver_data.bp')
+  ! reads mesh arrays
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "ibool", ibool(:, :, :, :))  
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "xixstore", dxsi_dx(:, :, :, :))
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "xiystore", dxsi_dy(:, :, :, :))
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "xizstore", dxsi_dz(:, :, :, :))
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "gammaxstore", dgam_dx(:, :, :, :))
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "gammaystore", dgam_dy(:, :, :, :))
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "gammazstore", dgam_dz(:, :, :, :))  
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "etaxstore", deta_dx(:, :, :, :))
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "etaystore", deta_dy(:, :, :, :))
+  call read_adios_array(myadios_file, myadios_group, myrank, nspec, trim(reg_name) // "etazstore", deta_dz(:, :, :, :))
+  call close_file_adios_read_and_finalize_method(myadios_file)
+ 
+  ! opens file for mesh
+  if (myrank == 0) print *, 'reading in ADIOS solver file: ',trim(solver_file_mpi)
+  call init_adios_group(myadios_group, "MeshMPIReader")
+  call open_file_adios_read_and_init_method(myadios_file,myadios_group,solver_file_mpi)  
+  ! MPI interfaces
+  call read_adios_scalar(myadios_file,myadios_group,myrank,trim(reg_name) // "num_interfaces",num_interfaces)
+  call read_adios_scalar(myadios_file,myadios_group,myrank,trim(reg_name) // "max_nibool_interfaces",max_nibool_interfaces)
+
+  allocate(my_neighbors(num_interfaces), &
+       nibool_interfaces(num_interfaces), &
+       stat=ier)
+  if (ier /= 0 ) call exit_mpi(myrank,'Error allocating array my_neighbors_crust_mantle etc.')
+  if (num_interfaces > 0) then
+     allocate(ibool_interfaces(max_nibool_interfaces,num_interfaces), stat=ier)
+     if (ier /= 0 ) call exit_mpi(myrank,'Error allocating array ibool_interfaces_crust_mantle')
+     allocate(ibool_interfaces_tmp(max_nibool_interfaces * num_interfaces), stat=ier)
+     if (ier /= 0 ) call exit_mpi(myrank,'Error allocating array ibool_interfaces_crust_mantle_tmp')
+     call read_adios_array(myadios_file, myadios_group, myrank, num_interfaces, trim(reg_name) // "my_neighbors", my_neighbors(:))
+     call read_adios_array(myadios_file, myadios_group, myrank, num_interfaces, trim(reg_name) // "nibool_interfaces", nibool_interfaces(:))
+     call read_adios_array(myadios_file, myadios_group, myrank, num_interfaces*max_nibool_interfaces, &
+        trim(reg_name) // "ibool_interfaces", ibool_interfaces_tmp(:))
+     k = 0
+     do j = 1, num_interfaces
+        do i = 1, max_nibool_interfaces
+            k = k + 1
+            ibool_interfaces(i, j) = ibool_interfaces_tmp(k)
+        enddo  
+     enddo
+     deallocate(ibool_interfaces_tmp)
+  else  
+     max_nibool_interfaces = 0
+     allocate(ibool_interfaces(0,0),stat=ier)
+     if (ier /= 0 ) call exit_mpi(myrank,'Error allocating array dummy ibool_interfaces_crust_mantle')
+  endif
+  call close_file_adios_read_and_finalize_method(myadios_file)
+
+#else  
+  ! read in the topology files of the current and neighboring slices
+  ! point locations
+  write(filename,'(a,i6.6,a)') trim(topo_dir)//'/proc',myrank,trim(reg_name)//'solver_data.bin'
+  open(IIN,file=trim(filename),status='old',action='read',form='unformatted',iostat=ier)
+  if (ier /= 0) then
+     print *,'Error opening file: ',trim(filename)
+     call exit_mpi(myrank,'Error opening solver_data.bin file')
+  endif
+
+  ! checks nspec
+  read(IIN) nspec
+  if (nspec /= NSPEC_AB) call exit_mpi(myrank,'Error invalid nspec value in solver_data.bin')
+
+  ! checks nglob
+  read(IIN) nglob
+  if (nglob /= NGLOB_AB) call exit_mpi(myrank,'Error invalid nglob value in solver_data.bin')
+
+  ! node locations
+  read(IIN) xglob
+  read(IIN) yglob
+  read(IIN) zglob
+
+  read(IIN) ibool
+  read(IIN) idoubling
+  read(IIN) ispec_is_tiso
+
+  read(IIN) dxsi_dx
+  read(IIN) dxsi_dy
+  read(IIN) dxsi_dz
+  read(IIN) deta_dx
+  read(IIN) deta_dy
+  read(IIN) deta_dz
+  read(IIN) dgam_dx
+  read(IIN) dgam_dy
+  read(IIN) dgam_dz
+  close(IIN)
+
+  !! Read MPI
+  write(filename,'(a,i6.6,a)') trim(topo_dir)//'/proc',myrank,trim(reg_name)//'solver_data_mpi.bin'
+  open(unit=IIN,file=filename, &
+       status='old',action='read',form='unformatted',iostat=ier)
+  if (ier /= 0 ) call exit_mpi(myrank,'Error opening solver_data_mpi.bin')
+  ! MPI interfaces
+  read(IIN) num_interfaces
+  allocate(my_neighbors(num_interfaces), &
+          nibool_interfaces(num_interfaces), &
+          stat=ier)
+  if (ier /= 0 ) &
+    call exit_mpi(myrank,'Error allocating array my_neighbors_crust_mantle etc.')
+  if (num_interfaces > 0) then
+     read(IIN) max_nibool_interfaces
+     allocate(ibool_interfaces(max_nibool_interfaces,num_interfaces), &
+          stat=ier)
+     if (ier /= 0 ) call exit_mpi(myrank,'Error allocating array ibool_interfaces_crust_mantle')
+     read(IIN) my_neighbors
+     read(IIN) nibool_interfaces
+     read(IIN) ibool_interfaces
+  else
+     ! dummy array
+     max_nibool_interfaces = 0
+     allocate(ibool_interfaces(0,0),stat=ier)
+     if (ier /= 0 ) call exit_mpi(myrank,'Error allocating array dummy ibool_interfaces_crust_mantle')
+  endif
+  close(IIN)
+
+  deallocate(xglob, yglob, zglob, idoubling, ispec_is_tiso)
+#endif
+  call synchronize_all()
+
+  ! 2. Modify jacobian and inverse jacobian for non-dimensionalize smoothing
+  !    note: correlation mengths Lx, Ly and Lz could be made depth or space dependent
+  do iel = 1, nspec_ab
+     do k = 1, ngllz
+        do j = 1, nglly
+           do i = 1, ngllx
+              ! Get inverse jacobian
+              dxsi_dxl = dxsi_dx(i,j,k,iel)
+              deta_dxl = deta_dx(i,j,k,iel)
+              dgam_dxl = dgam_dx(i,j,k,iel)
+              dxsi_dyl = dxsi_dy(i,j,k,iel)
+              deta_dyl = deta_dy(i,j,k,iel)
+              dgam_dyl = dgam_dy(i,j,k,iel)
+              dxsi_dzl = dxsi_dz(i,j,k,iel)
+              deta_dzl = deta_dz(i,j,k,iel)
+              dgam_dzl = dgam_dz(i,j,k,iel)
+              ! Compute jacobian
+              jacobianl = dxsi_dxl * (deta_dyl * dgam_dzl - deta_dzl * dgam_dyl) &
+                   - dxsi_dyl * (deta_dxl * dgam_dzl - deta_dzl * dgam_dxl) &
+                   + dxsi_dzl * (deta_dxl * dgam_dyl - deta_dyl * dgam_dxl)
+              jacobianl = 1. / jacobianl
+              ! Apply scaling
+              dxsi_dx(i,j,k,iel)  = dxsi_dxl * Lx
+              deta_dx(i,j,k,iel)  = deta_dxl * Lx
+              dgam_dx(i,j,k,iel)  = dgam_dxl * Lx
+              dxsi_dy(i,j,k,iel)  = dxsi_dyl * Ly
+              deta_dy(i,j,k,iel)  = deta_dyl * Ly
+              dgam_dy(i,j,k,iel)  = dgam_dyl * Ly
+              dxsi_dz(i,j,k,iel)  = dxsi_dzl * Lz
+              deta_dz(i,j,k,iel)  = deta_dzl * Lz
+              dgam_dz(i,j,k,iel)  = dgam_dzl * Lz
+              jacobian(i,j,k,iel) = jacobianl / (Lx*Ly*Lz)
+           end do
+        end do
+     end do
+  end do
+  call synchronize_all()
+
+
+  !! PREPARE ADIOS OUTPUTS
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+     ! ADIOS
+     ! user output
+     if (myrank == 0) print *, 'writing to ADIOS output file: ',trim(output_file)
+     ! determines group size
+     call init_adios_group(myadios_group, "ValWriter")
+     group_size_inc = 0
+     call define_adios_scalar(myadios_group, group_size_inc, '',trim(reg_name)//"nspec", nspec)
+     call define_adios_scalar(myadios_group, group_size_inc, '',trim(reg_name)//"nglob", nglob)
+     do iker = 1, nker
+        kernel_name = kernel_names(iker)
+        local_dim = NGLLX * NGLLY * NGLLZ * nspec
+        !!! warning different conventions 
+        write(tmp_str,'(a,a)')trim(kernel_name),'_crust_mantle'
+        !write(tmp_str,'(a,a)')trim(reg_name),trim(kernel_name)        
+        call define_adios_global_array1D(myadios_group, group_size_inc,local_dim, '', &
+                                     trim(tmp_str), so(:, :, :, :))
+     enddo
+     ! opens output files
+     call open_file_adios_write(myadios_file, myadios_group,trim(output_file), "ValWriter")
+     call set_adios_group_size(myadios_file,group_size_inc)
+     ! writes to file
+     call write_adios_scalar(myadios_file, myadios_group, trim(reg_name)//"nspec", nspec)
+     call write_adios_scalar(myadios_file, myadios_group, trim(reg_name)//"nglob", nglob)
+#endif
+
+
+  ! 3. Smooth kernels / models
+  !    solves inverse filtering problem for each kernel / model
+  !         must solve A A s = M m
+  !         where A = (M + K)
+  !    done with two conjugate gradients
+  do iker = 1, nker
+     !! Read input kernels
+     kernel_name = kernel_names(iker)
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+     ! ADIOS single file opening
+     ! user output
+     if (myrank == 0) print *, 'reading in ADIOS input file : ',trim(input_file)
+     call init_adios_group(myadios_val_group, "ValReader")
+     call open_file_adios_read(myadios_val_file, myadios_val_group, trim(input_file))
+     ! ADIOS array name
+     ! determines if parameter name is for a kernel
+      if (len_trim(kernel_name) > 3) then
+        if (kernel_name(len_trim(kernel_name)-2:len_trim(kernel_name)) == '_kl') then
+          is_kernel = .true.
+        endif
+      endif
+      if (is_kernel) then
+        ! NOTE: reg1 => crust_mantle, others are not implemented
+        varname = trim(kernel_name) // "_crust_mantle"
+      else
+        varname = trim(reg_name) // trim(kernel_name)
+      endif
+      ! user output
+      if (myrank == 0) then
+        print *, '  data: ADIOS ',trim(kernel_name), " is_kernel = ", is_kernel
+        print *, '  data: ADIOS using array name = ',trim(varname)
+        print *
+      endif
+      ! reads kernel values
+      call read_adios_array(myadios_val_file, myadios_val_group, myrank, nspec, trim(varname), mo(:, :, :, :))
+      call synchronize_all()
+      call close_file_adios_read(myadios_val_file)
+#else
+     ! user output
+     if (myrank == 0) then
+        print *,'  kernel ',iker,'out of ',nker
+        print *,'  reading data file: proc = ',myrank,' name = ',trim(kernel_name)
+        print *
+     endif
+     ! data file
+     write(local_data_file,'(a,i6.6,a)') &
+          trim(input_dir)//'/proc',myrank,trim(reg_name)//trim(kernel_name)//'.bin'
+     
+     open(IIN,file=trim(local_data_file),status='old',action='read',form='unformatted',iostat=ier)
+     if (ier /= 0) then
+        print *,'Error opening data file: ',trim(local_data_file)
+        call exit_mpi(myrank,'Error opening data file')
+     endif
+     read(IIN) mo(:,:,:,:)
+     close(IIN)
+#endif
+     ! Get normalization factor
+     norm_kerl = sum(mo**2)/nglob
+     call sum_all_cr(norm_kerl, norm_ker)
+     norm_ker = sqrt(norm_ker)
+     call bcast_all_singlecr(norm_ker)
+     mo = mo / norm_ker
+     call synchronize_all()
+
+     !! First pass
+     call apply_mass_matrix_gll(mo, m)
+     call solve_laplace_linear_system_cg(m, s) ! Solve A y = m
+        
+     !! Second pass
+     call apply_mass_matrix_glob(s, m)
+     call solve_laplace_linear_system_cg(m, s) ! Solve A s = y
+
+     !! SAve kernels
+     call model_glob_to_gll(s, so)
+     so = so * norm_ker
+     
+     ! smoothed kernel file name
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+     ! ADIOS
+     write(tmp_str,'(a,a)')trim(kernel_name),'_crust_mantle'
+     !write(tmp_str,'(a,a)')trim(reg_name),trim(kernel_name)  
+     local_dim = NGLLX * NGLLY * NGLLZ * nspec
+     call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs_adios, local_dim, &
+          trim(tmp_str), so(:, :, :, :))
+#else
+     write(output_file,'(a,i6.6,a)') trim(output_dir)//'/proc', myrank, trim(reg_name)//trim(kernel_name)//'_smooth.bin'     
+     open(IOUT,file=trim(output_file),status='unknown',form='unformatted',action='write',iostat=ier)
+     if (ier /= 0) call exit_mpi(myrank,'Error opening smoothed kernel file')     
+     ! Note: output the following instead of kernel_smooth(:,:,:,1:NSPEC_AB) to create files of the same sizes
+     write(IOUT) so(:,:,:,:)
+     close(IOUT)
+     if (myrank == 0) print *,'  written: ',trim(output_file)
+#endif
+     ! synchronizes
+     call synchronize_all()
+
+  end do
+  
+#ifdef USE_ADIOS_INSTEAD_OF_MESH
+  ! ADIOS
+  ! actual writing
+  ! (note: done at the very end, otherwise it will reset path and we would need
+  ! to re-initiate a group)
+  call write_adios_perform(myadios_file)
+  ! closes adios files
+  call close_file_adios(myadios_file)
+!  call close_file_adios_read_and_finalize_method(myadios_file)
+  call finalize_adios()
+#endif
+
+ ! user output
+ if (myrank == 0) print *, 'all done'
+
+ ! stop all the processes, and exit
+ call finalize_mpi()
+ 
+  
+contains
+
+
+  subroutine solve_laplace_linear_system_cg(m, s)
+    
+    implicit none
+
+    integer :: iter_cg, niter_cg_max    
+    real(kind=CUSTOM_REAL)    :: res_ini, res_norm, res_norm_new, res_norm_inf
+    real(kind=CUSTOM_REAL)    :: pAp, alpha, beta
+
+    real(kind=CUSTOM_REAL), dimension(:), allocatable, intent(in)    :: m
+    real(kind=CUSTOM_REAL), dimension(:), allocatable, intent(inout) :: s
+    real(kind=CUSTOM_REAL), dimension(:), allocatable                :: r, p, Ap
+
+    
+    ! Initializations and allocations
+    if (.not.allocated(r))  allocate(r(nglob))
+    if (.not.allocated(p))  allocate(p(nglob))
+    if (.not.allocated(Ap)) allocate(Ap(nglob))
+    r(:)  = 0.
+    p(:)  = 0.
+    Ap(:) = 0.    
+    !! niter_cg_max = nglob !300 !nglob   ! could be changed, here it's the theoretical maximum value
+                                       ! warning should be bcast from master...
+
+    ! Compute As and form residuals, use them as fir direction
+    ! As = 0 because we assume s=0
+    s(:) = 0.
+    r(:) = m(:) 
+    p(:) = r(:)
+
+    ! Compute initial squared norm of residuals
+    call compute_scalar_product(r, r, res_norm)       
+    res_ini = res_norm
+    if (myrank == 0) then
+        write(6,*) 'Initial residual: ',res_ini
+    end if
+    call synchronize_all()
+
+    ! Conjugate gradient iterations
+    do iter_cg = 1, niter_cg_max
+
+       ! Compute Ap product and scalar product
+       call compute_Ax_product(p, Ap)
+       call compute_scalar_product(p, Ap, pAp)
+              
+       ! Compute alpha, then update smooth model and residual      
+       alpha = res_norm / pAp
+       s     = s + real(alpha, kind=4) * p
+       r     = r - real(alpha, kind=4) * Ap
+
+       ! Compute new norm of residual and check convergence
+       call compute_scalar_product(r, r, res_norm_new)
+       call compute_infinite_norm(r, res_norm_inf)
+       !if ( res_norm_inf < conv_crit) then
+       if ( res_norm_new < res_ini*conv_crit) then
+          exit
+       end if
+       
+       ! Compute beta and update conjugate direction
+       beta     = res_norm_new / res_norm
+       res_norm = res_norm_new
+       p        = r + real(beta, kind=4) * p 
+
+       ! Print infos
+       if (myrank == 0) then
+           write(6,*)'Iterations ',iter_cg,', max residual ',res_norm_inf,' l2 norm ',res_norm_new
+       end if
+
+    end do
+
+    if (myrank == 0) write(6,*)'Iterations ',iter_cg,', max residual ',res_norm_inf
+
+    
+  end subroutine solve_laplace_linear_system_cg
+
+  
+  subroutine compute_Ax_product(s, As)
+
+    implicit none
+
+    real(kind=CUSTOM_REAL), dimension(NGLLX, NGLLY, NGLLZ) :: sl, stif, mass
+    real(kind=CUSTOM_REAL), dimension(NGLLX, NGLLY, NGLLZ) :: grad_xsil, grad_etal, grad_gaml
+    
+    integer :: i, j, k, l, iel, idof
+    
+    real(kind=CUSTOM_REAL)    :: lapla_x, lapla_y, lapla_z, jacobianl
+    real(kind=CUSTOM_REAL)    :: dxsi_dxl, deta_dxl, dgam_dxl
+    real(kind=CUSTOM_REAL)    :: dxsi_dyl, deta_dyl, dgam_dyl
+    real(kind=CUSTOM_REAL)    :: dxsi_dzl, deta_dzl, dgam_dzl
+    real(kind=CUSTOM_REAL)    :: dsl_dxsi, dsl_deta, dsl_dgam
+    real(kind=CUSTOM_REAL)    :: dsl_dxl, dsl_dyl, dsl_dzl
+
+    real(kind=CUSTOM_REAL), dimension(:), allocatable, intent(in)    :: s
+    real(kind=CUSTOM_REAL), dimension(:), allocatable, intent(inout) :: As
+
+    As(:) = 0
+
+    ! Loop over elements
+    do iel = 1, nspec
+
+       ! Get element values
+       do k = 1, ngllz
+          do j = 1, nglly
+             do i = 1, ngllx
+                idof      = ibool(i, j, k, iel)
+                sl(i,j,k) = s(idof)
+             end do
+          end do
+       end do
+
+       ! First loop
+       do k = 1, ngllz
+          do j = 1, nglly
+             do i = 1, ngllx
+                
+                ! Compute derivatives at elemental level
+                dsl_dxsi = 0.
+                dsl_deta = 0.
+                dsl_dgam = 0.
+                do l = 1,ngllx
+                   dsl_dxsi = dsl_dxsi + sl(l, j, k) * dlagx(i, l)
+                   dsl_deta = dsl_deta + sl(i, l, k) * dlagy(j, l)
+                   dsl_dgam = dsl_dgam + sl(i, j, l) * dlagz(k, l)
+                end do
+
+                ! Get derivatives informations
+                dxsi_dxl  = dxsi_dx(i, j, k, iel) 
+                dxsi_dyl  = dxsi_dy(i, j, k, iel)
+                dxsi_dzl  = dxsi_dz(i, j, k, iel)
+                deta_dxl  = deta_dx(i, j, k, iel) 
+                deta_dyl  = deta_dy(i, j, k, iel)
+                deta_dzl  = deta_dz(i, j, k, iel)
+                dgam_dxl  = dgam_dx(i, j, k, iel) 
+                dgam_dyl  = dgam_dy(i, j, k, iel)
+                dgam_dzl  = dgam_dz(i, j, k, iel)
+                jacobianl = jacobian(i, j, k, iel) 
+
+                ! Get physical derivatives
+                dsl_dxl = dsl_dxsi * dxsi_dxl + dsl_deta * deta_dxl + dsl_dgam * dgam_dxl
+                dsl_dyl = dsl_dxsi * dxsi_dyl + dsl_deta * deta_dyl + dsl_dgam * dgam_dyl
+                dsl_dzl = dsl_dxsi * dxsi_dzl + dsl_deta * deta_dzl + dsl_dgam * dgam_dzl
+
+                ! Start product
+                grad_xsil(i, j, k) = jacobianl * (dxsi_dxl * dsl_dxl + dxsi_dyl * dsl_dyl + dxsi_dzl * dsl_dzl)
+                grad_etal(i, j, k) = jacobianl * (deta_dxl * dsl_dxl + deta_dyl * dsl_dyl + deta_dzl * dsl_dzl)
+                grad_gaml(i, j, k) = jacobianl * (dgam_dxl * dsl_dxl + dgam_dyl * dsl_dyl + dgam_dzl * dsl_dzl)
+
+                ! Compute mass term
+                mass(i, j, k) = wxyz(i, j, k) * jacobianl *  sl(i, j, k)
+                
+             end do
+          end do
+       end do       
+       
+       ! Second loop
+       do k = 1, ngllz
+          do j = 1, nglly
+             do i = 1, ngllx
+
+                ! Compute derivatives at elemental level
+                lapla_x = 0.
+                lapla_y = 0.
+                lapla_z = 0.
+                do l = 1,ngllx
+                   lapla_x = lapla_x + grad_xsil(l, j, k) * dlagxwx(l, i)
+                   lapla_y = lapla_y + grad_etal(i, l, k) * dlagywy(l, j)
+                   lapla_z = lapla_z + grad_gaml(i, j, l) * dlagzwz(l, k)
+                end do
+
+                ! Stiffness
+                stif(i,j,k) = wyz(j,k)*lapla_x + wxz(i,k)*lapla_y + wxy(i,j)*lapla_z                
+                
+             end do
+          end do
+       end do
+       
+      ! Go back to dof
+       do k = 1, ngllz
+          do j = 1, nglly
+             do i = 1, ngllx                
+                idof     = ibool(i, j, k, iel)
+                As(idof) = As(idof) + stif(i, j, k) + mass(i, j, k)                
+             end do
+          end do
+       end do
+              
+    end do
+
+    
+    call assemble_MPI_scalar(sizeprocs, nglob, As, &
+                             num_interfaces, max_nibool_interfaces, &
+                             nibool_interfaces, ibool_interfaces, my_neighbors)
+
+    
+  end subroutine compute_Ax_product
+
+  ! subroutine model_gll_to_glob(mgll, mglob)
+
+  !   implicit none
+    
+  !   integer :: i, j, k, iel, idof
+    
+  !   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable, intent(in)    :: mgll
+  !   real(kind=CUSTOM_REAL), dimension(:),       allocatable, intent(inout) :: mglob
+
+  !   mglob(:) = 0.
+  !   do iel = 1, nspec
+  !      do k = 1, ngllz
+  !         do j = 1, nglly
+  !            do i = 1, ngllx
+  !               idof        = ibool(i, j, k, iel)
+  !               mglob(idof) = mglob(idof) + mgll(i, j, k, iel) / valglob(idof)
+  !            end do
+  !         end do
+  !      end do
+  !   end do
+    
+  !   call assemble_MPI_scalar(sizeprocs, nglob_ab, mglob, &
+  !                            num_interfaces, max_nibool_interfaces, &
+  !                            nibool_interfaces, ibool_interfaces, my_neighbors)
+    
+  ! end subroutine model_gll_to_glob
+  
+  subroutine model_glob_to_gll(mglob, mgll)
+    
+    implicit none
+    
+    integer :: i, j, k, iel, idof
+    
+    real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable, intent(inout) :: mgll
+    real(kind=CUSTOM_REAL), dimension(:),       allocatable, intent(inout)    :: mglob
+    
+    do iel = 1, nspec
+       do k = 1, ngllz
+          do j = 1, nglly
+             do i = 1, ngllx
+                idof               = ibool(i, j, k, iel)
+                mgll(i, j, k, iel) =  mglob(idof)
+             end do
+          end do
+       end do
+    end do
+    
+  end subroutine model_glob_to_gll
+  
+  subroutine apply_mass_matrix_glob(m, s)
+    
+    implicit none
+    
+    integer :: i, j, k, iel, idof
+    
+    real(kind=CUSTOM_REAL), dimension(:), allocatable, intent(in)    :: m
+    real(kind=CUSTOM_REAL), dimension(:), allocatable, intent(inout) :: s
+    
+    s(:) = 0.
+    do iel = 1, nspec
+       do k = 1, ngllz
+          do j = 1, nglly
+             do i = 1, ngllx
+                idof    = ibool(i, j, k, iel)
+                s(idof) = s(idof) + m(idof) * jacobian(i, j, k, iel) * wxyz(i,j,k)
+             end do
+          end do
+       end do
+    end do
+
+    call assemble_MPI_scalar(sizeprocs, nglob, s, &
+                             num_interfaces, max_nibool_interfaces, &
+                             nibool_interfaces, ibool_interfaces, my_neighbors)
+    
+  end subroutine apply_mass_matrix_glob
+  
+  subroutine apply_mass_matrix_gll(m, s)
+    
+    implicit none
+    
+    integer :: i, j, k, iel, idof
+    
+    real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable, intent(in)    :: m
+    real(kind=CUSTOM_REAL), dimension(:),       allocatable, intent(inout) :: s
+    
+    s(:) = 0.
+    do iel = 1, nspec
+       do k = 1, ngllz
+          do j = 1, nglly
+             do i = 1, ngllx
+                idof    = ibool(i, j, k, iel)
+                s(idof) = s(idof) + m(i, j, k, iel) * jacobian(i, j, k, iel) * wxyz(i,j,k)
+                !s(idof) = m(i, j, k, iel) * jacobian(i, j, k, iel) * wxyz(i,j,k)
+             end do
+          end do
+       end do
+    end do
+    
+    call assemble_MPI_scalar(sizeprocs, nglob, s, &
+                             num_interfaces, max_nibool_interfaces, &
+                             nibool_interfaces, ibool_interfaces, my_neighbors)
+    
+  end subroutine apply_mass_matrix_gll
+
+  subroutine compute_scalar_product(a, b, val)
+
+    implicit none
+    
+    real(kind=CUSTOM_REAL), dimension(:), allocatable, intent(in) :: a, b
+    real(kind=CUSTOM_REAL), intent(out) :: val
+    real(kind=CUSTOM_REAL) :: valloc
+    integer :: i
+    valloc = 0
+    val    = 0
+    if (size(a) /= size(b)) then
+       stop 
+    end if
+    do i=1,size(a)
+       valloc = valloc + a(i) * b(i)
+    end do
+    call sum_all_cr(valloc, val)
+    call bcast_all_singlecr(val)
+    !print *,'scal prod',myrank,valloc,val
+    
+  end subroutine compute_scalar_product
+
+  subroutine compute_infinite_norm(a, val)
+
+    implicit none
+    
+    real(kind=CUSTOM_REAL), dimension(:), allocatable, intent(in) :: a
+    integer :: i
+    real(kind=CUSTOM_REAL), intent(inout) :: val
+    real(kind=CUSTOM_REAL) :: valloc
+
+    valloc = 0
+    val    = 0
+    do i=1,size(a)
+       valloc = max(valloc,abs(a(i)))
+    end do
+    call max_all_cr(valloc, val)
+    call bcast_all_singlecr(val)
+    !print *,'inf norm ',myrank,valloc,val
+
+  end subroutine compute_infinite_norm
+
+
+ subroutine assemble_MPI_scalar(NPROC,nglob,array_val, &
+                        num_interfaces,max_nibool_interfaces, &
+                        nibool_interfaces,ibool_interfaces, &
+                        my_neighbors)
+
+! blocking send/receive
+
+  use constants
+
+  implicit none
+
+  integer :: NPROC
+  integer :: nglob
+
+  ! array to assemble
+  real(kind=CUSTOM_REAL), dimension(nglob), intent(inout) :: array_val
+
+  integer :: num_interfaces,max_nibool_interfaces
+  integer, dimension(num_interfaces) :: nibool_interfaces,my_neighbors
+  integer, dimension(max_nibool_interfaces,num_interfaces) :: ibool_interfaces
+
+  ! local parameters
+  real(kind=CUSTOM_REAL), dimension(:,:), allocatable :: buffer_send_scalar
+  real(kind=CUSTOM_REAL), dimension(:,:), allocatable :: buffer_recv_scalar
+  integer, dimension(:), allocatable :: request_send_scalar
+  integer, dimension(:), allocatable :: request_recv_scalar
+
+  integer ipoin,iinterface,ier
+
+! here we have to assemble all the contributions between partitions using MPI
+
+  ! assemble only if more than one partition
+  if (NPROC > 1) then
+ allocate(buffer_send_scalar(max_nibool_interfaces,num_interfaces),stat=ier)
+    if (ier /= 0 ) stop 'Error allocating array buffer_send_scalar'
+    allocate(buffer_recv_scalar(max_nibool_interfaces,num_interfaces),stat=ier)
+    if (ier /= 0 ) stop 'Error allocating array buffer_recv_scalar'
+    allocate(request_send_scalar(num_interfaces),stat=ier)
+    if (ier /= 0 ) stop 'Error allocating array request_send_scalar'
+    allocate(request_recv_scalar(num_interfaces),stat=ier)
+    if (ier /= 0 ) stop 'Error allocating array request_recv_scalar'
+
+    ! partition border copy into the buffer
+    do iinterface = 1, num_interfaces
+      do ipoin = 1, nibool_interfaces(iinterface)
+        buffer_send_scalar(ipoin,iinterface) = array_val(ibool_interfaces(ipoin,iinterface))
+      enddo
+    enddo
+
+    ! send messages
+    do iinterface = 1, num_interfaces
+      ! non-blocking synchronous send request
+      call isend_cr(buffer_send_scalar(1:nibool_interfaces(iinterface),iinterface), &
+                   nibool_interfaces(iinterface),my_neighbors(iinterface), &
+                   itag,request_send_scalar(iinterface) )
+      ! receive request
+      call irecv_cr(buffer_recv_scalar(1:nibool_interfaces(iinterface),iinterface), &
+                   nibool_interfaces(iinterface),my_neighbors(iinterface), &
+                   itag,request_recv_scalar(iinterface) )
+    enddo
+
+    ! wait for communications completion (recv)
+    do iinterface = 1, num_interfaces
+      call wait_req(request_recv_scalar(iinterface))
+    enddo
+
+    ! adding contributions of neighbors
+    do iinterface = 1, num_interfaces
+      do ipoin = 1, nibool_interfaces(iinterface)
+        array_val(ibool_interfaces(ipoin,iinterface)) = &
+             array_val(ibool_interfaces(ipoin,iinterface)) + buffer_recv_scalar(ipoin,iinterface)
+      enddo
+   enddo
+   
+    ! wait for communications completion (send)
+    do iinterface = 1, num_interfaces
+      call wait_req(request_send_scalar(iinterface))
+    enddo
+
+    deallocate(buffer_send_scalar)
+    deallocate(buffer_recv_scalar)
+    deallocate(request_send_scalar)
+    deallocate(request_recv_scalar)
+
+  endif
+
+  end subroutine assemble_MPI_scalar
+
+  
+end program laplacian_smoothing_sem

--- a/src/tomography/postprocess_sensitivity_kernels/rules.mk
+++ b/src/tomography/postprocess_sensitivity_kernels/rules.mk
@@ -39,6 +39,7 @@ tomography/postprocess_sensitivity_kernels_TARGETS = \
 	$E/xinterpolate_model \
 	$E/xcreate_cross_section \
 	$E/xsmooth_sem \
+	$E/xlaplacian_smoothing_sem \
 	$(EMPTY_MACRO)
 
 tomography/postprocess_sensitivity_kernels_OBJECTS = \
@@ -49,6 +50,7 @@ tomography/postprocess_sensitivity_kernels_OBJECTS = \
 	$(xinterpolate_model_OBJECTS) \
 	$(xcreate_cross_section_OBJECTS) \
 	$(xsmooth_sem_OBJECTS) \
+	$(xlaplacian_smoothing_sem_OBJECTS) \
 	$(xconvert_model_file_adios_OBJECTS) \
 	$(EMPTY_MACRO)
 
@@ -58,11 +60,11 @@ tomography/adios_postprocess_sensitivity_kernels_TARGETS += \
 	$E/xconvert_model_file_adios \
 	$E/xinterpolate_model_adios \
 	$E/xsmooth_sem_adios \
+	$E/xlaplacian_smoothing_sem_adios \
 	$(EMPTY_MACRO)
 
 tomography/adios_postprocess_sensitivity_kernels_OBJECTS += \
 	$(xinterpolate_model_adios_OBJECTS) \
-	$(xsmooth_sem_adios_OBJECTS) \
 	$(EMPTY_MACRO)
 
 ifeq ($(ADIOS),yes)
@@ -82,6 +84,7 @@ tomography/postprocess_sensitivity_kernels_SHARED_OBJECTS = \
 	$(xinterpolate_model_SHARED_OBJECTS) \
 	$(xcreate_cross_section_SHARED_OBJECTS) \
 	$(xsmooth_sem_SHARED_OBJECTS) \
+	$(xsmooth_laplacian_sem_SHARED_OBJECTS) \
 	$(xconvert_model_file_adios_SHARED_OBJECTS) \
 	$(EMPTY_MACRO)
 
@@ -322,18 +325,66 @@ xsmooth_sem_adios_SHARED_OBJECTS = \
 
 
 xsmooth_sem_adios_SHARED_OBJECTS += \
-	$O/adios_helpers_addons.shared_adios_cc.o \
-	$O/adios_helpers_definitions.shared_adios.o \
+	$O/adios_helpers_definitions.shared_adios_module.o \
 	$O/adios_helpers_readers.shared_adios.o \
-	$O/adios_helpers_writers.shared_adios.o \
-	$O/adios_helpers.shared_adios.o \
-	$O/adios_manager.shared_adios_module.o \
+        $O/adios_helpers_writers.shared_adios_module.o \
+        $O/adios_helpers.shared_adios.o \
+        $O/adios_manager.shared_adios_module.o \
 	$(EMPTY_MACRO)
 
 # extra dependencies
 $O/smooth_sem.postprocess_adios.o: $O/search_kdtree.shared.o
 
 ${E}/xsmooth_sem_adios: $(xsmooth_sem_adios_OBJECTS) $(xsmooth_sem_adios_SHARED_OBJECTS)
+	${MPIFCCOMPILE_CHECK} -o $@ $+ $(MPILIBS)
+
+
+##
+## xlaplacian_smoothing_sem
+##
+xlaplacian_smoothing_sem_OBJECTS = \
+        $O/postprocess_par.postprocess_module.o \
+	$O/parse_kernel_names.postprocess.o \
+        $O/laplacian_smoothing_sem.postprocess.o \
+	$(EMPTY_MACRO)
+
+xlaplacian_smoothing_sem_SHARED_OBJECTS = \
+        $O/shared_par.shared_module.o \
+        $O/parallel.sharedmpi.o \
+        $O/exit_mpi.shared.o \
+        $O/gll_library.shared.o \
+        $O/lagrange_poly.shared.o \
+        $O/param_reader.cc.o \
+        $O/read_parameter_file.shared.o \
+        $O/read_value_parameters.shared.o \
+        $(EMPTY_MACRO)
+
+${E}/xlaplacian_smoothing_sem: $(xlaplacian_smoothing_sem_OBJECTS) $(xlaplacian_smoothing_sem_SHARED_OBJECTS) 
+	${MPIFCCOMPILE_CHECK} -o $@ $+ $(MPILIBS)
+
+
+##
+## xlaplacian_smoothing_sem_adios
+##
+xlaplacian_smoothing_sem_adios_OBJECTS = \
+        $O/postprocess_par.postprocess_module.o \
+        $O/parse_kernel_names.postprocess.o \
+        $O/laplacian_smoothing_sem.postprocess_adios.o \
+        $(EMPTY_MACRO)
+
+xlaplacian_smoothing_sem_adios_SHARED_OBJECTS = \
+        $(xlaplacian_smoothing_sem_SHARED_OBJECTS)
+
+
+xlaplacian_smoothing_sem_adios_SHARED_OBJECTS += \
+        $O/adios_helpers_definitions.shared_adios_module.o \
+        $O/adios_helpers_readers.shared_adios.o \
+        $O/adios_helpers_writers.shared_adios_module.o \
+        $O/adios_helpers.shared_adios.o \
+        $O/adios_manager.shared_adios_module.o \
+        $(EMPTY_MACRO)
+
+${E}/xlaplacian_smoothing_sem_adios: $(xlaplacian_smoothing_sem_adios_OBJECTS) $(xlaplacian_smoothing_sem_adios_SHARED_OBJECTS) 
 	${MPIFCCOMPILE_CHECK} -o $@ $+ $(MPILIBS)
 
 


### PR DESCRIPTION
Add inverse Laplacian smoothing (binary + adios implementation)
Patch for ocean load, surface normal not handled properly at MPI slices boundary (those boundaries pop up in the gradient when ocean load is enabled). Normal at MPI slice boundaries are counted twice. The patch takes account of the valence of those dof during the preprocessing of ocean load. 
Fixes a typo in interpolation routine.
