### PR TITLE
Updated Laplacian smoothing

### DIFF
--- a/src/tomography/postprocess_sensitivity_kernels/rules.mk
+++ b/src/tomography/postprocess_sensitivity_kernels/rules.mk
@@ -367,6 +367,9 @@ xsmooth_laplacian_sem_SHARED_OBJECTS = \
 	$O/param_reader.cc.o \
 	$O/read_parameter_file.shared.o \
 	$O/read_value_parameters.shared.o \
+	$O/model_prem.shared.o \
+	$O/reduce.shared.o \
+	$O/rthetaphi_xyz.shared.o \
 	$(EMPTY_MACRO)
 
 ${E}/xsmooth_laplacian_sem: $(xsmooth_laplacian_sem_OBJECTS) $(xsmooth_laplacian_sem_SHARED_OBJECTS)


### PR DESCRIPTION
1. corrected the smoothing length (previously the input parameters sigma_h and sigma_v were lengths in x and z direction, now changed to horizontal and vertical direction).
2. added an option to increase vertical smoothing length sigma_v with depth at a given depth range, enabling users to use a smaller vertical length in crust and upper mantle only.
3. depth-dependent smoothing length is now relative to the PREM model instead of the 3D velocity model which eliminates horizontal variation in smoothing length.