### PR TITLE
Change time string in quakeml(ASDF) length to 24

### DIFF
--- a/src/specfem3D/write_output_ASDF.f90
+++ b/src/specfem3D/write_output_ASDF.f90
@@ -178,7 +178,7 @@
   integer, parameter :: MAX_STATIONXML_LENGTH = 16182
   integer, parameter :: MAX_PARFILE_LENGTH = 20000
   integer, parameter :: MAX_CONSTANTS_LENGTH = 45000
-  integer, parameter :: MAX_TIME_STRING_LENGTH = 22
+  integer, parameter :: MAX_TIME_STRING_LENGTH = 24
 
   !--- Character strings to be written to the ASDF file
   character(len=MAX_QUAKEML_LENGTH) :: quakeml


### PR DESCRIPTION
Change time string in quakeml (ASDF) length to 24 so sec will be save with 4 digits intead of 2.

For example, the origin time string is with length of 22:
```
1994-06-09T00:33:45.61
```
Now it saves more digits in the sec:
```
1994-06-09T00:33:45.6166
```
