### PR TITLE
Solve mesher crash on power9 architectures

### DIFF
--- a/src/meshfem3D/get_model.F90
+++ b/src/meshfem3D/get_model.F90
@@ -166,8 +166,8 @@
 
         ! stores isotropic shear modulus from reference 1D model
         ! calculates isotropic value
-        vs = sqrt(((1.d0-2.d0*eta_aniso)*vph*vph + vpv*vpv &
-                  + 5.d0*vsh*vsh + (6.d0+4.d0*eta_aniso)*vsv*vsv)/15.d0)
+        vs = sqrt(abs((1.d0-2.d0*eta_aniso)*vph*vph + vpv*vpv &
+                  + 5.d0*vsh*vsh + (6.d0+4.d0*eta_aniso)*vsv*vsv)/15.d0))
         ! stores 1D isotropic mu0 = (rho * Vs*Vs) values
         mu0 = rho * vs*vs
         mu0store(i,j,k,ispec) = real( mu0, kind=CUSTOM_REAL)

--- a/src/meshfem3D/get_model.F90
+++ b/src/meshfem3D/get_model.F90
@@ -166,8 +166,14 @@
 
         ! stores isotropic shear modulus from reference 1D model
         ! calculates isotropic value
-        vs = sqrt(abs((1.d0-2.d0*eta_aniso)*vph*vph + vpv*vpv &
-                  + 5.d0*vsh*vsh + (6.d0+4.d0*eta_aniso)*vsv*vsv)/15.d0))
+        if (iregion_code == IREGION_OUTER_CORE) then
+          ! fluid with zero shear speed
+          vs = 0.d0
+        else
+          vs = sqrt(((1.d0-2.d0*eta_aniso)*vph*vph + vpv*vpv &
+                    + 5.d0*vsh*vsh + (6.d0+4.d0*eta_aniso)*vsv*vsv)/15.d0)
+        endif
+        
         ! stores 1D isotropic mu0 = (rho * Vs*Vs) values
         mu0 = rho * vs*vs
         mu0store(i,j,k,ispec) = real( mu0, kind=CUSTOM_REAL)


### PR DESCRIPTION
Add absolute value of argument to avoid square root of slightly negative values.