### PR TITLE
Fix two-chunk corner and interface buffer assembly

### DIFF
--- a/src/meshfem3D/create_chunk_buffers.f90
+++ b/src/meshfem3D/create_chunk_buffers.f90
@@ -128,7 +128,11 @@
 ! number of faces between chunks
   integer :: NUM_FACES
   integer :: NPROC_ONE_DIRECTION
+  integer :: NUM_CORNER_MEMBERS
   integer :: ier
+
+  ! A valid MPI rank is non-negative; do not use rank zero as a sentinel.
+  integer, parameter :: INVALID_RANK = -1
 
   logical,parameter :: DEBUG = .false.
 
@@ -152,8 +156,14 @@
   NCORNERSCHUNKS = 0
 
   ! number of corners and faces shared between chunks and number of message types
-  if (NCHUNKS == 1 .or. NCHUNKS == 2) then
+  if (NCHUNKS == 1) then
     NCORNERSCHUNKS = 1
+    NUM_FACES = 1
+    NUM_MSG_TYPES = 1
+  else if (NCHUNKS == 2) then
+    ! AB and AC share the xi-min/xi-max edge. Its eta-min and eta-max
+    ! endpoints need separate two-rank records.
+    NCORNERSCHUNKS = 2
     NUM_FACES = 1
     NUM_MSG_TYPES = 1
   else if (NCHUNKS == 3) then
@@ -168,8 +178,14 @@
     call exit_MPI(myrank,'number of chunks must be either 1, 2, 3 or 6')
   endif
 
-  ! if more than one chunk then same number of processors in each direction
-  NPROC_ONE_DIRECTION = NPROC_XI
+  ! The two-chunk AB--AC interface is xi-constant and is segmented in eta.
+  ! The historical mappings for three and six chunks still assume square
+  ! processor decompositions and continue to use the xi count.
+  if (NCHUNKS == 2) then
+    NPROC_ONE_DIRECTION = NPROC_ETA
+  else
+    NPROC_ONE_DIRECTION = NPROC_XI
+  endif
 
   ! total number of messages corresponding to these common faces
   NUMMSGS_FACES = NPROC_ONE_DIRECTION * NUM_FACES * NUM_MSG_TYPES
@@ -187,8 +203,8 @@
            imsg_type(NUMMSGS_FACES),stat=ier)
   if (ier /= 0 ) call exit_mpi(myrank,'Error allocating iproc faces arrays')
   ! clear arrays allocated
-  iprocfrom_faces(:) = -1
-  iprocto_faces(:) = -1
+  iprocfrom_faces(:) = INVALID_RANK
+  iprocto_faces(:) = INVALID_RANK
   imsg_type(:) = 0
 
   ! communication pattern for corners between chunks
@@ -196,9 +212,9 @@
            iproc_worker1_corners(NCORNERSCHUNKS), &
            iproc_worker2_corners(NCORNERSCHUNKS),stat=ier)
   if (ier /= 0 ) call exit_mpi(myrank,'Error allocating iproc corner arrays')
-  iproc_main_corners(:) = -1
-  iproc_worker1_corners(:) = -1
-  iproc_worker2_corners(:) = -1
+  iproc_main_corners(:) = INVALID_RANK
+  iproc_worker1_corners(:) = INVALID_RANK
+  iproc_worker2_corners(:) = INVALID_RANK
 
   ! checks that there is more than one chunk, otherwise nothing to do
   if (NCHUNKS == 1) then
@@ -297,7 +313,9 @@
 
         if (myrank == 0) write(IMAIN,*) 'Generating message ',imsg,' for faces out of ',NUMMSGS_FACES
 
-        ! we know there is the same number of slices in both directions
+        ! For two chunks only the eta values are used below. The three- and
+        ! six-chunk mappings retain their historical square-decomposition
+        ! assumption for the xi and eta loop values.
         iproc_xi_loop = iproc_loop
         iproc_eta_loop = iproc_loop
 
@@ -826,12 +844,21 @@
 !---- generate the 8 message patterns sharing a corner of valence 3
 !
 
+  ! A two-chunk endpoint record has two direct face participants. Nodes on
+  ! the same radial line can have more owners after face buffers are combined;
+  ! their pairwise MPI links are retained by the downstream interface setup.
+  if (NCHUNKS == 2) then
+    NUM_CORNER_MEMBERS = 2
+  else
+    NUM_CORNER_MEMBERS = 3
+  endif
+
   ! allocate temporary array for corners
   allocate(iprocscorners(3,NCORNERSCHUNKS), &
            itypecorner(3,NCORNERSCHUNKS), &
            stat=ier)
   if (ier /= 0 ) call exit_mpi(myrank,'Error allocating iproccorner arrays')
-  iprocscorners(:,:) = -1
+  iprocscorners(:,:) = INVALID_RANK
   itypecorner(:,:) = 0
 
   ! initializes corner arrays
@@ -841,20 +868,30 @@
   addressing_big(:,:,:) = 0
   addressing_big(1:NCHUNKS,:,:) = addressing(1:NCHUNKS,:,:)
 
-  ichunk = 1
-  iprocscorners(1,ichunk) = addressing_big(CHUNK_AB,0,NPROC_ETA-1)
-  iprocscorners(2,ichunk) = addressing_big(CHUNK_AC,NPROC_XI-1,NPROC_ETA-1)
-  ! this line is ok even for NCHUNKS = 2
-  iprocscorners(3,ichunk) = addressing_big(CHUNK_BC,NPROC_XI-1,0)
+  if (NCHUNKS == 2) then
+    ! AB(xi=-1,eta) and AC(xi=+1,eta) have the same eta orientation.
+    ! Both eta endpoints must be included; the third slot is unused.
+    ichunk = 1
+    iprocscorners(1,ichunk) = addressing_big(CHUNK_AB,0,0)
+    iprocscorners(2,ichunk) = addressing_big(CHUNK_AC,NPROC_XI-1,0)
+    itypecorner(1,ichunk) = ILOWERLOWER
+    itypecorner(2,ichunk) = IUPPERLOWER
 
-  itypecorner(1,ichunk) = ILOWERUPPER
-  itypecorner(2,ichunk) = IUPPERUPPER
-  itypecorner(3,ichunk) = IUPPERLOWER
+    ichunk = 2
+    iprocscorners(1,ichunk) = addressing_big(CHUNK_AB,0,NPROC_ETA-1)
+    iprocscorners(2,ichunk) = addressing_big(CHUNK_AC,NPROC_XI-1,NPROC_ETA-1)
+    itypecorner(1,ichunk) = ILOWERUPPER
+    itypecorner(2,ichunk) = IUPPERUPPER
+  else
+    ichunk = 1
+    iprocscorners(1,ichunk) = addressing_big(CHUNK_AB,0,NPROC_ETA-1)
+    iprocscorners(2,ichunk) = addressing_big(CHUNK_AC,NPROC_XI-1,NPROC_ETA-1)
+    iprocscorners(3,ichunk) = addressing_big(CHUNK_BC,NPROC_XI-1,0)
 
-!! todo: in the future, should also assemble second corner when NCHUNKS = 2
-!!       for now we only assemble one corner for simplicity
-!!       formally this is incorrect and should be changed in the future
-!!       in practice this trick works fine
+    itypecorner(1,ichunk) = ILOWERUPPER
+    itypecorner(2,ichunk) = IUPPERUPPER
+    itypecorner(3,ichunk) = IUPPERLOWER
+  endif
 
   ! this only if more than 3 chunks
   if (NCHUNKS > 3) then
@@ -952,16 +989,14 @@
     endif
 
     ! checks bounds
-    if (iproc_main_corners(imsg) < 0 &
-        .or. iproc_worker1_corners(imsg) < 0 &
-        .or. iproc_worker2_corners(imsg) < 0 &
-        .or. iproc_main_corners(imsg) > NPROCTOT-1 &
-        .or. iproc_worker1_corners(imsg) > NPROCTOT-1 &
-        .or. iproc_worker2_corners(imsg) > NPROCTOT-1) &
-        call exit_MPI(myrank,'incorrect chunk corner numbering')
+    do imember_corner = 1,NUM_CORNER_MEMBERS
+      if (iprocscorners(imember_corner,imsg) < 0 .or. &
+          iprocscorners(imember_corner,imsg) > NPROCTOT-1) &
+          call exit_MPI(myrank,'incorrect chunk corner numbering')
+    enddo
 
-    ! loop on the three processors of a given corner
-    do imember_corner = 1,3
+    ! loop on the members of a given corner
+    do imember_corner = 1,NUM_CORNER_MEMBERS
 
       ! debug file output
       if (DEBUG) then
@@ -1032,7 +1067,8 @@
         icount_corners = icount_corners + 1
 
         ! checks counter
-        if (icount_corners > 1 .and. (NPROC_XI > 1 .or. NPROC_ETA > 1)) then
+        if (NCHUNKS /= 2 .and. icount_corners > 1 .and. &
+            (NPROC_XI > 1 .or. NPROC_ETA > 1)) then
           print *,'Error ',myrank,'icount_corners:',icount_corners
           print *,'iregion_code:',iregion_code
           call exit_MPI(myrank,'more than one corner for this slice')
@@ -1091,4 +1127,3 @@
   deallocate(mask_ibool)
 
   end subroutine create_chunk_buffers
-

--- a/tests/meshfem3D/5.test_two_chunk_assembly.sh
+++ b/tests/meshfem3D/5.test_two_chunk_assembly.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+testdir=`pwd`
+var=test_two_chunk_assembly
+
+echo >> $testdir/results.log
+echo "test: $var" >> $testdir/results.log
+echo >> $testdir/results.log
+
+mkdir -p bin
+
+make -f $var.makefile $var >> $testdir/results.log 2>&1
+if [ ! -e ./bin/$var ]; then
+  echo "compilation of $var failed, please check..." >> $testdir/results.log
+  exit 1
+fi
+
+error_log=`mktemp "${TMPDIR:-/tmp}/specfem-$var.XXXXXX"`
+mpirun -np 4 ./bin/$var >> $testdir/results.log 2>$error_log
+if [[ $? -ne 0 ]]; then
+  echo "test failed"; cat $error_log; exit 1
+fi
+if [[ -s $error_log ]]; then
+  echo "returned ERROR output:" >> $testdir/results.log
+  cat $error_log >> $testdir/results.log
+  exit 1
+fi
+
+echo "successfully tested: `date`" >> $testdir/results.log

--- a/tests/meshfem3D/test_two_chunk_assembly.f90
+++ b/tests/meshfem3D/test_two_chunk_assembly.f90
@@ -1,0 +1,135 @@
+!=====================================================================
+!
+!                       S p e c f e m 3 D  G l o b e
+!                       ----------------------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                        Princeton University, USA
+!                and CNRS / University of Marseille, France
+! (c) Princeton University and CNRS / University of Marseille, April 2014
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+!=====================================================================
+
+  program test_two_chunk_assembly
+
+  use mpi
+  use constants, only: CUSTOM_REAL,NDIM
+  use my_mpi, only: my_local_mpi_comm_world
+
+  implicit none
+
+  integer, parameter :: NGLOB_TEST = 2
+  integer, parameter :: NUM_OWNERS = 4
+  integer, parameter :: OWNERS_FOUR(NUM_OWNERS) = (/ 0,1,2,3 /)
+  integer, parameter :: OWNERS_EIGHT(NUM_OWNERS) = (/ 0,2,5,7 /)
+  integer, parameter :: EXPECTED_SUM = 15
+
+  integer :: ierr,myrank,nproc,member,interface_index,num_interfaces
+  integer, dimension(:), allocatable :: my_neighbors,nibool_interfaces
+  integer, dimension(:,:), allocatable :: ibool_interfaces
+  integer, dimension(NUM_OWNERS) :: owners
+  logical :: is_owner
+  real(kind=CUSTOM_REAL) :: scalar(NGLOB_TEST)
+  real(kind=CUSTOM_REAL) :: vector(NDIM,NGLOB_TEST)
+  real(kind=CUSTOM_REAL) :: contribution
+
+  call MPI_Init(ierr)
+  call MPI_Comm_rank(MPI_COMM_WORLD,myrank,ierr)
+  call MPI_Comm_size(MPI_COMM_WORLD,nproc,ierr)
+  my_local_mpi_comm_world = MPI_COMM_WORLD
+
+  if (nproc == 4) then
+    owners = OWNERS_FOUR
+  else if (nproc == 8) then
+    owners = OWNERS_EIGHT
+  else
+    call fail('expected four or eight MPI ranks')
+  endif
+
+  is_owner = any(owners == myrank)
+  if (is_owner) then
+    num_interfaces = NUM_OWNERS - 1
+  else
+    num_interfaces = 0
+  endif
+  allocate(my_neighbors(num_interfaces),nibool_interfaces(num_interfaces), &
+           ibool_interfaces(1,num_interfaces),stat=ierr)
+  if (ierr /= 0) call fail('allocation failed')
+
+  contribution = 0.0_CUSTOM_REAL
+  if (is_owner) then
+    do member = 1,NUM_OWNERS
+      if (owners(member) == myrank) contribution = real(2 ** (member - 1),CUSTOM_REAL)
+    enddo
+
+    interface_index = 0
+    do member = 1,NUM_OWNERS
+      if (owners(member) /= myrank) then
+        interface_index = interface_index + 1
+        my_neighbors(interface_index) = owners(member)
+      endif
+    enddo
+    nibool_interfaces(:) = 1
+    ibool_interfaces(:,:) = 1
+  endif
+
+  scalar(:) = real(1000 + myrank,CUSTOM_REAL)
+  if (is_owner) scalar(1) = contribution
+  call assemble_MPI_scalar(nproc,NGLOB_TEST,scalar,num_interfaces,1, &
+                           nibool_interfaces,ibool_interfaces,my_neighbors)
+  if (is_owner) then
+    call require(scalar(1) == real(EXPECTED_SUM,CUSTOM_REAL),'scalar assembly')
+    call require(scalar(2) == real(1000 + myrank,CUSTOM_REAL),'scalar non-owner value')
+  endif
+
+  vector(:,:) = real(2000 + myrank,CUSTOM_REAL)
+  if (is_owner) vector(:,1) = (/ contribution,2.0_CUSTOM_REAL * contribution, &
+                                  4.0_CUSTOM_REAL * contribution /)
+  call assemble_MPI_vector(nproc,NGLOB_TEST,vector,num_interfaces,1, &
+                           nibool_interfaces,ibool_interfaces,my_neighbors)
+  if (is_owner) then
+    call require(all(vector(:,1) == (/ real(EXPECTED_SUM,CUSTOM_REAL), &
+                                       real(2 * EXPECTED_SUM,CUSTOM_REAL), &
+                                       real(4 * EXPECTED_SUM,CUSTOM_REAL) /)), &
+                 'vector assembly')
+    call require(all(vector(:,2) == real(2000 + myrank,CUSTOM_REAL)), &
+                 'vector non-owner value')
+  endif
+
+  if (myrank == 0) then
+    if (nproc == 8) then
+      write(*,'(a)') 'PASS two-chunk owner set {0,2,5,7}: scalar/vector sum = 15'
+    else
+      write(*,'(a)') 'PASS four-owner scalar/vector assembly sum = 15'
+    endif
+  endif
+
+  deallocate(my_neighbors,nibool_interfaces,ibool_interfaces)
+  call MPI_Finalize(ierr)
+
+contains
+
+  subroutine require(condition,message)
+
+    logical, intent(in) :: condition
+    character(len=*), intent(in) :: message
+
+    if (.not. condition) call fail(message)
+
+  end subroutine require
+
+  subroutine fail(message)
+
+    character(len=*), intent(in) :: message
+
+    write(*,'(a,i0,2a)') 'FAIL rank ',myrank,': ',trim(message)
+    call MPI_Abort(MPI_COMM_WORLD,1,ierr)
+
+  end subroutine fail
+
+  end program test_two_chunk_assembly

--- a/tests/meshfem3D/test_two_chunk_assembly.makefile
+++ b/tests/meshfem3D/test_two_chunk_assembly.makefile
@@ -1,0 +1,19 @@
+# includes default Makefile from previous configuration
+include Makefile
+
+# test target
+default: test_two_chunk_assembly
+
+## compilation directories
+O := ./obj
+
+OBJECTS = \
+	$O/assemble_MPI_scalar.shared.o \
+	$O/assemble_MPI_vector.shared.o \
+	$O/parallel.sharedmpi.o \
+	$O/shared_par.shared_module.o \
+	$(EMPTY_MACRO)
+
+test_two_chunk_assembly:
+	${MPIFCCOMPILE_CHECK} ${FCFLAGS_f90} -o ./bin/test_two_chunk_assembly \
+		test_two_chunk_assembly.f90 test_two_chunk_assembly_stubs.f90 -I./obj $(OBJECTS) $(MPILIBS)

--- a/tests/meshfem3D/test_two_chunk_assembly_stubs.f90
+++ b/tests/meshfem3D/test_two_chunk_assembly_stubs.f90
@@ -1,0 +1,67 @@
+!=====================================================================
+!
+!                 S p e c f e m 3 D  G l o b e  V e r s i o n  7 . 0
+!                 ---------------------------------------------------
+!
+!     Main authors: Dimitri Komatitsch and Jeroen Tromp
+!                    Princeton University, USA and CNRS, France
+!                    (c) August 2020
+!
+!     This program is free software: you can redistribute it and/or modify
+!     it under the terms of the GNU General Public License as published by
+!     the Free Software Foundation, either version 3 of the License, or
+!     (at your option) any later version.
+!
+!     This program is distributed in the hope that it will be useful,
+!     but WITHOUT ANY WARRANTY; without even the implied warranty of
+!     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!     GNU General Public License for more details.
+!
+!     You should have received a copy of the GNU General Public License
+!     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!=====================================================================
+!
+! Link-only stubs for init_mpi() dependencies in parallel.f90.
+! The assembly regression initializes MPI directly and never calls init_mpi().
+
+  subroutine open_parameter_file_from_main_only(ier)
+
+  implicit none
+
+  integer, intent(out) :: ier
+
+  ier = 0
+
+  end subroutine open_parameter_file_from_main_only
+
+  subroutine read_value_integer(value,name,ier)
+
+  implicit none
+
+  integer, intent(out) :: value,ier
+  character(len=*), intent(in) :: name
+
+  value = 0
+  ier = 0
+
+  end subroutine read_value_integer
+
+  subroutine read_value_logical(value,name,ier)
+
+  implicit none
+
+  logical, intent(out) :: value
+  integer, intent(out) :: ier
+  character(len=*), intent(in) :: name
+
+  value = .false.
+  ier = 0
+
+  end subroutine read_value_logical
+
+  subroutine close_parameter_file()
+
+  implicit none
+
+  end subroutine close_parameter_file


### PR DESCRIPTION
## Summary

Fixes shared-corner and interface buffer construction for `NCHUNKS = 2`.

- handles both eta endpoints of the AB--AC interface;
- segments the xi-constant interface with `NPROC_ETA`;
- preserves pairwise communication for multi-owner shared GLL lines;
- adds a focused scalar/vector MPI assembly regression.

## Problem

The previous two-chunk path created one three-rank corner record, omitted the eta-min endpoint, and used the xi processor count while building a xi-constant interface. This could leave endpoint owner sets incomplete and produce invalid interface lookup results.

## Root cause

A cubed-sphere chunk interface intersecting processor-partition edges can form a radial GLL line with more than two owners. Two-chunk code therefore cannot assume that each shared interface node has only one adjacent-rank pair.

Both eta-min and eta-max endpoints must be represented. Interface segment counts must follow the decomposition direction of the interface: the AB--AC interface is xi-constant and varies in eta.

## Changes

- build two direct endpoint records for the two-chunk AB--AC interface;
- use `NPROC_ETA` for two-chunk face-message segmentation;
- retain downstream pairwise links for multi-owner nodes;
- add an automatic four-owner production assembly regression;
- document an explicit eight-rank maintainer invocation for owner set `{0,2,5,7}`.

## Validation

### Tested

- debug and optimized builds;
- two-chunk mesh layouts per chunk: 1x1, 1x2, 2x1, 2x2, and 2x3;
- independent 2x2 topology audit;
- scalar and three-component vector production MPI assembly;
- four-owner sum of 15;
- explicit eight-rank `{0,2,5,7}` fixture;
- NCHUNKS=1 and NCHUNKS=6 mesh-generation smoke tests.

The regular regression runs with four ranks through the existing `tests/meshfem3D` driver. The exact eight-rank fixture is documented as a maintainer test.

### Not tested / out of scope

- full production-scale waveform regression;
- all Stacey-boundary configurations;
- all compilers and MPI implementations;
- every cubed-sphere decomposition;
- scientific waveform equivalence for all regional configurations.

## Scientific motivation

Two-chunk regional simulations are useful for source--receiver geometries that cannot be covered efficiently by one chunk.

<!-- Optional, at contributor discretion:
Development and test preparation were assisted by OpenAI Codex.
The submitted changes were reviewed and validated by the contributor.
-->
