### PR TITLE
Corrected Laplacian smoothing

### DIFF
--- a/src/tomography/postprocess_sensitivity_kernels/laplacian_smoothing_sem.F90
+++ b/src/tomography/postprocess_sensitivity_kernels/laplacian_smoothing_sem.F90
@@ -67,8 +67,8 @@ program smooth_laplacian_sem
   integer :: nspec, nglob, nker, niter_cg_max
   integer :: iker, i, j, k, idof, iel, i1, i2, ier, sizeprocs
 
-  double precision    :: Lx, Ly, Lz, Lh, Lv, conv_crit, taper_vertical, Lh2, Lv2
-  double precision    :: x, y, z, r, theta, phi, e2, rel_to_prem
+  double precision    :: Lx, Ly, Lz, Lh, Lv, conv_crit, Lh2, Lv2
+  double precision    :: x, y, z, r, theta, phi, rel_to_prem
   double precision    :: rho,drhodr,vp,vs,Qkappa,Qmu
 
 


### PR DESCRIPTION
The previous implementation of Lh and Lv in Laplacian smoothing was incorrect and it seems that there is no easy way to convert Lx / Ly to Lv / Lh. So I've added a warning when input Lv and Lh are different.